### PR TITLE
feat(churn): add hotspot and stable file detection

### DIFF
--- a/pkg/analyzer/churn.go
+++ b/pkg/analyzer/churn.go
@@ -202,6 +202,9 @@ func (a *ChurnAnalyzer) AnalyzeRepo(repoPath string) (*models.ChurnAnalysis, err
 	// Calculate churn statistics
 	analysis.Summary.CalculateStatistics(analysis.Files)
 
+	// Identify hotspot and stable files
+	analysis.Summary.IdentifyHotspotAndStableFiles(analysis.Files)
+
 	return analysis, nil
 }
 


### PR DESCRIPTION
## Summary
- Add `HotspotFiles` and `StableFiles` fields to `ChurnSummary` struct
- Add `IdentifyHotspotAndStableFiles` method with configurable thresholds
- Integrate detection into churn analyzer pipeline

## Changes
- **pkg/models/churn.go**: Add new fields and detection method with thresholds (hotspot > 0.5, stable < 0.1 with commits > 0)
- **pkg/analyzer/churn.go**: Call detection after statistics calculation
- **pkg/models/churn_test.go**: Add comprehensive tests for new functionality

## Test plan
- [x] Run `go test ./pkg/models/... -run Churn` - all tests pass
- [x] Run `go test ./...` - full test suite passes
- [x] Verify JSON output includes `hotspot_files` and `stable_files` fields