### PR TITLE
perf(analyzer): optimize context command for large codebases

### DIFF
--- a/internal/analyzer/repomap.go
+++ b/internal/analyzer/repomap.go
@@ -32,8 +32,8 @@ func (a *RepoMapAnalyzer) AnalyzeProjectWithProgress(files []string, onProgress 
 		return nil, err
 	}
 
-	// Calculate graph metrics including PageRank
-	metrics := a.graphAnalyzer.CalculateMetrics(graph)
+	// Calculate PageRank only - much faster than full metrics
+	metrics := a.graphAnalyzer.CalculatePageRankOnly(graph)
 
 	// Build repo map from graph nodes and metrics
 	repoMap := &models.RepoMap{


### PR DESCRIPTION
## Summary

Optimizes the `omen context --repo-map` command to run on large codebases (4300+ files, 25,000+ symbols) in under 30 seconds, down from over 5 minutes.

## Changes

### Sparse PageRank Implementation
- Added `sparsePageRank()` function using sparse power iteration with adjacency lists
- Complexity: O(E * iterations) instead of gonum's O(V^2 * iterations)
- For 25k nodes, reduces PageRank computation from ~5 minutes to <1 second

### PageRank-Only Fast Path
- Added `CalculatePageRankOnly()` method on GraphAnalyzer
- Repo map only needs PageRank and degree metrics
- Skips expensive Betweenness, Closeness, and Harmonic centrality calculations

### Parallel Centrality Metrics
- When full metrics ARE needed (via `CalculateMetrics`), compute PageRank, Betweenness, and AllShortest paths in parallel
- Closeness and Harmonic computed in parallel after AllShortest completes

### Diameter/Radius Sampling
- For graphs >100 nodes, sample 100 evenly-distributed nodes instead of computing from all nodes
- Reduces O(V^2) BFS to O(100*V)

### Data Structure Reuse
- Pre-allocate and reuse distance maps and queues in BFS
- Reduces GC pressure on large graphs

## Performance Results

| Subset | Before | After |
|--------|--------|-------|
| app/ (2069 files) | ~33s | 7.2s |
| Full legacy codebase (4300 files, 25k symbols) | >5 min | ~24s |

## Test Plan

- [x] All existing tests pass
- [x] Verified on large production codebase with 4300+ files
- [x] Benchmarked before/after on multiple repository sizes