### PR TITLE
ci(release): use goreleaser for homebrew formula generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,8 +69,36 @@ jobs:
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release --clean --skip=validate
+          args: release --clean --skip=validate,homebrew
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
+
+  homebrew:
+    name: Update Homebrew Formula
+    needs: [release-please, goreleaser]
+    if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - name: Set up Go
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+        with:
+          go-version: stable
+
+      - name: Run GoReleaser (Homebrew only)
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean --skip=build,archive,checksum,publish,validate,announce,sbom,docker,ko,nix,winget,aur,nfpm,snapcraft,chocolatey,scoop
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -90,3 +90,16 @@ release:
     owner: panbanda
     name: omen
   mode: append
+
+brews:
+  - name: omen
+    repository:
+      owner: panbanda
+      name: homebrew-omen
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    directory: Formula
+    homepage: "https://github.com/panbanda/omen"
+    description: "Multi-language code analysis CLI"
+    license: "MIT"
+    test: |
+      system "#{bin}/omen", "--version"


### PR DESCRIPTION
## Summary

- Replace manual shell script with goreleaser's built-in `brews` publisher
- Add `brews` config to `.goreleaser.yml` for homebrew-omen tap
- Homebrew job now runs goreleaser with skip flags to only generate and push the formula

## Changes

- `.goreleaser.yml`: Added `brews` section with tap configuration
- `release.yml`: Replaced 60-line shell script with goreleaser invocation, added `--skip=homebrew` to matrix builds

## Testing

- Formula generation will be tested on next release