### PR TITLE
ci(coverage): add Codecov integration and update README badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,31 @@ jobs:
           go-version: stable
 
       - name: Test
-        run: go test -race -v ./...
+        run: go test -race ./...
 
       - name: Build
         run: go build -o omen ./cmd/omen
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+        with:
+          go-version: stable
+
+      - name: Test with coverage
+        run: go test -race -coverprofile=coverage.out ./...
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   lint:
     name: Lint

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # Omen
 
-[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/panbanda/omen/ci.yml?branch=main&style=flat-square)](https://github.com/panbanda/omen/actions?query=workflow%3ACI)
-[![GoDoc](https://pkg.go.dev/badge/github.com/panbanda/omen)](https://pkg.go.dev/github.com/panbanda/omen)
-[![Go Report Card](https://goreportcard.com/badge/github.com/panbanda/omen)](https://goreportcard.com/report/github.com/panbanda/omen)
-![Go Version](https://img.shields.io/badge/go%20version-%3E=1.23-61CFDD.svg?style=flat-square)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/panbanda/omen-cli)](https://go.dev/)
+[![License](https://img.shields.io/github/license/panbanda/omen-cli)](https://github.com/panbanda/omen-cli/blob/main/LICENSE)
+[![CI](https://github.com/panbanda/omen-cli/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/panbanda/omen-cli/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/panbanda/omen-cli/graph/badge.svg)](https://codecov.io/gh/panbanda/omen-cli)
+[![Go Report Card](https://goreportcard.com/badge/github.com/panbanda/omen-cli)](https://goreportcard.com/report/github.com/panbanda/omen-cli)
+[![Release](https://img.shields.io/github/v/release/panbanda/omen-cli)](https://github.com/panbanda/omen-cli/releases)
+[![Go Reference](https://pkg.go.dev/badge/github.com/panbanda/omen-cli.svg)](https://pkg.go.dev/github.com/panbanda/omen-cli)
 [![Snyk Security](https://snyk.io/test/github/panbanda/omen-cli/badge.svg)](https://snyk.io/test/github/panbanda/omen-cli)
 
 A multi-language code analysis CLI built in Go. Omen uses tree-sitter for parsing source code across 13 languages, providing insights into complexity, technical debt, code duplication, and defect prediction.


### PR DESCRIPTION
## Summary

Add Codecov integration for test coverage reporting and update README badges to point to the correct `omen-cli` repository.

## Changes Made

- Add separate `coverage` job to CI workflow that runs tests with coverage and uploads to Codecov
- Update all README badges to use correct `panbanda/omen-cli` repo (previously pointed to `panbanda/omen`)
- Add new badges: codecov, license, release, go reference
- Keep existing Snyk badge

## Testing

- CI workflow syntax validated
- Badge URLs verified to use correct repository

## Notes

- Requires `CODECOV_TOKEN` secret to be added to repository settings
- Repo needs to be connected to Codecov at codecov.io