### PR TITLE
chore: add codecov config to exclude mocks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - "**/mocks/**"
+  - "internal/testutil/**"


### PR DESCRIPTION
## Summary

Adds codecov configuration to exclude generated files from coverage reports.

## Changes Made

- Created `codecov.yml` with ignore patterns for:
  - `**/mocks/**` - generated mock files
  - `internal/testutil/**` - test utilities