### PR TITLE
fix(ci): correct release workflow and use simple v-prefix tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      release_created: ${{ steps.release.outputs['.--release_created'] }}
-      tag_name: ${{ steps.release.outputs['.--tag_name'] }}
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
       skills_release_created: ${{ steps.release.outputs['.claude-plugin--release_created'] }}
 
     steps:


### PR DESCRIPTION
## Summary

Two fixes for the release workflow:

1. **Fix GoReleaser trigger** - Changed `releases_created` (aggregate JSON array) to `release_created` (boolean for root package) so GoReleaser actually runs
2. **Use simple v-prefix tags** - Added `include-component-in-tag: false` so CLI releases use `v3.0.2` instead of `omen-v3.0.2`

## Cleanup

Deleted old `omen-v*` releases and tags:
- omen-v3.0.1
- omen-v3.0.0  
- omen-v2.0.0

The skills plugin keeps its `omen-skills-v*` prefix for distinction.

## Test plan

- [x] Delete old omen-v* releases and tags
- [ ] Merge to main
- [ ] Verify next release uses `v*` tag format and triggers GoReleaser