### PR TITLE
fix(output): enable toon format serialization for all model types

### DIFF
--- a/internal/analyzer/deadcode.go
+++ b/internal/analyzer/deadcode.go
@@ -1,6 +1,7 @@
 package analyzer
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -920,7 +921,7 @@ func isTerminatingStatement(node *sitter.Node, source []byte, lang parser.Langua
 
 // getUnreachableReason returns a human-readable reason for unreachable code.
 func getUnreachableReason(terminatorLine uint32) string {
-	return "Code after terminating statement at line " + string(rune(terminatorLine))
+	return fmt.Sprintf("Code after terminating statement at line %d", terminatorLine)
 }
 
 // getFunctionNameNode returns the name node of a function.

--- a/pkg/models/deadcode.go
+++ b/pkg/models/deadcode.go
@@ -315,10 +315,10 @@ type ReferenceNode struct {
 
 // CallGraph represents the reference graph for reachability analysis.
 type CallGraph struct {
-	Nodes       map[uint32]*ReferenceNode `json:"nodes"`
-	Edges       []ReferenceEdge           `json:"edges"`
-	EntryPoints []uint32                  `json:"entry_points"`
-	EdgeIndex   map[uint32][]int          `json:"-"` // node -> edge indices (outgoing)
+	Nodes       map[uint32]*ReferenceNode `json:"nodes" toon:"-"`
+	Edges       []ReferenceEdge           `json:"edges" toon:"edges"`
+	EntryPoints []uint32                  `json:"entry_points" toon:"entry_points"`
+	EdgeIndex   map[uint32][]int          `json:"-" toon:"-"` // node -> edge indices (outgoing)
 }
 
 // NewCallGraph creates an initialized call graph.
@@ -412,20 +412,20 @@ type UnreachableBlock struct {
 
 // DeadCodeSummary provides aggregate statistics.
 type DeadCodeSummary struct {
-	TotalDeadFunctions     int                  `json:"total_dead_functions"`
-	TotalDeadVariables     int                  `json:"total_dead_variables"`
-	TotalDeadClasses       int                  `json:"total_dead_classes"`
-	TotalUnreachableBlocks int                  `json:"total_unreachable_blocks"`
-	TotalUnreachableLines  int                  `json:"total_unreachable_lines"`
-	DeadCodePercentage     float64              `json:"dead_code_percentage"`
-	ByFile                 map[string]int       `json:"by_file"`
-	ByKind                 map[DeadCodeKind]int `json:"by_kind,omitempty"`
-	TotalFilesAnalyzed     int                  `json:"total_files_analyzed"`
-	TotalLinesAnalyzed     int                  `json:"total_lines_analyzed"`
-	TotalNodesInGraph      int                  `json:"total_nodes_in_graph,omitempty"`
-	ReachableNodes         int                  `json:"reachable_nodes,omitempty"`
-	UnreachableNodes       int                  `json:"unreachable_nodes,omitempty"`
-	ConfidenceLevel        float64              `json:"confidence_level,omitempty"`
+	TotalDeadFunctions     int                  `json:"total_dead_functions" toon:"total_dead_functions"`
+	TotalDeadVariables     int                  `json:"total_dead_variables" toon:"total_dead_variables"`
+	TotalDeadClasses       int                  `json:"total_dead_classes" toon:"total_dead_classes"`
+	TotalUnreachableBlocks int                  `json:"total_unreachable_blocks" toon:"total_unreachable_blocks"`
+	TotalUnreachableLines  int                  `json:"total_unreachable_lines" toon:"total_unreachable_lines"`
+	DeadCodePercentage     float64              `json:"dead_code_percentage" toon:"dead_code_percentage"`
+	ByFile                 map[string]int       `json:"by_file" toon:"by_file"`
+	ByKind                 map[DeadCodeKind]int `json:"by_kind,omitempty" toon:"-"`
+	TotalFilesAnalyzed     int                  `json:"total_files_analyzed" toon:"total_files_analyzed"`
+	TotalLinesAnalyzed     int                  `json:"total_lines_analyzed" toon:"total_lines_analyzed"`
+	TotalNodesInGraph      int                  `json:"total_nodes_in_graph,omitempty" toon:"total_nodes_in_graph,omitempty"`
+	ReachableNodes         int                  `json:"reachable_nodes,omitempty" toon:"reachable_nodes,omitempty"`
+	UnreachableNodes       int                  `json:"unreachable_nodes,omitempty" toon:"unreachable_nodes,omitempty"`
+	ConfidenceLevel        float64              `json:"confidence_level,omitempty" toon:"confidence_level,omitempty"`
 }
 
 // NewDeadCodeSummary creates an initialized summary.

--- a/pkg/models/debt.go
+++ b/pkg/models/debt.go
@@ -5,6 +5,11 @@ import "time"
 // DebtCategory represents the type of technical debt.
 type DebtCategory string
 
+// String implements fmt.Stringer for toon serialization.
+func (d DebtCategory) String() string {
+	return string(d)
+}
+
 const (
 	DebtDesign      DebtCategory = "design"      // HACK, KLUDGE, SMELL
 	DebtDefect      DebtCategory = "defect"      // BUG, FIXME, BROKEN
@@ -17,6 +22,11 @@ const (
 // Severity represents the urgency of addressing the debt.
 type Severity string
 
+// String implements fmt.Stringer for toon serialization.
+func (s Severity) String() string {
+	return string(s)
+}
+
 const (
 	SeverityLow      Severity = "low"
 	SeverityMedium   Severity = "medium"
@@ -26,17 +36,17 @@ const (
 
 // TechnicalDebt represents a single SATD item found in code.
 type TechnicalDebt struct {
-	Category    DebtCategory `json:"category"`
-	Severity    Severity     `json:"severity"`
-	File        string       `json:"file"`
-	Line        uint32       `json:"line"`
-	Description string       `json:"description"`
-	Marker      string       `json:"marker"` // TODO, FIXME, HACK, etc.
-	Text        string       `json:"text,omitempty"`
-	Column      uint32       `json:"column,omitempty"`
-	ContextHash string       `json:"context_hash,omitempty"` // BLAKE3 hash for identity tracking
-	Author      string       `json:"author,omitempty"`
-	Date        *time.Time   `json:"date,omitempty"`
+	Category    DebtCategory `json:"category" toon:"category"`
+	Severity    Severity     `json:"severity" toon:"severity"`
+	File        string       `json:"file" toon:"file"`
+	Line        uint32       `json:"line" toon:"line"`
+	Description string       `json:"description" toon:"description"`
+	Marker      string       `json:"marker" toon:"marker"` // TODO, FIXME, HACK, etc.
+	Text        string       `json:"text,omitempty" toon:"text,omitempty"`
+	Column      uint32       `json:"column,omitempty" toon:"column,omitempty"`
+	ContextHash string       `json:"context_hash,omitempty" toon:"context_hash,omitempty"` // BLAKE3 hash for identity tracking
+	Author      string       `json:"author,omitempty" toon:"author,omitempty"`
+	Date        *time.Time   `json:"date,omitempty" toon:"date,omitempty"`
 }
 
 // SATDAnalysis represents the full SATD analysis result.

--- a/pkg/models/format_test.go
+++ b/pkg/models/format_test.go
@@ -1,0 +1,511 @@
+package models
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+
+	toon "github.com/toon-format/toon-go"
+)
+
+// TestAllTypesSerializeToJSON ensures all custom string types work with JSON encoding.
+func TestAllTypesSerializeToJSON(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name string
+		data any
+	}{
+		{
+			name: "TechnicalDebt",
+			data: TechnicalDebt{
+				Category:    DebtDesign,
+				Severity:    SeverityHigh,
+				File:        "test.go",
+				Line:        42,
+				Description: "Test debt",
+				Marker:      "HACK",
+				Text:        "some text",
+				Author:      "test",
+				Date:        &now,
+			},
+		},
+		{
+			name: "TechnicalDebt_nil_date",
+			data: TechnicalDebt{
+				Category:    DebtDefect,
+				Severity:    SeverityMedium,
+				File:        "test.go",
+				Line:        10,
+				Description: "Nil date test",
+				Marker:      "BUG",
+			},
+		},
+		{
+			name: "SATDAnalysis",
+			data: SATDAnalysis{
+				Items: []TechnicalDebt{
+					{Category: DebtRequirement, Severity: SeverityLow, File: "a.go", Line: 1, Marker: "TODO"},
+				},
+				Summary: SATDSummary{
+					TotalItems: 1,
+					BySeverity: map[string]int{"low": 1},
+					ByCategory: map[string]int{"requirement": 1},
+				},
+				TotalFilesAnalyzed: 1,
+				AnalyzedAt:         now,
+			},
+		},
+		{
+			name: "DeadCodeItem",
+			data: DeadCodeItem{
+				ItemType: DeadCodeTypeFunction,
+				Name:     "unusedFunc",
+				Line:     100,
+				Reason:   "not called",
+			},
+		},
+		{
+			name: "DeadCodeAnalysis",
+			data: DeadCodeAnalysis{
+				DeadFunctions: []DeadFunction{
+					{Name: "foo", File: "a.go", Line: 1, Confidence: 0.9, Reason: "unused"},
+				},
+				DeadVariables: []DeadVariable{
+					{Name: "bar", File: "b.go", Line: 2, Confidence: 0.8, Reason: "unused"},
+				},
+			},
+		},
+		{
+			name: "CodeClone",
+			data: CodeClone{
+				Type:       CloneType1,
+				Similarity: 1.0,
+				FileA:      "a.go",
+				FileB:      "b.go",
+				StartLineA: 1,
+				EndLineA:   10,
+				StartLineB: 20,
+				EndLineB:   30,
+			},
+		},
+		{
+			name: "CloneAnalysis",
+			data: CloneAnalysis{
+				Clones: []CodeClone{
+					{Type: CloneType2, Similarity: 0.95},
+					{Type: CloneType3, Similarity: 0.8},
+				},
+				Summary: CloneSummary{
+					TotalClones: 2,
+					Type1Count:  0,
+					Type2Count:  1,
+					Type3Count:  1,
+				},
+			},
+		},
+		{
+			name: "FunctionComplexity",
+			data: FunctionComplexity{
+				Name:      "testFunc",
+				File:      "test.go",
+				StartLine: 1,
+				EndLine:   20,
+				Metrics:   ComplexityMetrics{Cyclomatic: 5, Cognitive: 3, MaxNesting: 2, Lines: 20},
+			},
+		},
+		{
+			name: "FileComplexity",
+			data: FileComplexity{
+				Path:     "test.go",
+				Language: "go",
+				Functions: []FunctionComplexity{
+					{Name: "foo", Metrics: ComplexityMetrics{Cyclomatic: 10}},
+				},
+			},
+		},
+		{
+			name: "TdgScore",
+			data: TdgScore{
+				FilePath:   "test.go",
+				Language:   LanguageGo,
+				Total:      85.0,
+				Grade:      GradeA,
+				Confidence: 0.9,
+			},
+		},
+		{
+			name: "DefectScore",
+			data: DefectScore{
+				FilePath:    "test.go",
+				Probability: 0.8,
+				RiskLevel:   RiskHigh,
+			},
+		},
+		{
+			name: "GraphNode",
+			data: GraphNode{
+				ID:   "pkg/foo",
+				Name: "foo",
+				Type: NodePackage,
+			},
+		},
+		{
+			name: "GraphEdge",
+			data: GraphEdge{
+				From: "pkg/a",
+				To:   "pkg/b",
+				Type: EdgeImport,
+			},
+		},
+		{
+			name: "DependencyGraph",
+			data: DependencyGraph{
+				Nodes: []GraphNode{
+					{ID: "a", Name: "a", Type: NodePackage},
+				},
+				Edges: []GraphEdge{
+					{From: "a", To: "b", Type: EdgeImport},
+				},
+			},
+		},
+		{
+			name: "Violation",
+			data: Violation{
+				Severity:  SeverityWarning,
+				Rule:      "max_cyclomatic",
+				Message:   "High complexity",
+				Value:     15,
+				Threshold: 10,
+			},
+		},
+		{
+			name: "DeadFunction_with_kind",
+			data: DeadFunction{
+				Name:       "test",
+				File:       "test.go",
+				Line:       1,
+				Kind:       DeadKindFunction,
+				Confidence: 0.9,
+			},
+		},
+		{
+			name: "ReferenceEdge",
+			data: ReferenceEdge{
+				From:       1,
+				To:         2,
+				Type:       RefDirectCall,
+				Confidence: 0.95,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+"_json", func(t *testing.T) {
+			data, err := json.Marshal(tt.data)
+			if err != nil {
+				t.Errorf("JSON marshal failed: %v", err)
+				return
+			}
+			if len(data) == 0 {
+				t.Error("JSON output should not be empty")
+			}
+		})
+	}
+}
+
+// TestAllTypesSerializeToTOON ensures all custom string types work with TOON encoding.
+func TestAllTypesSerializeToTOON(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name string
+		data any
+	}{
+		{
+			name: "TechnicalDebt",
+			data: TechnicalDebt{
+				Category:    DebtDesign,
+				Severity:    SeverityHigh,
+				File:        "test.go",
+				Line:        42,
+				Description: "Test debt",
+				Marker:      "HACK",
+			},
+		},
+		{
+			name: "TechnicalDebt_nil_date",
+			data: TechnicalDebt{
+				Category:    DebtDefect,
+				Severity:    SeverityMedium,
+				File:        "test.go",
+				Line:        10,
+				Description: "Nil date test",
+				Marker:      "BUG",
+			},
+		},
+		{
+			name: "SATDAnalysis",
+			data: SATDAnalysis{
+				Items: []TechnicalDebt{
+					{Category: DebtRequirement, Severity: SeverityLow, File: "a.go", Line: 1, Marker: "TODO"},
+				},
+				Summary: SATDSummary{
+					TotalItems: 1,
+					BySeverity: map[string]int{"low": 1},
+					ByCategory: map[string]int{"requirement": 1},
+				},
+				TotalFilesAnalyzed: 1,
+				AnalyzedAt:         now,
+			},
+		},
+		{
+			name: "DeadCodeItem",
+			data: DeadCodeItem{
+				ItemType: DeadCodeTypeFunction,
+				Name:     "unusedFunc",
+				Line:     100,
+				Reason:   "unused",
+			},
+		},
+		{
+			name: "DeadCodeAnalysis",
+			data: DeadCodeAnalysis{
+				DeadFunctions: []DeadFunction{
+					{Name: "foo", File: "a.go", Line: 1, Confidence: 0.9},
+				},
+				DeadVariables: []DeadVariable{
+					{Name: "bar", File: "b.go", Line: 2, Confidence: 0.5},
+				},
+			},
+		},
+		{
+			name: "CodeClone",
+			data: CodeClone{
+				Type:       CloneType1,
+				Similarity: 1.0,
+				FileA:      "a.go",
+				FileB:      "b.go",
+			},
+		},
+		{
+			name: "FunctionComplexity",
+			data: FunctionComplexity{
+				Name:      "testFunc",
+				File:      "test.go",
+				StartLine: 1,
+				EndLine:   20,
+				Metrics:   ComplexityMetrics{Cyclomatic: 5, Cognitive: 3, MaxNesting: 2, Lines: 20},
+			},
+		},
+		{
+			name: "TdgScore",
+			data: TdgScore{
+				FilePath:   "test.go",
+				Language:   LanguageGo,
+				Total:      85.0,
+				Grade:      GradeA,
+				Confidence: 0.9,
+			},
+		},
+		{
+			name: "DefectScore",
+			data: DefectScore{
+				FilePath:    "test.go",
+				Probability: 0.8,
+				RiskLevel:   RiskHigh,
+			},
+		},
+		{
+			name: "DependencyGraph",
+			data: DependencyGraph{
+				Nodes: []GraphNode{
+					{ID: "a", Name: "a", Type: NodePackage},
+				},
+				Edges: []GraphEdge{
+					{From: "a", To: "b", Type: EdgeImport},
+				},
+			},
+		},
+		{
+			name: "Violation",
+			data: Violation{
+				Severity: SeverityError,
+				Rule:     "test",
+				Message:  "test violation",
+			},
+		},
+		{
+			name: "DeadFunction_with_kind",
+			data: DeadFunction{
+				Name: "test",
+				File: "test.go",
+				Line: 1,
+				Kind: DeadKindFunction,
+			},
+		},
+		{
+			name: "ReferenceEdge",
+			data: ReferenceEdge{
+				From: 1,
+				To:   2,
+				Type: RefDirectCall,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+"_toon", func(t *testing.T) {
+			data, err := toon.Marshal(tt.data)
+			if err != nil {
+				t.Errorf("TOON marshal failed: %v", err)
+				return
+			}
+			if len(data) == 0 {
+				t.Error("TOON output should not be empty")
+			}
+		})
+	}
+}
+
+// TestCustomStringTypesImplementStringer ensures all custom string types implement fmt.Stringer
+// which is required for toon serialization.
+func TestCustomStringTypesImplementStringer(t *testing.T) {
+	tests := []struct {
+		name   string
+		value  interface{ String() string }
+		expect string
+	}{
+		// DebtCategory values
+		{"DebtCategory_design", DebtDesign, "design"},
+		{"DebtCategory_defect", DebtDefect, "defect"},
+		{"DebtCategory_requirement", DebtRequirement, "requirement"},
+		{"DebtCategory_test", DebtTest, "test"},
+		{"DebtCategory_performance", DebtPerformance, "performance"},
+		{"DebtCategory_security", DebtSecurity, "security"},
+		// Severity values
+		{"Severity_low", SeverityLow, "low"},
+		{"Severity_medium", SeverityMedium, "medium"},
+		{"Severity_high", SeverityHigh, "high"},
+		{"Severity_critical", SeverityCritical, "critical"},
+		// ConfidenceLevel values
+		{"ConfidenceLevel_high", ConfidenceHigh, "High"},
+		{"ConfidenceLevel_medium", ConfidenceMedium, "Medium"},
+		{"ConfidenceLevel_low", ConfidenceLow, "Low"},
+		// DeadCodeType values
+		{"DeadCodeType_function", DeadCodeTypeFunction, "function"},
+		{"DeadCodeType_class", DeadCodeTypeClass, "class"},
+		{"DeadCodeType_variable", DeadCodeTypeVariable, "variable"},
+		{"DeadCodeType_unreachable", DeadCodeTypeUnreachable, "unreachable"},
+		// ReferenceType values
+		{"ReferenceType_direct_call", RefDirectCall, "direct_call"},
+		{"ReferenceType_indirect_call", RefIndirectCall, "indirect_call"},
+		{"ReferenceType_import", RefImport, "import"},
+		// DeadCodeKind values
+		{"DeadCodeKind_function", DeadKindFunction, "unused_function"},
+		{"DeadCodeKind_class", DeadKindClass, "unused_class"},
+		{"DeadCodeKind_variable", DeadKindVariable, "unused_variable"},
+		// Grade values
+		{"Grade_A", GradeA, "A"},
+		{"Grade_B", GradeB, "B"},
+		{"Grade_C", GradeC, "C"},
+		{"Grade_D", GradeD, "D"},
+		{"Grade_F", GradeF, "F"},
+		// MetricCategory values
+		{"MetricCategory_structural", MetricStructuralComplexity, "structural_complexity"},
+		{"MetricCategory_semantic", MetricSemanticComplexity, "semantic_complexity"},
+		// Language values
+		{"Language_go", LanguageGo, "go"},
+		{"Language_rust", LanguageRust, "rust"},
+		{"Language_python", LanguagePython, "python"},
+		// CloneType values
+		{"CloneType_1", CloneType1, "type1"},
+		{"CloneType_2", CloneType2, "type2"},
+		{"CloneType_3", CloneType3, "type3"},
+		// ViolationSeverity values
+		{"ViolationSeverity_warning", SeverityWarning, "warning"},
+		{"ViolationSeverity_error", SeverityError, "error"},
+		// RiskLevel values
+		{"RiskLevel_high", RiskHigh, "high"},
+		{"RiskLevel_medium", RiskMedium, "medium"},
+		{"RiskLevel_low", RiskLow, "low"},
+		// NodeType values
+		{"NodeType_package", NodePackage, "package"},
+		{"NodeType_file", NodeFile, "file"},
+		{"NodeType_function", NodeFunction, "function"},
+		// EdgeType values
+		{"EdgeType_import", EdgeImport, "import"},
+		{"EdgeType_call", EdgeCall, "call"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.value.String()
+			if result != tt.expect {
+				t.Errorf("String() = %q, want %q", result, tt.expect)
+			}
+		})
+	}
+}
+
+// TestRoundTripJSON verifies JSON serialization and deserialization works correctly.
+func TestRoundTripJSON(t *testing.T) {
+	original := TechnicalDebt{
+		Category:    DebtDesign,
+		Severity:    SeverityHigh,
+		File:        "test.go",
+		Line:        42,
+		Description: "Test debt",
+		Marker:      "HACK",
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var decoded TechnicalDebt
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if decoded.Category != original.Category {
+		t.Errorf("Category = %v, want %v", decoded.Category, original.Category)
+	}
+	if decoded.Severity != original.Severity {
+		t.Errorf("Severity = %v, want %v", decoded.Severity, original.Severity)
+	}
+}
+
+// TestTextOutputFormat verifies types can be formatted as text/strings for display.
+func TestTextOutputFormat(t *testing.T) {
+	tests := []struct {
+		name   string
+		format func() string
+		want   string
+	}{
+		{
+			name:   "DebtCategory_format",
+			format: func() string { var buf bytes.Buffer; buf.WriteString(DebtDesign.String()); return buf.String() },
+			want:   "design",
+		},
+		{
+			name:   "Severity_format",
+			format: func() string { var buf bytes.Buffer; buf.WriteString(SeverityHigh.String()); return buf.String() },
+			want:   "high",
+		},
+		{
+			name:   "Grade_format",
+			format: func() string { var buf bytes.Buffer; buf.WriteString(GradeA.String()); return buf.String() },
+			want:   "A",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.format()
+			if result != tt.want {
+				t.Errorf("format() = %q, want %q", result, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/models/stringer.go
+++ b/pkg/models/stringer.go
@@ -1,0 +1,46 @@
+package models
+
+// String methods for all custom string types.
+// These are required for toon serialization, which uses fmt.Stringer.
+
+// ConfidenceLevel
+func (c ConfidenceLevel) String() string { return string(c) }
+
+// DeadCodeType
+func (d DeadCodeType) String() string { return string(d) }
+
+// ReferenceType
+func (r ReferenceType) String() string { return string(r) }
+
+// DeadCodeKind
+func (d DeadCodeKind) String() string { return string(d) }
+
+// Grade
+func (g Grade) String() string { return string(g) }
+
+// MetricCategory
+func (m MetricCategory) String() string { return string(m) }
+
+// Language
+func (l Language) String() string { return string(l) }
+
+// TDGSeverity
+func (t TDGSeverity) String() string { return string(t) }
+
+// CloneType
+func (c CloneType) String() string { return string(c) }
+
+// ViolationSeverity
+func (v ViolationSeverity) String() string { return string(v) }
+
+// RiskLevel
+func (r RiskLevel) String() string { return string(r) }
+
+// NodeType
+func (n NodeType) String() string { return string(n) }
+
+// EdgeType
+func (e EdgeType) String() string { return string(e) }
+
+// PenaltyCurve
+func (pc PenaltyCurve) String() string { return string(pc) }


### PR DESCRIPTION
## Summary

- Add missing `fmt.Stringer` implementations for custom string types (required by toon serialization)
- Fix non-string map key serialization issues by excluding incompatible fields from toon output
- Fix bug in `getUnreachableReason` that was converting line numbers to control characters
- Add proper toon struct tags to TechnicalDebt and DeadCodeSummary types

## Changes

### New Files
- `pkg/models/stringer.go` - String() methods for 14 custom string types:
  - ConfidenceLevel, DeadCodeType, ReferenceType, DeadCodeKind
  - Grade, MetricCategory, Language, TDGSeverity
  - CloneType, ViolationSeverity, RiskLevel
  - NodeType, EdgeType, PenaltyCurve

- `pkg/models/format_test.go` - Serialization tests:
  - TestAllTypesSerializeToJSON
  - TestAllTypesSerializeToTOON
  - TestCustomStringTypesImplementStringer
  - TestRoundTripJSON
  - TestTextOutputFormat

### Bug Fixes
- `internal/analyzer/deadcode.go:923` - Fixed `getUnreachableReason` which used `string(rune(terminatorLine))` instead of `fmt.Sprintf`. This was converting line numbers like `42` to control characters instead of the string `"42"`.

### Toon Serialization Fixes
- `pkg/models/deadcode.go` - Added `toon:"-"` tags for:
  - `CallGraph.Nodes` (map[uint32]*ReferenceNode not supported)
  - `DeadCodeSummary.ByKind` (map[DeadCodeKind]int not supported)

- `pkg/models/debt.go` - Added:
  - String() methods for DebtCategory and Severity
  - Proper toon struct tags for TechnicalDebt fields including `omitempty` for optional fields

## Test Plan

- [x] All existing tests pass
- [x] New serialization tests verify JSON and TOON output for all major model types
- [x] Custom string type stringer tests verify 46 constant values
- [x] Manual verification of `omen analyze -f toon` output

Generated with [Claude Code](https://claude.com/claude-code)