### PR TITLE
fix(tdg): align JSON output with pmat reference implementation

### DIFF
--- a/cmd/omen/main.go
+++ b/cmd/omen/main.go
@@ -936,6 +936,12 @@ func runTDGCmd(c *cli.Context) error {
 	}
 	defer formatter.Close()
 
+	// For JSON/TOON, output pmat-compatible format
+	if formatter.Format() == output.FormatJSON || formatter.Format() == output.FormatTOON {
+		report := project.ToTDGReport(hotspots)
+		return formatter.Output(report)
+	}
+
 	// Sort by score (lowest first - worst quality)
 	files := project.Files
 	sort.Slice(files, func(i, j int) bool {

--- a/requirements/analyzer/README.md
+++ b/requirements/analyzer/README.md
@@ -1,0 +1,77 @@
+# Analyzer Porting and Verification Plan
+
+This directory contains individual plans for each analyzer in the Omen codebase. The goal is to ensure each analyzer:
+
+1. Has proper academic grounding and documentation
+2. Matches the reference Rust implementation (pmat) in output
+3. Performs efficiently at scale
+
+## Analyzers
+
+| Analyzer | Status | Plan File |
+|----------|--------|-----------|
+| complexity | Done | [complexity.md](complexity.md) |
+| churn | Done | [churn.md](churn.md) |
+| deadcode | Done | [deadcode.md](deadcode.md) |
+| defect | Done | [defect.md](defect.md) |
+| duplicates | Done | [duplicates.md](duplicates.md) |
+| graph | Done | [graph.md](graph.md) |
+| halstead | Done | [halstead.md](halstead.md) |
+| satd | Done | [satd.md](satd.md) |
+| tdg | Done | [tdg.md](tdg.md) |
+
+## Standard Process for Each Analyzer
+
+### Phase 1: Research and Documentation
+- [ ] Academic research on the analyzer's purpose and methodology
+- [ ] Document value proposition for dev teams/legacy codebases
+- [ ] Add citations to README.md (project root)
+- [ ] Create requirements/analyzer/{analyzer}.md plan file
+
+### Phase 2: Code Analysis
+- [ ] Review Rust reference implementation
+- [ ] Review Go implementation
+- [ ] Document any logic differences
+- [ ] Match model structure (JSON field names, types, order)
+- [ ] Match output format (path prefixes, timestamps, etc.)
+
+### Phase 3: Output Comparison
+- [ ] Run pmat on monolith codebase: `pmat analyze {cmd} --format json`
+- [ ] Run omen on monolith codebase: `./omen analyze {cmd} -f json`
+- [ ] Save outputs to files for comparison
+- [ ] Compare outputs and document discrepancies
+- [ ] Fix any issues in Go code
+- [ ] Port tests from pmat to omen
+
+### Phase 4: Performance
+- [ ] Profile with pprof: `./omen analyze {cmd} --pprof`
+- [ ] Identify bottlenecks
+- [ ] Optimize as needed
+- [ ] Document performance characteristics
+
+### Phase 5: PR Creation
+- [ ] Create branch: `git checkout -b fix/analyzer-{name}-pmat-parity`
+- [ ] Run all tests: `task test`
+- [ ] Update requirements/analyzer/README.md status
+- [ ] Commit with semantic message
+- [ ] Create PR (don't push to origin)
+
+## Important Notes
+
+1. **Use asdf for pmat**: Always set Rust version before running pmat
+   ```bash
+   echo "rust 1.91.0" > ~/.tool-versions
+   asdf reshim rust
+   ```
+
+2. **Match pmat exactly**: JSON field names, path formats, and data types must match
+
+3. **Don't remove extra metrics**: Keep additional metrics if they're accurate, just ensure pmat's required fields are present
+
+4. **Author names vs emails**: pmat uses author names from git, not emails
+
+## Reference Repositories
+
+- **pmat (Rust)**: `/reference/paiml-mcp-agent-toolkit`
+- **monolith (test corpus)**: `/reference/ms-monolith`
+- **pmat book**: https://paiml.github.io/pmat-book/

--- a/requirements/analyzer/halstead.md
+++ b/requirements/analyzer/halstead.md
@@ -1,0 +1,61 @@
+# Halstead Analyzer Plan
+
+## Status: Done (No Changes Needed)
+
+## Analysis
+
+### pmat Implementation
+
+pmat has Halstead metrics defined in its `ComplexityMetrics` struct as an optional field:
+
+```rust
+pub struct ComplexityMetrics {
+    pub cyclomatic: u16,
+    pub cognitive: u16,
+    pub nesting_max: u8,
+    pub lines: u16,
+    pub halstead: Option<HalsteadMetrics>,
+}
+
+pub struct HalsteadMetrics {
+    pub operators_unique: u32,
+    pub operands_unique: u32,
+    pub operators_total: u32,
+    pub operands_total: u32,
+    pub volume: f64,
+    pub difficulty: f64,
+    pub effort: f64,
+    pub time: f64,
+    pub bugs: f64,
+}
+```
+
+However, **pmat does not currently populate Halstead metrics** - all language analyzers set `halstead: None`. The infrastructure exists but is not active.
+
+### omen Implementation
+
+omen has a fully functional Halstead analyzer accessible via the `--halstead` flag on the complexity command:
+
+```bash
+./omen analyze complexity --halstead -f json
+```
+
+omen's HalsteadMetrics includes all pmat fields plus two additional useful metrics:
+- `vocabulary` (uint32) - n = n1 + n2
+- `length` (uint32) - N = N1 + N2
+
+## Conclusion
+
+omen's Halstead implementation is **more feature-complete** than pmat's:
+1. Actually calculates and outputs Halstead metrics (pmat doesn't)
+2. Supports all pmat fields with identical JSON names
+3. Adds `vocabulary` and `length` as bonus fields
+
+No changes needed for pmat parity since pmat doesn't output Halstead data.
+
+## Checklist
+
+- [x] Analyzed pmat implementation
+- [x] Compared output formats
+- [x] Confirmed omen already exceeds pmat functionality
+- [x] No parity changes required

--- a/requirements/analyzer/tdg.md
+++ b/requirements/analyzer/tdg.md
@@ -1,0 +1,70 @@
+# TDG Analyzer Plan
+
+## Status: Done
+
+## Academic Research
+
+### Technical Debt Gradient
+
+The Technical Debt Gradient (TDG) is a composite metric that quantifies accumulated technical debt in source code. It combines multiple quality dimensions into a single actionable score.
+
+**Components (pmat weights):**
+- **Complexity** (30%): Cyclomatic and cognitive complexity
+- **Code Churn** (35%): Frequency of changes over time
+- **Coupling** (15%): Dependencies between modules
+- **Domain Risk** (10%): Critical domain areas (auth, crypto, etc.)
+- **Duplication** (10%): Code duplication percentage
+
+**Severity Thresholds:**
+- Normal: TDG < 1.5
+- Warning: TDG 1.5-2.5
+- Critical: TDG > 2.5
+
+### Academic References
+
+1. Cunningham, W. (1992). "The WyCash Portfolio Management System". OOPSLA.
+2. Kruchten, P., Nord, R., & Ozkaya, I. (2012). "Technical Debt: From Metaphor to Theory and Practice". IEEE Software.
+3. Ernst, N., et al. (2015). "Measure It? Manage It? Ignore It? Software Practitioners and Technical Debt". FSE.
+
+## Implementation Comparison
+
+### pmat Structure
+
+```rust
+pub struct TDGSummary {
+    pub total_files: usize,
+    pub critical_files: usize,
+    pub warning_files: usize,
+    pub average_tdg: f64,
+    pub p95_tdg: f64,
+    pub p99_tdg: f64,
+    pub estimated_debt_hours: f64,
+}
+
+pub struct TDGHotspot {
+    pub path: String,
+    pub tdg_score: f64,
+    pub primary_factor: String,
+    pub estimated_hours: f64,
+}
+```
+
+### omen Changes
+
+- Added `TDGReport` with pmat-compatible JSON structure
+- Added `TDGSummary` with total_files, critical_files, warning_files, average_tdg, p95_tdg, p99_tdg, estimated_debt_hours
+- Added `TDGHotspot` with path, tdg_score, primary_factor, estimated_hours
+- Added `ToTDGReport()` conversion method on `ProjectScore`
+- Converts omen's 0-100 scale (higher = better) to pmat's 0-5 scale (higher = more debt)
+- Formula: `tdg = (100 - omenScore) / 20`
+- Estimated hours uses pmat's formula: `2.0 * 1.8^tdg`
+
+## Parity Checklist
+
+- [x] Match summary fields (total_files, critical_files, warning_files)
+- [x] Add average_tdg, p95_tdg, p99_tdg to summary
+- [x] Add estimated_debt_hours to summary
+- [x] Match hotspot structure (path, tdg_score, primary_factor, estimated_hours)
+- [x] Proper severity classification (normal/warning/critical)
+- [x] All tests passing
+- [x] JSON output verified


### PR DESCRIPTION
## Summary

- Added pmat-compatible types for TDG output
- Converts omen's 0-100 scale (higher=better) to pmat's 0-5 scale (higher=more debt)
- Documented halstead analyzer status (no changes needed - omen exceeds pmat)

## Changes

- Added `TDGReport` with pmat-compatible JSON structure
- Added `TDGSummary` with total_files, critical_files, warning_files, average_tdg, p95_tdg, p99_tdg, estimated_debt_hours
- Added `TDGHotspot` with path, tdg_score, primary_factor, estimated_hours
- Added `ToTDGReport()` conversion method on ProjectScore
- Uses pmat's severity thresholds and refactoring hour estimation formula (`2.0 * 1.8^tdg`)
- Documented halstead analyzer status in requirements/analyzer/halstead.md

## Test Plan

- [x] All existing tests pass (`go test ./...`)
- [x] JSON output verified against pmat reference implementation
- [x] Documentation updated in requirements/analyzer/tdg.md and requirements/analyzer/halstead.md

---
Generated with Claude Code