### PR TITLE
fix(defect): align JSON output with pmat format

### DIFF
--- a/cmd/omen/main.go
+++ b/cmd/omen/main.go
@@ -810,6 +810,12 @@ func runDefectCmd(c *cli.Context) error {
 		return analysis.Files[i].Probability > analysis.Files[j].Probability
 	})
 
+	// For JSON/TOON, output pmat-compatible format
+	if formatter.Format() == output.FormatJSON || formatter.Format() == output.FormatTOON {
+		report := analysis.ToDefectPredictionReport()
+		return formatter.Output(report)
+	}
+
 	var rows [][]string
 	for _, ds := range analysis.Files {
 		if highRiskOnly && ds.RiskLevel != models.RiskHigh {


### PR DESCRIPTION
## Summary

- Added pmat-compatible types for defect prediction output
- Renamed fields to match pmat convention (probability -> risk_score)
- Converted contributing_factors from map to string array

## Changes

- Added `FilePrediction` type with file_path, risk_score, risk_level, factors
- Added `DefectPredictionReport` for pmat-compatible output
- Renamed `probability` to `risk_score`
- Converted `contributing_factors` from map to string array
- Added `ToDefectPredictionReport()` conversion method
- CLI updated to output pmat format for JSON

## Test Plan

- [x] All existing tests pass (`go test ./...`)
- [x] JSON output verified against pmat reference implementation
- [x] Documentation updated in requirements/analyzer/defect.md

---
Generated with Claude Code