### PR TITLE
fix: address issues from comprehensive code review

### DIFF
--- a/cmd/omen/main.go
+++ b/cmd/omen/main.go
@@ -118,9 +118,6 @@ func validateDays(days int) error {
 	if days <= 0 {
 		return fmt.Errorf("--days must be a positive integer (got %d)", days)
 	}
-	if days > 3650 { // ~10 years
-		return fmt.Errorf("--days cannot exceed 3650 (10 years), got %d", days)
-	}
 	return nil
 }
 

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -129,7 +129,7 @@ func (c *Cache) Set(key string, data []byte) error {
 		return err
 	}
 
-	return os.WriteFile(c.keyPath(key), entryData, 0644)
+	return os.WriteFile(c.keyPath(key), entryData, 0600)
 }
 
 // SetWithHash stores data in the cache with a hash for validation.
@@ -149,7 +149,7 @@ func (c *Cache) SetWithHash(key, hash string, data []byte) error {
 		return err
 	}
 
-	return os.WriteFile(c.keyPath(key), entryData, 0644)
+	return os.WriteFile(c.keyPath(key), entryData, 0600)
 }
 
 // Invalidate removes a cache entry.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -235,11 +235,13 @@ func LoadOrDefault() *Config {
 
 // ShouldExclude checks if a path should be excluded from analysis.
 func (c *Config) ShouldExclude(path string) bool {
-	// Check directory exclusions
+	// Check directory exclusions using exact path component matching
+	pathComponents := strings.Split(filepath.Clean(path), string(filepath.Separator))
 	for _, dir := range c.Exclude.Dirs {
-		if strings.Contains(path, string(filepath.Separator)+dir+string(filepath.Separator)) ||
-			strings.HasPrefix(path, dir+string(filepath.Separator)) {
-			return true
+		for _, component := range pathComponents {
+			if component == dir {
+				return true
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes multiple issues identified during a comprehensive code review, focusing on security, correctness, and robustness improvements across the codebase.

## Changes Made

- **Security**: Cache file permissions changed from 0644 to 0600 to restrict read access to owner only (`internal/cache/cache.go`)
- **Correctness**: Gitignore loading now stops at git repository root instead of walking up to filesystem root (`internal/scanner/scanner.go`)
- **Correctness**: Directory exclusion logic uses exact path component matching instead of substring matching, preventing false positives like "vendor" matching "vendors-api" (`pkg/config/config.go`)
- **Flexibility**: Removed arbitrary 3650-day limit on `--days` flag to allow analysis of older repositories (`cmd/omen/main.go`)
- **Robustness**: Added 5-minute timeout/context support to git operations in churn and temporal coupling analyzers (`internal/analyzer/churn.go`, `internal/analyzer/temporal.go`)

## Testing

- Existing tests pass
- Manual verification of gitignore behavior in nested repositories
- Verified cache files are created with correct permissions