### PR TITLE
fix(deadcode): restructure JSON output to match pmat format

### DIFF
--- a/cmd/omen/main.go
+++ b/cmd/omen/main.go
@@ -477,9 +477,11 @@ func runDeadCodeCmd(c *cli.Context) error {
 	}
 	defer formatter.Close()
 
-	// For JSON/TOON, output raw analysis
+	// For JSON/TOON, output pmat-compatible format
 	if formatter.Format() == output.FormatJSON || formatter.Format() == output.FormatTOON {
-		return formatter.Output(analysis)
+		result := models.NewDeadCodeResult()
+		result.FromDeadCodeAnalysis(analysis)
+		return formatter.Output(result)
 	}
 
 	// Functions table


### PR DESCRIPTION
## Summary

- Restructured from item-centric to file-centric output format
- Added pmat-compatible types for JSON serialization
- Implemented dead_score calculation using pmat's weighted algorithm

## Changes

- Added `DeadCodeResult` with pmat-compatible JSON structure
- Added `FileDeadCodeMetrics` with path, dead_lines, total_lines, dead_percentage, dead_score
- Added `DeadCodeItem` for individual dead code entries nested within files
- Implemented `dead_score` calculation using pmat's weighted algorithm
- Added `FromDeadCodeAnalysis()` conversion method
- Added `total_files` and `analyzed_files` to result

## Test Plan

- [x] All existing tests pass (`go test ./...`)
- [x] JSON output verified against pmat reference implementation
- [x] Documentation updated in requirements/analyzer/deadcode.md

---
Generated with Claude Code