### PR TITLE
feat(mcp): add Go template support for prompts with frontmatter defaults

### DIFF
--- a/internal/mcpserver/mcp_test.go
+++ b/internal/mcpserver/mcp_test.go
@@ -751,8 +751,8 @@ func TestPromptFiles(t *testing.T) {
 				t.Fatal("file is empty")
 			}
 
-			description, body := parseFrontmatter(content)
-			if description == "" {
+			fm, body := parseFrontmatter(content)
+			if fm.Description == "" {
 				t.Error("frontmatter description is empty")
 			}
 			if body == "" {

--- a/internal/mcpserver/prompts.go
+++ b/internal/mcpserver/prompts.go
@@ -6,6 +6,7 @@ import (
 	"embed"
 	"path/filepath"
 	"strings"
+	"text/template"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"gopkg.in/yaml.v3"
@@ -14,9 +15,20 @@ import (
 //go:embed prompts/*.md
 var promptFiles embed.FS
 
+// promptArgument defines a customization parameter for a prompt.
+type promptArgument struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+	Required    bool   `yaml:"required"`
+	Default     string `yaml:"default"`
+}
+
 // promptFrontmatter is parsed from YAML frontmatter in prompt files.
 type promptFrontmatter struct {
-	Description string `yaml:"description"`
+	Name        string           `yaml:"name"`
+	Title       string           `yaml:"title"`
+	Description string           `yaml:"description"`
+	Arguments   []promptArgument `yaml:"arguments"`
 }
 
 // registerPrompts discovers and registers all prompts from embedded markdown files.
@@ -31,7 +43,7 @@ func (s *Server) registerPrompts() {
 			continue
 		}
 
-		name := strings.TrimSuffix(entry.Name(), ".md")
+		fallbackName := strings.TrimSuffix(entry.Name(), ".md")
 		path := filepath.Join("prompts", entry.Name())
 
 		content, err := promptFiles.ReadFile(path)
@@ -39,45 +51,138 @@ func (s *Server) registerPrompts() {
 			continue
 		}
 
-		description, body := parseFrontmatter(content)
+		fm, body := parseFrontmatter(content)
+
+		// Use frontmatter name if provided, otherwise fall back to filename
+		name := fm.Name
+		if name == "" {
+			name = fallbackName
+		}
+
+		// Build MCP arguments from frontmatter
+		var args []*mcp.PromptArgument
+		for _, a := range fm.Arguments {
+			args = append(args, &mcp.PromptArgument{
+				Name:        a.Name,
+				Description: a.Description,
+				Required:    a.Required,
+			})
+		}
 
 		prompt := &mcp.Prompt{
 			Name:        name,
-			Description: description,
+			Description: fm.Description,
+			Arguments:   args,
 		}
-		s.server.AddPrompt(prompt, makePromptHandler(description, body))
+		s.server.AddPrompt(prompt, makePromptHandler(fm, body))
 	}
 }
 
-// parseFrontmatter extracts YAML frontmatter and returns description and body.
-func parseFrontmatter(content []byte) (description string, body string) {
+// parseFrontmatter extracts YAML frontmatter and returns the parsed struct and body.
+func parseFrontmatter(content []byte) (fm promptFrontmatter, body string) {
 	if !bytes.HasPrefix(content, []byte("---\n")) {
-		return "", string(content)
+		return promptFrontmatter{}, string(content)
 	}
 
 	rest := content[4:]
 	end := bytes.Index(rest, []byte("\n---\n"))
 	if end == -1 {
-		return "", string(content)
+		return promptFrontmatter{}, string(content)
 	}
 
-	var fm promptFrontmatter
 	if err := yaml.Unmarshal(rest[:end], &fm); err != nil {
-		return "", string(content)
+		return promptFrontmatter{}, string(content)
 	}
 
 	body = strings.TrimPrefix(string(rest[end+5:]), "\n")
-	return fm.Description, body
+	return fm, body
 }
 
-func makePromptHandler(description, body string) mcp.PromptHandler {
+// templateFuncs provides helper functions for prompt templates.
+var templateFuncs = template.FuncMap{
+	"default": func(defaultVal, val string) string {
+		if val == "" {
+			return defaultVal
+		}
+		return val
+	},
+	"join":     strings.Join,
+	"split":    strings.Split,
+	"lower":    strings.ToLower,
+	"upper":    strings.ToUpper,
+	"contains": strings.Contains,
+}
+
+// extractDefaults builds a defaults map from frontmatter arguments.
+func extractDefaults(args []promptArgument) map[string]string {
+	defaults := make(map[string]string)
+	for _, arg := range args {
+		if arg.Default != "" {
+			defaults[arg.Name] = arg.Default
+		}
+	}
+	return defaults
+}
+
+// mergeArgs combines user arguments with defaults, user args take precedence.
+func mergeArgs(userArgs map[string]string, defaults map[string]string) map[string]string {
+	result := make(map[string]string)
+	for k, v := range defaults {
+		result[k] = v
+	}
+	for k, v := range userArgs {
+		if v != "" {
+			result[k] = v
+		}
+	}
+	return result
+}
+
+func makePromptHandler(fm promptFrontmatter, body string) mcp.PromptHandler {
+	// Parse template at registration time for early error detection
+	tmpl, parseErr := template.New(fm.Name).Funcs(templateFuncs).Parse(body)
+
+	// Extract defaults from frontmatter at registration time
+	defaults := extractDefaults(fm.Arguments)
+
 	return func(ctx context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+		if parseErr != nil {
+			// Fall back to raw body if template parsing failed
+			return &mcp.GetPromptResult{
+				Description: fm.Description,
+				Messages: []*mcp.PromptMessage{
+					{
+						Role:    "user",
+						Content: &mcp.TextContent{Text: body},
+					},
+				},
+			}, nil
+		}
+
+		// Merge user arguments with defaults from frontmatter
+		args := mergeArgs(req.Params.Arguments, defaults)
+
+		// Execute template
+		var buf bytes.Buffer
+		if err := tmpl.Execute(&buf, args); err != nil {
+			// Fall back to raw body on execution error
+			return &mcp.GetPromptResult{
+				Description: fm.Description,
+				Messages: []*mcp.PromptMessage{
+					{
+						Role:    "user",
+						Content: &mcp.TextContent{Text: body},
+					},
+				},
+			}, nil
+		}
+
 		return &mcp.GetPromptResult{
-			Description: description,
+			Description: fm.Description,
 			Messages: []*mcp.PromptMessage{
 				{
 					Role:    "user",
-					Content: &mcp.TextContent{Text: body},
+					Content: &mcp.TextContent{Text: buf.String()},
 				},
 			},
 		}, nil

--- a/internal/mcpserver/prompts/architecture-review.md
+++ b/internal/mcpserver/prompts/architecture-review.md
@@ -1,33 +1,150 @@
 ---
-description: Analyze architectural health including module coupling, cohesion metrics, hidden dependencies, and design smells.
+name: architecture-review
+title: Architecture Review
+description: Analyze architectural health including module coupling, cohesion metrics, dependency cycles, and design smells
+arguments:
+  - name: paths
+    description: Paths to analyze
+    required: false
+    default: "."
+  - name: scope
+    description: "Analysis scope: file, function, module, or package"
+    required: false
+    default: "module"
+  - name: include_temporal
+    description: Include temporal coupling analysis (requires git)
+    required: false
+    default: "true"
+  - name: top
+    description: Maximum items to return
+    required: false
+    default: "20"
+  - name: days
+    description: Days of git history for temporal coupling
+    required: false
+    default: "30"
+  - name: min_cochanges
+    description: Minimum co-changes for temporal coupling
+    required: false
+    default: "3"
 ---
 
 # Architecture Review
 
-Analyze the architectural health of this codebase.
+Analyze the architectural health of the codebase at: {{.paths}}
 
-## Instructions
+## When to Use
 
-1. Use `analyze_graph` with `scope: "module"` and `include_metrics: true` for dependency analysis
-2. Use `analyze_cohesion` to check OO design quality (CK metrics)
-3. Use `analyze_temporal_coupling` to find hidden dependencies not visible in imports
-4. Use `analyze_ownership` to check if architecture aligns with team structure
+- During architectural design reviews
+- Before major refactoring efforts
+- When onboarding to understand system structure
+- Periodic health checks (monthly/quarterly)
 
-## Architectural Concerns
+## Workflow
 
-Look for:
-- **High Coupling**: Modules with many dependencies (high CBO, high out-degree)
-- **Low Cohesion**: Classes doing unrelated things (high LCOM)
-- **Hidden Dependencies**: Temporal coupling without import relationships
-- **God Classes**: High WMC combined with high LCOM
-- **Deep Hierarchies**: DIT > 4 indicates overly complex inheritance
-- **Conway's Law Violations**: Code ownership that doesn't match module boundaries
+### Step 1: Dependency Graph Analysis
+```
+analyze_graph:
+  paths: {{.paths}}
+  scope: {{.scope}}
+  include_metrics: true
+```
+Get module dependencies, cycles, and centrality metrics (PageRank, betweenness).
 
-## Output Format
+### Step 2: Architectural Smell Detection
+```
+analyze_smells:
+  paths: {{.paths}}
+```
+Detect cyclic dependencies, hub components, god components, and unstable dependencies.
 
-Provide an architecture assessment with:
-1. **Health Score**: Overall architectural health (Good/Fair/Poor)
-2. **Dependency Analysis**: Module coupling and potential cycles
-3. **Design Smells**: Classes violating CK metric thresholds
-4. **Hidden Couplings**: Temporal dependencies that suggest missing abstractions
-5. **Recommendations**: Specific architectural improvements to consider
+### Step 3: Class-Level Design Quality
+```
+analyze_cohesion:
+  paths: {{.paths}}
+  sort: lcom
+  top: {{.top}}
+```
+Get CK metrics (LCOM, WMC, CBO, DIT, RFC) for OO design quality.
+
+### Step 4: Hidden Dependencies (if git available)
+```
+analyze_temporal_coupling:
+  paths: {{.paths}}
+  days: {{.days}}
+  min_cochanges: {{.min_cochanges}}
+```
+Find files that change together but have no import relationship - indicates missing abstractions.
+
+### Step 5: Ownership Alignment
+```
+analyze_ownership:
+  paths: {{.paths}}
+```
+Check if code ownership aligns with module boundaries (Conway's Law).
+
+## Thresholds
+
+| Metric | Good | Warning | Critical |
+|--------|------|---------|----------|
+| Cyclic dependencies | 0 | 1-2 | 3+ |
+| LCOM (lack of cohesion) | < 0.5 | 0.5-0.8 | > 0.8 |
+| WMC (weighted methods) | < 20 | 20-50 | > 50 |
+| CBO (coupling) | < 10 | 10-20 | > 20 |
+| DIT (inheritance depth) | < 4 | 4-6 | > 6 |
+| Hub components | 0 | 1-2 | 3+ |
+| God components | 0 | 1 | 2+ |
+
+## Output
+
+### Architecture Health Summary
+
+**Overall Health**: [GOOD | FAIR | POOR | CRITICAL]
+**Scope Analyzed**: {{.paths}} at {{.scope}} level
+
+### Dependency Analysis
+
+| Metric | Value | Status |
+|--------|-------|--------|
+| Total modules | | |
+| Total dependencies | | |
+| Dependency cycles | | |
+| Graph density | | |
+| Avg path length | | |
+
+### Architectural Smells
+
+| Smell | Count | Severity | Components |
+|-------|-------|----------|------------|
+| Cyclic Dependency | | | |
+| Hub Component | | | |
+| God Component | | | |
+| Unstable Dependency | | | |
+
+### Design Quality (Top Classes by LCOM)
+
+| Class | File | LCOM | WMC | CBO | DIT | Issue |
+|-------|------|------|-----|-----|-----|-------|
+
+### Hidden Dependencies
+
+File pairs with high temporal coupling but no import relationship:
+| File A | File B | Co-changes | Suggestion |
+|--------|--------|------------|------------|
+
+### Conway's Law Analysis
+
+Modules with ownership that doesn't match team boundaries:
+| Module | Primary Owner | Secondary Owners | Concern |
+|--------|---------------|------------------|---------|
+
+### Recommendations
+
+1. **Immediate** (blocking issues):
+   - [List cycles to break, god components to split]
+
+2. **Short-term** (next sprint):
+   - [Hub reduction, cohesion improvements]
+
+3. **Long-term** (roadmap):
+   - [Architectural refactoring suggestions]

--- a/internal/mcpserver/prompts/bug-hunt.md
+++ b/internal/mcpserver/prompts/bug-hunt.md
@@ -1,30 +1,148 @@
 ---
-description: Find the most likely locations for bugs using defect prediction, hotspot analysis, temporal coupling, and ownership patterns.
+name: bug-hunt
+title: Bug Hunt
+description: Find likely bug locations using defect prediction, hotspot analysis, and ownership patterns
+arguments:
+  - name: paths
+    description: Paths to analyze
+    required: false
+    default: "."
+  - name: days
+    description: Days of git history to consider
+    required: false
+    default: "30"
+  - name: focus
+    description: "Focus area: security, performance, reliability, or all"
+    required: false
+    default: "all"
+  - name: top
+    description: Maximum items to return
+    required: false
+    default: "20"
+  - name: min_cochanges
+    description: Minimum co-changes for temporal coupling
+    required: false
+    default: "3"
 ---
 
 # Bug Hunt
 
-Identify the most likely locations for bugs in this codebase using statistical defect prediction.
+Identify the most likely locations for bugs in: {{.paths}}
 
-## Instructions
+## When to Use
 
-1. Use `analyze_defect` with `high_risk_only: true` to find statistically high-risk files
-2. Use `analyze_hotspot` to find high-churn + high-complexity intersections
-3. Use `analyze_temporal_coupling` to find files that change together (bugs often span coupled files)
-4. Use `analyze_ownership` to find knowledge silos (single-owner files have higher risk)
+- After receiving a bug report (narrow the search)
+- Before a release (proactive bug hunting)
+- During security audits
+- When investigating intermittent failures
 
-## Bug Indicators
+## Workflow
+
+### Step 1: Statistical Defect Prediction
+```
+analyze_defect:
+  paths: {{.paths}}
+  high_risk_only: false
+```
+Get file-level defect probability based on churn, complexity, duplication, and coupling.
+
+### Step 2: Hotspot Analysis
+```
+analyze_hotspot:
+  paths: {{.paths}}
+  days: {{.days}}
+  top: {{.top}}
+```
+Find files with both high churn AND high complexity - the intersection is where bugs hide.
+
+### Step 3: Temporal Coupling
+```
+analyze_temporal_coupling:
+  paths: {{.paths}}
+  days: {{.days}}
+  min_cochanges: {{.min_cochanges}}
+```
+Find files that change together - bugs often span coupled files.
+
+### Step 4: Knowledge Silos
+```
+analyze_ownership:
+  paths: {{.paths}}
+  top: {{.top}}
+```
+Single-owner files have higher bug risk (no peer review, bus factor).
+
+### Step 5: Explicit Debt Markers
+```
+analyze_satd:
+  paths: {{.paths}}
+  strict_mode: false
+```
+Find TODO, FIXME, HACK, BUG markers - explicit acknowledgment of issues.
+
+## Risk Indicators
 
 Files are more likely to contain bugs when they have:
-- High defect probability (>70%)
-- High hotspot score (>0.5) - both complex AND frequently changed
-- Strong temporal coupling with other buggy files
-- Single owner (knowledge silo)
 
-## Output Format
+| Indicator | Threshold | Weight |
+|-----------|-----------|--------|
+| Defect probability | > 0.7 | High |
+| Hotspot score | > 0.5 | High |
+| Single owner | 100% ownership | Medium |
+| Strong temporal coupling | > 5 co-changes | Medium |
+| SATD markers (BUG, FIXME) | Any | Medium |
+| Security SATD | Any | Critical |
 
-Provide a risk assessment with:
-1. **High-Risk Files**: Files most likely to contain bugs, ranked by probability
-2. **Contributing Factors**: Why each file is risky (churn, complexity, coupling, ownership)
-3. **Related Files**: Temporally coupled files that may share the bug
-4. **Testing Recommendations**: Which files need the most test coverage
+## Output
+
+### Bug Hunt Summary
+
+**Analysis Scope**: {{.paths}}
+**History Window**: {{.days}} days
+**Focus**: {{.focus}}
+
+### High-Risk Files (Defect Probability > 0.7)
+
+| Rank | File | Probability | Primary Factor | Secondary Factors |
+|------|------|-------------|----------------|-------------------|
+| 1 | | | | |
+
+### Hotspots (High Churn + High Complexity)
+
+| File | Hotspot Score | Churn Score | Complexity Score | Severity |
+|------|---------------|-------------|------------------|----------|
+
+### Knowledge Silos (Bus Factor = 1)
+
+| File | Owner | Lines | Risk |
+|------|-------|-------|------|
+
+### Temporal Coupling Clusters
+
+Files that change together (bugs may span these):
+| Cluster | Files | Co-changes | Concern |
+|---------|-------|------------|---------|
+
+### Explicit Bug Markers
+
+| File | Line | Marker | Content | Severity |
+|------|------|--------|---------|----------|
+
+### Investigation Priorities
+
+Based on the analysis, investigate in this order:
+
+1. **Critical** (investigate immediately):
+   - [Files with defect probability > 0.8 AND hotspot score > 0.6]
+
+2. **High** (investigate soon):
+   - [Files with defect probability > 0.7 OR hotspot score > 0.5]
+
+3. **Medium** (add to backlog):
+   - [Single-owner hotspots, temporal coupling clusters]
+
+### Testing Recommendations
+
+Files that need additional test coverage based on risk:
+| File | Current Risk | Recommended Tests |
+|------|--------------|-------------------|

--- a/internal/mcpserver/prompts/change-impact.md
+++ b/internal/mcpserver/prompts/change-impact.md
@@ -1,30 +1,151 @@
 ---
-description: Analyze the potential impact of changes to specific files, including dependencies, temporal coupling, and ownership.
+name: change-impact
+title: Change Impact Analysis
+description: Analyze blast radius before modifying a file - find dependents, co-change candidates, and reviewers
+arguments:
+  - name: target
+    description: File or function to analyze impact for
+    required: true
+  - name: paths
+    description: Scope of analysis
+    required: false
+    default: "."
+  - name: days
+    description: Days of git history for temporal coupling
+    required: false
+    default: "30"
+  - name: min_cochanges
+    description: Minimum co-changes for temporal coupling
+    required: false
+    default: "3"
 ---
 
 # Change Impact Analysis
 
-Analyze the potential impact of changes to specific files or functions in this codebase.
+Analyze the impact of changing: {{.target}}
 
-## Instructions
+## When to Use
 
-1. Use `analyze_graph` with `scope: "function"` and `include_metrics: true` to see what depends on the target
-2. Use `analyze_temporal_coupling` to find files that historically change together with the target
-3. Use `analyze_ownership` to identify who should review changes to this area
+- Before refactoring a core module
+- When planning breaking API changes
+- To understand ripple effects of a bug fix
+- Before deprecating or removing code
+- When estimating effort for a change
 
-## Analysis Steps
+## Workflow
 
-For the target file/function:
-1. **Direct Dependencies**: What directly calls or imports this code?
-2. **Transitive Impact**: What depends on the direct dependencies?
-3. **Historical Co-changes**: What files typically change when this file changes?
-4. **PageRank**: How central is this code? High PageRank = more careful changes needed.
+### Step 1: Direct Dependencies
+```
+analyze_graph:
+  paths: {{.paths}}
+  scope: function
+  include_metrics: true
+```
+Find what directly imports, calls, or extends `{{.target}}`.
+Check PageRank - high centrality means more careful changes needed.
 
-## Output Format
+### Step 2: Temporal Coupling
+```
+analyze_temporal_coupling:
+  paths: {{.paths}}
+  days: {{.days}}
+  min_cochanges: {{.min_cochanges}}
+```
+Find files that historically change together with `{{.target}}`.
+These likely need updates even without direct dependencies.
 
-Provide an impact report with:
-1. **Direct Dependents**: Files/functions that directly use the target
-2. **Ripple Effect**: Estimate of how many files could be affected
-3. **Co-change Candidates**: Files that historically change together (likely need updates)
-4. **Risk Assessment**: Low/Medium/High based on centrality and coupling
-5. **Reviewers**: Suggested reviewers based on code ownership
+### Step 3: Code Ownership
+```
+analyze_ownership:
+  paths: {{.paths}}
+```
+Identify who should review changes to `{{.target}}` and its dependents.
+
+### Step 4: Complexity Assessment
+```
+analyze_complexity:
+  paths: [{{.target}}]
+  functions_only: true
+```
+Understand current complexity of `{{.target}}` to gauge refactoring risk.
+
+## Impact Factors
+
+| Factor | Risk Level | Implication |
+|--------|------------|-------------|
+| PageRank > 0.01 | High | Central code, many indirect dependents |
+| Direct dependents > 10 | High | Wide API surface |
+| Temporal coupling > 5 files | Medium | Hidden dependencies |
+| Single owner | Medium | Knowledge concentration |
+| Cognitive complexity > 15 | Medium | Hard to modify safely |
+
+## Output
+
+### Impact Summary for {{.target}}
+
+**Risk Level**: [LOW | MEDIUM | HIGH | CRITICAL]
+**PageRank**: [score] (higher = more central)
+**Direct Dependents**: [count]
+**Likely Co-Changes**: [count]
+
+### Centrality Analysis
+
+| Metric | Value | Interpretation |
+|--------|-------|----------------|
+| PageRank | | Importance in call graph |
+| In-degree | | Direct callers/importers |
+| Out-degree | | Direct dependencies |
+| Betweenness | | Bridge between components |
+
+### Direct Dependents
+
+Files/functions that directly use `{{.target}}`:
+
+| Dependent | Type | File | Line | Usage |
+|-----------|------|------|------|-------|
+| | import/call/extend | | | |
+
+### Transitive Impact
+
+Estimate of total affected files through dependency chain:
+| Depth | Files Affected | Notable Components |
+|-------|----------------|-------------------|
+| 1 (direct) | | |
+| 2 | | |
+| 3+ | | |
+
+### Historical Co-Changes
+
+Files that typically change when `{{.target}}` changes:
+
+| File | Co-change Count | Confidence | Has Import? |
+|------|-----------------|------------|-------------|
+| | | | Yes/No |
+
+Files with "No" in the import column indicate hidden dependencies - these need special attention.
+
+### Recommended Reviewers
+
+Based on code ownership of `{{.target}}` and its dependents:
+
+| Reviewer | Area | Ownership % | Required |
+|----------|------|-------------|----------|
+| | {{.target}} | | Yes |
+| | dependents | | Recommended |
+
+### Change Checklist
+
+Before modifying `{{.target}}`:
+
+- [ ] Update all direct dependents listed above
+- [ ] Check temporal coupling files for necessary updates
+- [ ] Notify reviewers listed above
+- [ ] Add/update tests for affected paths
+- [ ] Consider feature flag for high-risk changes
+- [ ] Plan rollback strategy if PageRank > 0.01
+
+### Risk Assessment
+
+**Verdict**: [SAFE | CAUTION | HIGH-RISK | CRITICAL]
+
+[Summary of key risks and mitigation strategies]

--- a/internal/mcpserver/prompts/code-review-focus.md
+++ b/internal/mcpserver/prompts/code-review-focus.md
@@ -1,33 +1,174 @@
 ---
-description: Identify what to focus on when reviewing code changes, including complexity deltas, duplication, and risk assessment.
+name: code-review-focus
+title: Code Review Focus
+description: Identify what to focus on when reviewing code changes - complexity deltas, duplication, and risk assessment
+arguments:
+  - name: changed_files
+    description: Comma-separated list of changed files to review
+    required: true
+  - name: paths
+    description: Repository root for context
+    required: false
+    default: "."
+  - name: days
+    description: Days of git history for context
+    required: false
+    default: "30"
 ---
 
 # Code Review Focus
 
-Identify what to focus on when reviewing code changes in this codebase.
+Focus your review effort on the highest-risk areas of these changes: {{.changed_files}}
 
-## Instructions
+## When to Use
 
-Given a set of changed files, analyze:
-1. Use `analyze_complexity` on the changed files to check if complexity increased
-2. Use `analyze_duplicates` to check if changes introduced code clones
-3. Use `analyze_deadcode` to check if changes orphaned any code
-4. Use `analyze_defect` to check if changes affected high-risk files
-5. Use `analyze_graph` to understand impact on dependencies
+- When reviewing a pull request
+- Before approving a merge
+- When triaging a large changeset
+- To prioritize limited review time
+
+## Workflow
+
+### Step 1: Complexity Analysis
+```
+analyze_complexity:
+  paths: [{{.changed_files}}]
+  functions_only: true
+```
+Check if changes increased complexity. Flag functions exceeding thresholds.
+
+### Step 2: Defect Risk Assessment
+```
+analyze_defect:
+  paths: [{{.changed_files}}]
+```
+Check if changes touched high-risk files. Higher scrutiny needed.
+
+### Step 3: Duplication Detection
+```
+analyze_duplicates:
+  paths: {{.paths}}
+  min_lines: 6
+  threshold: 0.8
+```
+Check if changes introduced code clones. Suggest extraction.
+
+### Step 4: Dead Code Check
+```
+analyze_deadcode:
+  paths: [{{.changed_files}}]
+  confidence: 0.8
+```
+Check if changes orphaned any code that should be removed.
+
+### Step 5: SATD Markers
+```
+analyze_satd:
+  paths: [{{.changed_files}}]
+  strict_mode: true
+```
+Check for new TODO/FIXME/HACK markers. Should be justified.
+
+### Step 6: Dependency Impact
+```
+analyze_graph:
+  paths: {{.paths}}
+  scope: function
+  include_metrics: true
+```
+Understand what depends on the changed code.
 
 ## Review Priorities
 
-Focus review attention based on:
-- **Complexity Delta**: Did the change make code harder to understand?
-- **Clone Introduction**: Did the change copy-paste instead of abstracting?
-- **High-Risk Areas**: Is this change in a statistically bug-prone file?
-- **Architectural Impact**: Does this change affect many dependents?
+| Finding | Priority | Action |
+|---------|----------|--------|
+| Cognitive complexity +10 | Critical | Request simplification |
+| New code in high-risk file | Critical | Extra scrutiny |
+| Introduced duplication >20 lines | High | Suggest extraction |
+| New HACK/FIXME marker | High | Require justification |
+| Orphaned code | Medium | Request cleanup |
+| New TODO marker | Low | Ensure ticket created |
 
-## Output Format
+## Output
 
-Provide review guidance with:
-1. **Risk Summary**: Overall risk level of the change (Low/Medium/High)
-2. **Focus Areas**: Specific files/functions that need careful review
-3. **Complexity Concerns**: Functions that may have become too complex
-4. **Duplication Warnings**: Potential code clones to address
-5. **Test Recommendations**: What additional tests might be needed
+### Review Summary
+
+**Files Changed**: {{.changed_files}}
+**Overall Risk**: [LOW | MEDIUM | HIGH | CRITICAL]
+**Estimated Review Time**: [quick | moderate | thorough]
+
+### Complexity Delta
+
+Functions with significant complexity changes:
+
+| Function | File | Before | After | Delta | Verdict |
+|----------|------|--------|-------|-------|---------|
+| | | | | | OK/WARN/BLOCK |
+
+**Threshold Violations**:
+- Cyclomatic > 10: [list functions]
+- Cognitive > 15: [list functions]
+- Nesting > 4: [list functions]
+
+### Risk Assessment by File
+
+| File | Defect Probability | Change Risk | Focus Areas |
+|------|-------------------|-------------|-------------|
+| | | | |
+
+### Duplication Warnings
+
+New or expanded code clones:
+
+| Clone | Location 1 | Location 2 | Lines | Recommendation |
+|-------|-----------|-----------|-------|----------------|
+| | | | | Extract to shared function |
+
+### Dead Code
+
+Code that may have been orphaned by these changes:
+
+| Item | File | Type | Confidence | Action |
+|------|------|------|------------|--------|
+| | | function/variable | | Remove/Verify |
+
+### New Technical Debt
+
+SATD markers introduced in this change:
+
+| File | Line | Marker | Content | Requires |
+|------|------|--------|---------|----------|
+| | | TODO/FIXME/HACK | | Ticket/Justification |
+
+### Dependency Impact
+
+Files that depend on the changed code:
+
+| Changed File | Dependents | Risk if Broken |
+|--------------|------------|----------------|
+| | | |
+
+### Review Checklist
+
+Priority items to verify during review:
+
+**Must Check** (blocking):
+- [ ] [List critical items from above]
+
+**Should Check** (important):
+- [ ] [List high-priority items]
+
+**Nice to Check** (if time permits):
+- [ ] [List medium-priority items]
+
+### Verdict
+
+**Recommendation**: [APPROVE | REQUEST CHANGES | NEEDS DISCUSSION]
+
+**Key Concerns**:
+1. [Most important issue]
+2. [Second issue]
+3. [Third issue]
+
+**Suggested Improvements** (non-blocking):
+- [Optional enhancements]

--- a/internal/mcpserver/prompts/codebase-onboarding.md
+++ b/internal/mcpserver/prompts/codebase-onboarding.md
@@ -1,31 +1,201 @@
 ---
-description: Generate an onboarding guide for developers new to a codebase, including key symbols, architecture, and subject matter experts.
+name: codebase-onboarding
+title: Codebase Onboarding Guide
+description: Generate an onboarding guide for developers new to a codebase - key symbols, architecture, and subject matter experts
+arguments:
+  - name: paths
+    description: Paths to analyze
+    required: false
+    default: "."
+  - name: role
+    description: "Developer role: frontend, backend, fullstack, devops, or general"
+    required: false
+    default: "general"
+  - name: depth
+    description: "Guide depth: quick, standard, or comprehensive"
+    required: false
+    default: "standard"
+  - name: top
+    description: Maximum items to return
+    required: false
+    default: "20"
 ---
 
-# Codebase Onboarding
+# Codebase Onboarding Guide
 
-Generate an onboarding guide for a developer new to this codebase.
+Generate an onboarding guide for: {{.paths}}
 
-## Instructions
+## When to Use
 
-1. Use `analyze_repo_map` with `top: 30` to identify the most important symbols
-2. Use `analyze_graph` with `scope: "module"` to understand high-level architecture
-3. Use `analyze_ownership` to identify subject matter experts for each area
-4. Use `analyze_complexity` to find the simplest entry points for learning
+- When a new developer joins the team
+- When switching to a new project
+- When exploring an unfamiliar codebase
+- To document institutional knowledge
 
-## Onboarding Structure
+## Workflow
 
-Build an understanding from simple to complex:
-1. **Entry Points**: Start with low-complexity, high-PageRank files
-2. **Core Abstractions**: Key types and interfaces that define the architecture
-3. **Module Boundaries**: How the codebase is organized
-4. **Subject Matter Experts**: Who to ask about each area
+### Step 1: Important Symbols
+```
+analyze_repo_map:
+  paths: {{.paths}}
+  top: 30
+```
+Get PageRank-ranked symbols - the most important functions, types, and classes.
 
-## Output Format
+### Step 2: Architecture Overview
+```
+analyze_graph:
+  paths: {{.paths}}
+  scope: module
+  include_metrics: true
+```
+Understand high-level module structure and dependencies.
 
-Provide an onboarding guide with:
-1. **Quick Start**: The 3-5 files to read first
-2. **Architecture Overview**: Module structure and dependencies
-3. **Key Abstractions**: Important types, interfaces, and patterns
-4. **Team Map**: Code owners and their areas of expertise
-5. **Learning Path**: Suggested order for exploring the codebase
+### Step 3: Subject Matter Experts
+```
+analyze_ownership:
+  paths: {{.paths}}
+  top: {{.top}}
+```
+Identify who knows what - who to ask about each area.
+
+### Step 4: Entry Points
+```
+analyze_complexity:
+  paths: {{.paths}}
+  functions_only: false
+```
+Find the simplest files (low complexity) that are also important (high PageRank) - good starting points.
+
+### Step 5: Technical Debt Awareness
+```
+analyze_satd:
+  paths: {{.paths}}
+  strict_mode: false
+```
+Surface known issues and caveats new developers should know about.
+
+## Output
+
+### Onboarding Guide for {{.paths}}
+
+**Target Role**: {{.role}}
+**Guide Depth**: {{.depth}}
+**Generated**: [date]
+
+---
+
+### Quick Start
+
+Read these files first (low complexity, high importance):
+
+| Priority | File | Why Start Here |
+|----------|------|----------------|
+| 1 | | Entry point / core abstraction |
+| 2 | | Key types and interfaces |
+| 3 | | Main business logic |
+| 4 | | Configuration and setup |
+| 5 | | Common utilities |
+
+### Architecture Overview
+
+```
+[Module dependency diagram - simplified]
+```
+
+**Core Modules**:
+| Module | Purpose | Key Files |
+|--------|---------|-----------|
+| | | |
+
+**Module Dependencies**:
+| From | To | Relationship |
+|------|-----|--------------|
+| | | imports/uses |
+
+### Key Abstractions
+
+The most important types and interfaces to understand:
+
+| Symbol | File | Purpose | Used By |
+|--------|------|---------|---------|
+| | | | |
+
+### Code Patterns
+
+Common patterns used in this codebase:
+
+| Pattern | Example Location | When Used |
+|---------|------------------|-----------|
+| | | |
+
+### Team Map
+
+Who to ask about each area:
+
+| Area | Expert | Backup | Notes |
+|------|--------|--------|-------|
+| | | | |
+
+**Bus Factor Warnings**:
+- [Files with single owner that are critical]
+
+### Learning Path
+
+Suggested order for exploring the codebase:
+
+**Week 1: Foundations**
+1. [ ] Read [entry point files]
+2. [ ] Understand [core abstractions]
+3. [ ] Run the test suite
+4. [ ] Make a small change (typo fix, logging)
+
+**Week 2: Core Domain**
+1. [ ] Study [main business logic modules]
+2. [ ] Trace a request through the system
+3. [ ] Review recent PRs
+4. [ ] Pair with [expert] on a task
+
+**Week 3: Deep Dive**
+1. [ ] Explore [complex subsystems]
+2. [ ] Understand [integration points]
+3. [ ] Review [architectural decisions]
+4. [ ] Take on a small feature
+
+### Known Gotchas
+
+Things that might trip you up:
+
+| Gotcha | Location | Workaround |
+|--------|----------|------------|
+| | | |
+
+### Technical Debt Awareness
+
+Known issues documented in the code:
+
+| Category | Count | Examples |
+|----------|-------|----------|
+| TODO | | |
+| FIXME | | |
+| HACK | | |
+
+### Development Setup
+
+Key commands and configurations:
+```
+[Build commands]
+[Test commands]
+[Common tasks]
+```
+
+### Resources
+
+- [ ] Architecture docs: [location]
+- [ ] API docs: [location]
+- [ ] Runbooks: [location]
+- [ ] Slack channels: [channels]
+
+---
+
+**Next Steps**: After completing this guide, use `change-impact` before making changes and `code-review-focus` when reviewing PRs.

--- a/internal/mcpserver/prompts/context-compression.md
+++ b/internal/mcpserver/prompts/context-compression.md
@@ -1,24 +1,157 @@
 ---
-description: Generate a compressed context summary of a codebase for LLM consumption, using PageRank-ranked symbols and dependency graphs.
+name: context-compression
+title: Context Compression
+description: Generate a compressed context summary of a codebase for LLM consumption using PageRank-ranked symbols
+arguments:
+  - name: paths
+    description: Paths to analyze
+    required: false
+    default: "."
+  - name: max_symbols
+    description: Maximum symbols to include
+    required: false
+    default: "50"
+  - name: include_graph
+    description: Include dependency graph summary
+    required: false
+    default: "true"
 ---
 
 # Context Compression
 
-Generate a compressed context summary of this codebase that fits within LLM context windows while preserving the most important architectural information.
+Generate a compressed codebase summary for: {{.paths}}
 
-## Instructions
+## When to Use
 
-1. Use `analyze_repo_map` to get PageRank-ranked symbols
-2. Use `analyze_graph` with `scope: "module"` and `include_metrics: true` for dependency structure
-3. Combine into a summary showing:
-   - Top symbols by importance (highest PageRank)
-   - Module dependency relationships
-   - Key entry points and hub files
+- When providing codebase context to an LLM
+- When context window is limited
+- To create a "map" for navigating a large codebase
+- As a foundation for further exploration
 
-## Output Format
+## Workflow
 
-Provide a structured summary with:
-- **Core Symbols**: The most important functions/types by PageRank
-- **Architecture**: High-level module dependencies as a simplified graph
-- **Entry Points**: Files with highest in-degree (most depended upon)
-- **Recommendations**: Which files to read first for understanding the codebase
+### Step 1: PageRank Symbol Ranking
+```
+analyze_repo_map:
+  paths: {{.paths}}
+  top: {{.max_symbols}}
+```
+Get the most important symbols ranked by PageRank - these are the core abstractions.
+
+### Step 2: Module Structure
+```
+analyze_graph:
+  paths: {{.paths}}
+  scope: module
+  include_metrics: true
+```
+Get high-level module dependencies to understand architecture.
+
+### Step 3: Entry Points
+```
+analyze_graph:
+  paths: {{.paths}}
+  scope: function
+  include_metrics: true
+```
+Find functions with highest in-degree - these are the main entry points.
+
+## Compression Strategy
+
+1. **Symbol Selection**: PageRank prioritizes symbols that are most connected - changes to these affect the most code
+2. **Deduplication**: Group symbols by file to reduce redundancy
+3. **Hierarchy**: Present modules before functions before variables
+4. **Signatures Only**: Include function signatures, not implementations
+
+## Output
+
+### Codebase Context: {{.paths}}
+
+**Compression Level**: {{.max_symbols}} symbols
+**Total Files**: [count]
+**Total Symbols**: [count]
+**Compression Ratio**: [ratio]
+
+---
+
+### Architecture Summary
+
+```
+[Simplified module dependency graph]
+Module A --> Module B
+Module A --> Module C
+Module B --> Module D
+```
+
+**Core Modules**:
+| Module | Files | Symbols | Role |
+|--------|-------|---------|------|
+| | | | |
+
+### Entry Points
+
+Functions with highest in-degree (most called):
+
+| Function | File | In-Degree | Purpose |
+|----------|------|-----------|---------|
+| | | | |
+
+### Hub Files
+
+Files with highest PageRank (most central):
+
+| File | PageRank | Key Exports |
+|------|----------|-------------|
+| | | |
+
+### Core Symbols (by PageRank)
+
+#### Types and Interfaces
+
+```
+// File: [path]
+type Symbol1 struct { ... }
+type Symbol2 interface { ... }
+```
+
+#### Key Functions
+
+```
+// File: [path]
+func Function1(args) returns { ... }
+func Function2(args) returns { ... }
+```
+
+#### Constants and Configuration
+
+```
+// File: [path]
+const KEY_CONSTANT = value
+var GlobalConfig = ...
+```
+
+### Symbol Index
+
+Quick reference of all included symbols:
+
+| Symbol | Kind | File | PageRank |
+|--------|------|------|----------|
+| | type/func/const | | |
+
+### Navigation Hints
+
+To explore further:
+- **Understand X**: Read [files]
+- **Modify Y**: Check dependents via `change-impact`
+- **Debug Z**: Start at [entry point]
+
+### Excluded (Low PageRank)
+
+Symbols excluded from this summary (can be explored if needed):
+- [count] utility functions
+- [count] internal helpers
+- [count] test fixtures
+
+---
+
+**Usage**: This context can be provided to an LLM to help it understand the codebase structure before making changes.

--- a/internal/mcpserver/prompts/pr-review.md
+++ b/internal/mcpserver/prompts/pr-review.md
@@ -1,0 +1,218 @@
+---
+name: pr-review
+title: Pull Request Review Gate
+description: CI/CD quality gate for pull requests - evaluate commit risk, complexity delta, duplication, and code quality before merge
+arguments:
+  - name: changed_files
+    description: Comma-separated list of files changed in the PR
+    required: true
+  - name: paths
+    description: Repository root for full context
+    required: false
+    default: "."
+  - name: days
+    description: Days of git history for JIT context
+    required: false
+    default: "90"
+  - name: strict
+    description: Fail on any warning-level finding
+    required: false
+    default: "false"
+---
+
+# Pull Request Review Gate
+
+Evaluate PR risk before merge for changes to: {{.changed_files}}
+
+## When to Use
+
+- Automated CI/CD pipeline check
+- Before approving any PR
+- When triaging a large changeset
+- To ensure consistent review quality
+
+## Workflow
+
+### Step 1: Commit Risk Analysis (JIT)
+```
+analyze_changes:
+  paths: {{.paths}}
+  days: {{.days}}
+  high_risk_only: false
+```
+Score each commit using Just-In-Time defect prediction (Kamei et al. 2013).
+Factors: fix patterns, entropy, lines changed, files touched, author experience.
+
+### Step 2: Complexity Delta
+```
+analyze_complexity:
+  paths: [{{.changed_files}}]
+  functions_only: true
+```
+Check if changes increased complexity. Flag functions exceeding thresholds.
+
+### Step 3: Duplication Check
+```
+analyze_duplicates:
+  paths: {{.paths}}
+  min_lines: 6
+  threshold: 0.8
+```
+Detect if changes introduced code clones.
+
+### Step 4: Dead Code Check
+```
+analyze_deadcode:
+  paths: [{{.changed_files}}]
+  confidence: 0.8
+```
+Check if changes orphaned any code that should be removed.
+
+### Step 5: Technical Debt Markers
+```
+analyze_satd:
+  paths: [{{.changed_files}}]
+  strict_mode: true
+```
+Check for new TODO/FIXME/HACK markers. Require justification.
+
+### Step 6: File Risk Assessment
+```
+analyze_defect:
+  paths: [{{.changed_files}}]
+```
+Check if changes touched statistically high-risk files.
+
+## Gate Criteria
+
+| Check | Pass | Warn | Fail |
+|-------|------|------|------|
+| Max commit risk | < 0.5 | 0.5-0.7 | > 0.7 |
+| Complexity delta | < +5 | +5 to +10 | > +10 |
+| New code clones | 0 | 1-2 small | >2 or large |
+| Orphaned code | 0 | warnings | confirmed |
+| New HACK/FIXME | 0 | with ticket | without ticket |
+| Security SATD | 0 | N/A | any |
+| High-risk file changes | documented | undocumented | critical path |
+
+## Output
+
+### PR Review Gate Report
+
+**PR**: [PR number/title]
+**Changed Files**: {{.changed_files}}
+**Status**: [PASS | WARN | FAIL]
+
+---
+
+### Gate Summary
+
+| Check | Result | Details |
+|-------|--------|---------|
+| Commit Risk | PASS/WARN/FAIL | Max: [score], Avg: [score] |
+| Complexity | PASS/WARN/FAIL | Delta: [+/-N] |
+| Duplication | PASS/WARN/FAIL | [N] clones introduced |
+| Dead Code | PASS/WARN/FAIL | [N] items orphaned |
+| Tech Debt | PASS/WARN/FAIL | [N] new markers |
+| File Risk | PASS/WARN/FAIL | [N] high-risk files touched |
+
+### Commit Analysis
+
+Risk scores for commits in this PR:
+
+| Commit | Message | Risk | Factors | Action |
+|--------|---------|------|---------|--------|
+| [sha] | | | | |
+
+**High-Risk Commits** (require senior review):
+- [List commits with risk > 0.7]
+
+### Complexity Report
+
+Functions with complexity changes:
+
+| Function | File | Before | After | Delta | Status |
+|----------|------|--------|-------|-------|--------|
+| | | | | | OK/WARN/FAIL |
+
+**Threshold Violations**:
+- Cyclomatic > 10: [list]
+- Cognitive > 15: [list]
+- Nesting > 4: [list]
+
+### Duplication Report
+
+Code clones introduced or expanded:
+
+| Clone | File 1 | File 2 | Lines | Action |
+|-------|--------|--------|-------|--------|
+| | | | | Extract to shared function |
+
+### Dead Code
+
+Potentially orphaned by these changes:
+
+| Symbol | File | Type | Confidence | Action |
+|--------|------|------|------------|--------|
+| | | | | Verify/Remove |
+
+### Technical Debt
+
+New debt markers introduced:
+
+| File | Line | Marker | Content | Verdict |
+|------|------|--------|---------|---------|
+| | | | | OK (has ticket) / FAIL |
+
+**Security markers**: [NONE | list items]
+
+### File Risk Assessment
+
+High-risk files modified in this PR:
+
+| File | Defect Probability | Churn | Review Level |
+|------|-------------------|-------|--------------|
+| | | | Standard/Enhanced/Critical |
+
+---
+
+### Review Requirements
+
+Based on this analysis:
+
+**Required Reviewers**:
+| Reviewer | Reason |
+|----------|--------|
+| | High-risk commit author |
+| | Expert on modified code |
+
+**Review Focus Areas**:
+1. [Most critical area to review]
+2. [Second area]
+3. [Third area]
+
+### Checklist
+
+**Before Approving**:
+- [ ] High-risk commits reviewed by senior engineer
+- [ ] Complexity increases justified
+- [ ] No unexplained code clones
+- [ ] Orphaned code confirmed intentional or removed
+- [ ] Tech debt markers have tickets
+- [ ] No security SATD markers
+
+### Verdict
+
+**Gate Status**: [PASS | WARN | FAIL]
+
+**Blocking Issues** (must fix):
+1. [List blocking items]
+
+**Warnings** (should address):
+1. [List warning items]
+
+**Recommendation**: [APPROVE | REQUEST CHANGES | NEEDS DISCUSSION]
+
+---
+
+**CI Exit Code**: [0 = pass, 1 = fail]

--- a/internal/mcpserver/prompts/quality-gate.md
+++ b/internal/mcpserver/prompts/quality-gate.md
@@ -1,34 +1,199 @@
 ---
-description: Perform a quality gate check against configurable thresholds for TDG grade, complexity, duplication, and defect risk.
+name: quality-gate
+title: Quality Gate Check
+description: Pass/fail quality gate check against configurable thresholds for complexity, duplication, defect risk, and technical debt
+arguments:
+  - name: paths
+    description: Paths to analyze
+    required: false
+    default: "."
+  - name: cyclomatic_threshold
+    description: Max cyclomatic complexity per function
+    required: false
+    default: "15"
+  - name: cognitive_threshold
+    description: Max cognitive complexity per function
+    required: false
+    default: "20"
+  - name: duplication_threshold
+    description: Max duplication ratio as percentage
+    required: false
+    default: "5"
+  - name: high_risk_threshold
+    description: Max percentage of high-risk files
+    required: false
+    default: "10"
+  - name: strict
+    description: Fail on any threshold violation
+    required: false
+    default: "false"
 ---
 
 # Quality Gate Check
 
-Perform a quality gate check to determine if the codebase meets quality thresholds.
+Perform quality gate check for: {{.paths}}
 
-## Instructions
+## When to Use
 
-1. Use `analyze_tdg` to get overall quality grade and distribution
-2. Use `analyze_complexity` to check for functions exceeding thresholds
-3. Use `analyze_duplicates` to check duplication ratio
-4. Use `analyze_defect` to count high-risk files
-5. Use `analyze_satd` to count high-severity debt items
+- In CI/CD pipelines before merge
+- Before releases
+- Periodic quality audits
+- To establish baseline metrics
 
-## Quality Thresholds
+## Workflow
 
-Default thresholds (adjust as needed):
-- **TDG Average Grade**: B or better
-- **Max Cyclomatic Complexity**: 15 per function
-- **Max Cognitive Complexity**: 20 per function
-- **Duplication Ratio**: < 5%
-- **High-Risk Files**: < 10% of codebase
-- **Critical SATD Items**: 0
+### Step 1: Complexity Check
+```
+analyze_complexity:
+  paths: {{.paths}}
+  cyclomatic_threshold: {{.cyclomatic_threshold}}
+  cognitive_threshold: {{.cognitive_threshold}}
+```
+Check for functions exceeding complexity thresholds.
 
-## Output Format
+### Step 2: Duplication Check
+```
+analyze_duplicates:
+  paths: {{.paths}}
+  min_lines: 6
+  threshold: 0.8
+```
+Measure code duplication ratio.
 
-Provide a pass/fail gate report with:
-1. **Overall Status**: PASS or FAIL
-2. **Metric Results**: Each threshold with current value and status
-3. **Violations**: Specific items that failed thresholds
-4. **Trend**: If available, comparison to previous check
-5. **Remediation**: For failures, what needs to change to pass
+### Step 3: Defect Risk Check
+```
+analyze_defect:
+  paths: {{.paths}}
+```
+Count files with high defect probability.
+
+### Step 4: Technical Debt Check
+```
+analyze_satd:
+  paths: {{.paths}}
+  strict_mode: true
+```
+Count critical and high-severity debt markers.
+
+### Step 5: Architectural Smell Check
+```
+analyze_smells:
+  paths: {{.paths}}
+```
+Detect cyclic dependencies, god components, and other smells.
+
+## Default Thresholds
+
+| Metric | Default | Blocking | Warning |
+|--------|---------|----------|---------|
+| Max cyclomatic complexity | 15 | > 20 | > 15 |
+| Max cognitive complexity | 20 | > 30 | > 20 |
+| Duplication ratio | 5% | > 10% | > 5% |
+| High-risk files | 10% | > 20% | > 10% |
+| Critical SATD items | 0 | > 0 | N/A |
+| Cyclic dependencies | 0 | > 0 | N/A |
+| God components | 0 | > 1 | > 0 |
+
+## Output
+
+### Quality Gate Report
+
+**Scope**: {{.paths}}
+**Status**: [PASS | WARN | FAIL]
+**Timestamp**: [datetime]
+
+---
+
+### Gate Results
+
+| Check | Threshold | Actual | Status |
+|-------|-----------|--------|--------|
+| Max Cyclomatic Complexity | .cyclomatic_threshold | | PASS/WARN/FAIL |
+| Max Cognitive Complexity | .cognitive_threshold | | PASS/WARN/FAIL |
+| Duplication Ratio | .duplication_threshold% | | PASS/WARN/FAIL |
+| High-Risk Files | .high_risk_threshold% | | PASS/WARN/FAIL |
+| Critical SATD | 0 | | PASS/FAIL |
+| Cyclic Dependencies | 0 | | PASS/FAIL |
+| God Components | 0 | | PASS/WARN |
+
+### Complexity Violations
+
+Functions exceeding thresholds:
+
+| Function | File | Cyclomatic | Cognitive | Nesting | Severity |
+|----------|------|------------|-----------|---------|----------|
+| | | | | | WARN/BLOCK |
+
+### Duplication Report
+
+| Metric | Value |
+|--------|-------|
+| Total clones | |
+| Duplication ratio | |
+| Largest clone | |
+
+Top clones to address:
+| Clone | Location 1 | Location 2 | Lines |
+|-------|-----------|-----------|-------|
+| | | | |
+
+### Defect Risk Distribution
+
+| Risk Level | Count | Percentage |
+|------------|-------|------------|
+| High | | |
+| Medium | | |
+| Low | | |
+
+High-risk files:
+| File | Probability | Primary Factor |
+|------|-------------|----------------|
+| | | |
+
+### Technical Debt
+
+| Severity | Count | Blocking |
+|----------|-------|----------|
+| Critical | | Yes |
+| High | | No |
+| Medium | | No |
+| Low | | No |
+
+Critical items (must fix):
+| File | Line | Marker | Content |
+|------|------|--------|---------|
+| | | | |
+
+### Architectural Issues
+
+| Issue | Count | Severity |
+|-------|-------|----------|
+| Cyclic Dependencies | | BLOCK |
+| God Components | | WARN |
+| Hub Components | | WARN |
+| Unstable Dependencies | | INFO |
+
+### Gate Verdict
+
+**Overall Status**: [PASS | WARN | FAIL]
+
+**Blocking Issues** (must fix before merge):
+1. [List blocking items]
+
+**Warnings** (should address):
+1. [List warning items]
+
+**Recommendations**:
+1. [Prioritized list of improvements]
+
+### Trend (if available)
+
+| Metric | Previous | Current | Change |
+|--------|----------|---------|--------|
+| Complexity violations | | | |
+| Duplication ratio | | | |
+| High-risk files | | | |
+
+---
+
+**Exit Code**: [0 = pass, 1 = fail]

--- a/internal/mcpserver/prompts/refactoring-priority.md
+++ b/internal/mcpserver/prompts/refactoring-priority.md
@@ -1,30 +1,199 @@
 ---
-description: Identify highest-priority refactoring targets based on TDG scores, complexity, code clones, and technical debt markers.
+name: refactoring-priority
+title: Refactoring Priority
+description: Identify highest-ROI refactoring targets based on hotspots, complexity, duplication, and technical debt
+arguments:
+  - name: paths
+    description: Paths to analyze
+    required: false
+    default: "."
+  - name: days
+    description: Days of git history for churn analysis
+    required: false
+    default: "30"
+  - name: max_items
+    description: Maximum items to return
+    required: false
+    default: "20"
+  - name: focus
+    description: "Focus area: complexity, duplication, debt, or all"
+    required: false
+    default: "all"
 ---
 
 # Refactoring Priority
 
-Identify the highest-priority refactoring targets in this codebase based on quality metrics and technical debt signals.
+Identify highest-ROI refactoring targets in: {{.paths}}
 
-## Instructions
+## When to Use
 
-1. Use `analyze_tdg` to find lowest-quality files
-2. Use `analyze_complexity` with `functions_only: true` to find complex functions
-3. Use `analyze_duplicates` to find code clones that should be extracted
-4. Use `analyze_satd` to find explicit technical debt markers (TODO, FIXME, HACK)
-5. Use `analyze_cohesion` to find classes with poor design (high LCOM, high WMC)
+- During sprint planning to allocate refactoring time
+- When deciding what technical debt to address
+- Before major feature work in an area
+- To justify refactoring to stakeholders
 
-## Analysis
+## Workflow
 
-For each refactoring target, consider:
-- **Impact**: How central is this code? (check PageRank if needed)
-- **Risk**: How often does it change? (check churn)
-- **Effort**: How complex is the refactoring?
+### Step 1: Hotspot Analysis
+```
+analyze_hotspot:
+  paths: {{.paths}}
+  days: {{.days}}
+  top: {{.max_items}}
+```
+Find files with both high churn AND high complexity - highest ROI targets.
 
-## Output Format
+### Step 2: Complexity Outliers
+```
+analyze_complexity:
+  paths: {{.paths}}
+  functions_only: true
+```
+Find functions with extreme complexity that are hard to maintain.
 
-Provide a prioritized list of refactoring targets with:
-1. **File/Function**: Location of the issue
-2. **Problem**: What quality issue was detected
-3. **Recommendation**: Specific refactoring action
-4. **Priority**: High/Medium/Low based on impact and effort
+### Step 3: Code Clones
+```
+analyze_duplicates:
+  paths: {{.paths}}
+  min_lines: 6
+  threshold: 0.8
+```
+Find duplication that should be extracted to shared code.
+
+### Step 4: Explicit Debt
+```
+analyze_satd:
+  paths: {{.paths}}
+  strict_mode: false
+```
+Find TODO, FIXME, HACK markers - explicit acknowledgment of debt.
+
+### Step 5: Design Smells
+```
+analyze_cohesion:
+  paths: {{.paths}}
+  sort: lcom
+  top: {{.max_items}}
+```
+Find classes with poor cohesion that should be split.
+
+### Step 6: Centrality Check
+```
+analyze_repo_map:
+  paths: {{.paths}}
+  top: {{.max_items}}
+```
+Check PageRank - refactoring central code has more impact.
+
+## Prioritization Formula
+
+**Priority Score** = (Impact x Frequency) / Effort
+
+- **Impact**: PageRank + defect probability
+- **Frequency**: Churn rate (how often touched)
+- **Effort**: Complexity + coupling
+
+High score = High value, frequently touched, relatively easy to fix
+
+## Output
+
+### Refactoring Priority Report
+
+**Scope**: {{.paths}}
+**History Window**: {{.days}} days
+**Focus**: {{.focus}}
+
+---
+
+### Executive Summary
+
+| Category | Count | Effort Estimate |
+|----------|-------|-----------------|
+| Hotspots | | |
+| Complex functions | | |
+| Code clones | | |
+| SATD markers | | |
+| Low cohesion classes | | |
+
+### Top Refactoring Targets (by ROI)
+
+| Rank | Target | Type | Priority Score | Impact | Effort |
+|------|--------|------|----------------|--------|--------|
+| 1 | | | | | |
+| 2 | | | | | |
+| 3 | | | | | |
+
+### Hotspots (High Churn + High Complexity)
+
+Files where refactoring compounds over time:
+
+| File | Hotspot Score | Commits | Avg Complexity | Recommendation |
+|------|---------------|---------|----------------|----------------|
+| | | | | |
+
+**Why prioritize hotspots**: These files are touched frequently. Every future change benefits from improved code quality.
+
+### Complexity Hotspots
+
+Functions exceeding complexity thresholds:
+
+| Function | File | Cyclomatic | Cognitive | Nesting | Suggestion |
+|----------|------|------------|-----------|---------|------------|
+| | | | | | Extract/Split/Simplify |
+
+**Quick wins**: Functions with high complexity but low coupling are easiest to refactor.
+
+### Duplication Targets
+
+Code clones that should be extracted:
+
+| Clone Group | Instances | Lines | Locations | Extraction Target |
+|-------------|-----------|-------|-----------|-------------------|
+| | | | | |
+
+**Estimated savings**: [lines] lines of code could be eliminated.
+
+### Technical Debt Markers
+
+Explicit debt acknowledged in code:
+
+| Priority | File | Line | Marker | Content | Age |
+|----------|------|------|--------|---------|-----|
+| High | | | FIXME/HACK | | |
+| Medium | | | TODO | | |
+
+### Design Improvements
+
+Classes with poor cohesion (candidates for splitting):
+
+| Class | File | LCOM | WMC | Suggestion |
+|-------|------|------|-----|------------|
+| | | | | Split into X and Y |
+
+### Refactoring Roadmap
+
+#### Immediate (This Sprint)
+- [ ] [Highest ROI item with specific action]
+- [ ] [Second item]
+
+#### Short-term (Next 2-4 Sprints)
+- [ ] [Medium priority items]
+
+#### Long-term (Roadmap)
+- [ ] [Larger architectural improvements]
+
+### Effort Estimates
+
+| Refactoring | Complexity | Risk | Estimated Effort |
+|-------------|------------|------|------------------|
+| | Low/Med/High | Low/Med/High | hours/days |
+
+### Dependencies
+
+Refactorings that should be done together:
+- [X and Y are coupled - refactor together]
+- [Z depends on X - do X first]
+
+---
+
+**Next Steps**: Use `change-impact` before starting each refactoring to understand blast radius.

--- a/internal/mcpserver/prompts/tech-debt-report.md
+++ b/internal/mcpserver/prompts/tech-debt-report.md
@@ -1,34 +1,270 @@
 ---
-description: Generate a comprehensive technical debt assessment including SATD, quality grades, duplication, and high-risk areas.
+name: tech-debt-report
+title: Technical Debt Report
+description: Comprehensive technical debt assessment including explicit markers, structural debt, duplication, and high-risk areas
+arguments:
+  - name: paths
+    description: Paths to analyze
+    required: false
+    default: "."
+  - name: days
+    description: Days of git history for context
+    required: false
+    default: "30"
+  - name: categories
+    description: "Debt categories to include: explicit, structural, duplication, design, all"
+    required: false
+    default: "all"
+  - name: include_trends
+    description: Include trend analysis if history available
+    required: false
+    default: "true"
 ---
 
 # Technical Debt Report
 
-Generate a comprehensive technical debt assessment for this codebase.
+Generate comprehensive technical debt assessment for: {{.paths}}
 
-## Instructions
+## When to Use
 
-1. Use `analyze_satd` to find explicit debt (TODO, FIXME, HACK comments)
-2. Use `analyze_tdg` for quality scores and grade distribution
-3. Use `analyze_duplicates` to quantify copy-paste debt
-4. Use `analyze_defect` to find implicit debt (high-risk files)
-5. Use `analyze_complexity` for functions exceeding complexity thresholds
+- Quarterly technical debt reviews
+- Sprint planning to allocate debt paydown time
+- Stakeholder reporting on code health
+- Before major initiatives to assess baseline
 
-## Debt Categories
+## Workflow
 
-Organize findings by type:
-- **Explicit Debt**: SATD markers left by developers
-- **Structural Debt**: High complexity, poor cohesion
-- **Duplication Debt**: Code clones requiring synchronized maintenance
-- **Design Debt**: Architectural issues (coupling, inheritance depth)
-- **Test Debt**: High-risk files lacking coverage
+### Step 1: Explicit Debt (SATD)
+```
+analyze_satd:
+  paths: {{.paths}}
+  strict_mode: false
+```
+Find all TODO, FIXME, HACK, BUG markers - debt developers explicitly acknowledged.
 
-## Output Format
+### Step 2: Structural Debt
+```
+analyze_complexity:
+  paths: {{.paths}}
+  functions_only: true
+```
+Find overly complex functions that are hard to maintain.
 
-Provide a debt report with:
-1. **Executive Summary**: Overall debt level and trend
-2. **Grade Distribution**: How many files are A/B/C/D/F quality
-3. **Explicit Debt Inventory**: Categorized SATD items with severity
-4. **Duplication Report**: Clone count and estimated maintenance cost
-5. **High-Risk Areas**: Files that need immediate attention
-6. **Remediation Priorities**: Ordered list of what to fix first
+### Step 3: Duplication Debt
+```
+analyze_duplicates:
+  paths: {{.paths}}
+  min_lines: 6
+  threshold: 0.8
+```
+Find code clones that require synchronized maintenance.
+
+### Step 4: Design Debt
+```
+analyze_cohesion:
+  paths: {{.paths}}
+  sort: lcom
+```
+Find classes with poor cohesion (doing too many things).
+
+```
+analyze_smells:
+  paths: {{.paths}}
+```
+Find architectural smells (cycles, god components, etc.).
+
+### Step 5: Risk Debt
+```
+analyze_defect:
+  paths: {{.paths}}
+```
+Find high-risk files that likely contain latent bugs.
+
+### Step 6: Knowledge Debt
+```
+analyze_ownership:
+  paths: {{.paths}}
+```
+Find knowledge silos - code only one person understands.
+
+## Output
+
+### Technical Debt Report
+
+**Scope**: {{.paths}}
+**Assessment Date**: [date]
+**Categories**: {{.categories}}
+
+---
+
+### Executive Summary
+
+**Overall Debt Level**: [LOW | MODERATE | HIGH | CRITICAL]
+**Estimated Remediation**: [effort in person-days]
+
+| Category | Items | Severity Distribution | Trend |
+|----------|-------|----------------------|-------|
+| Explicit (SATD) | | H/M/L | |
+| Structural | | | |
+| Duplication | | | |
+| Design | | | |
+| Risk | | | |
+| Knowledge | | | |
+
+### Debt Distribution
+
+```
+[Visual distribution across categories]
+Explicit:    ████████░░ 40%
+Structural:  ██████░░░░ 30%
+Duplication: ████░░░░░░ 20%
+Design:      ██░░░░░░░░ 10%
+```
+
+---
+
+### Explicit Debt (SATD Markers)
+
+Debt that developers explicitly documented:
+
+#### By Severity
+
+| Severity | Count | Examples |
+|----------|-------|----------|
+| Critical | | Security, data loss risks |
+| High | | FIXME, HACK, BUG markers |
+| Medium | | TODO with clear action |
+| Low | | Notes, optimization ideas |
+
+#### By Category
+
+| Category | Count | Top Files |
+|----------|-------|-----------|
+| Design | | |
+| Defect | | |
+| Requirement | | |
+| Test | | |
+| Security | | |
+
+#### Critical Items (Immediate Attention)
+
+| File | Line | Marker | Content | Age |
+|------|------|--------|---------|-----|
+| | | | | |
+
+### Structural Debt
+
+Functions that are too complex to maintain safely:
+
+| Function | File | Cyclomatic | Cognitive | Issue |
+|----------|------|------------|-----------|-------|
+| | | | | Too many branches |
+| | | | | Deep nesting |
+| | | | | Long method |
+
+**Total**: [count] functions exceed recommended thresholds.
+
+### Duplication Debt
+
+Code that requires synchronized maintenance:
+
+| Metric | Value |
+|--------|-------|
+| Total clone groups | |
+| Duplicated lines | |
+| Duplication ratio | |
+| Files with clones | |
+
+**Top Clone Groups**:
+| Group | Instances | Lines | Maintenance Risk |
+|-------|-----------|-------|------------------|
+| | | | High - logic duplication |
+
+**Estimated Impact**: Each bug fix in duplicated code requires [N] coordinated changes.
+
+### Design Debt
+
+Classes and modules with structural issues:
+
+#### Low Cohesion Classes
+
+| Class | File | LCOM | WMC | Issue |
+|-------|------|------|-----|-------|
+| | | | | Should be split |
+
+#### Architectural Smells
+
+| Smell | Count | Components | Impact |
+|-------|-------|------------|--------|
+| Cyclic Dependencies | | | Build/test complexity |
+| God Components | | | Change risk |
+| Hub Components | | | Single point of failure |
+| Unstable Dependencies | | | Ripple effects |
+
+### Risk Debt
+
+Files with high defect probability (latent bugs):
+
+| File | Probability | Contributing Factors | Action |
+|------|-------------|---------------------|--------|
+| | | High churn + complexity | Refactor before next change |
+
+**Distribution**:
+- High Risk (>0.7): [count] files ([%])
+- Medium Risk (0.3-0.7): [count] files ([%])
+- Low Risk (<0.3): [count] files ([%])
+
+### Knowledge Debt
+
+Code that only one person understands:
+
+| File/Module | Owner | Lines | Bus Factor Risk |
+|-------------|-------|-------|-----------------|
+| | | | Critical - no backup |
+
+**Bus Factor Analysis**:
+- Single-owner modules: [count]
+- Critical paths with bus factor 1: [list]
+
+---
+
+### Remediation Plan
+
+#### Immediate (Block shipping)
+| Item | Type | Effort | Impact |
+|------|------|--------|--------|
+| | | | |
+
+#### This Quarter
+| Item | Type | Effort | Impact |
+|------|------|--------|--------|
+| | | | |
+
+#### Backlog
+| Item | Type | Effort | Impact |
+|------|------|--------|--------|
+| | | | |
+
+### Trend Analysis
+
+| Metric | 30 days ago | Today | Change |
+|--------|-------------|-------|--------|
+| SATD count | | | |
+| Complexity violations | | | |
+| Duplication ratio | | | |
+| High-risk files | | | |
+
+### Recommendations
+
+1. **Quick Wins** (high impact, low effort):
+   - [List items]
+
+2. **Strategic Investments** (high impact, higher effort):
+   - [List items]
+
+3. **Preventive Measures**:
+   - [Process improvements to prevent debt accumulation]
+
+---
+
+**Next Review**: [suggested date]

--- a/internal/mcpserver/prompts/test-targeting.md
+++ b/internal/mcpserver/prompts/test-targeting.md
@@ -1,31 +1,217 @@
 ---
-description: Identify which files and functions most need additional test coverage based on risk, complexity, and churn.
+name: test-targeting
+title: Test Targeting
+description: Identify files and functions most needing test coverage based on defect risk, complexity, and churn
+arguments:
+  - name: paths
+    description: Paths to analyze
+    required: false
+    default: "."
+  - name: days
+    description: Days of git history for churn analysis
+    required: false
+    default: "30"
+  - name: coverage_threshold
+    description: Minimum acceptable coverage percentage
+    required: false
+    default: "80"
+  - name: max_items
+    description: Maximum items to return
+    required: false
+    default: "20"
 ---
 
 # Test Targeting
 
-Identify which files and functions most need additional test coverage.
+Identify where to invest test coverage in: {{.paths}}
 
-## Instructions
+## When to Use
 
-1. Use `analyze_defect` to find high-risk files (statistically likely to have bugs)
-2. Use `analyze_hotspot` to find high-churn + high-complexity code
-3. Use `analyze_complexity` to find functions with many code paths (need more test cases)
-4. Use `analyze_ownership` to find knowledge silos (need tests as documentation)
+- When prioritizing test writing effort
+- Before releases to identify coverage gaps
+- When coverage budget is limited
+- To maximize defect detection per test
+
+## Workflow
+
+### Step 1: Defect Risk Assessment
+```
+analyze_defect:
+  paths: {{.paths}}
+```
+High-risk files statistically contain more bugs - they need more tests.
+
+### Step 2: Hotspot Analysis
+```
+analyze_hotspot:
+  paths: {{.paths}}
+  days: {{.days}}
+  top: {{.max_items}}
+```
+High-churn + high-complexity files need regression protection.
+
+### Step 3: Complexity Analysis
+```
+analyze_complexity:
+  paths: {{.paths}}
+  functions_only: true
+```
+High cyclomatic complexity = many paths = need more test cases.
+
+### Step 4: Knowledge Silos
+```
+analyze_ownership:
+  paths: {{.paths}}
+```
+Single-owner files need tests as documentation - the tests explain behavior when the owner is unavailable.
+
+### Step 5: SATD Markers
+```
+analyze_satd:
+  paths: {{.paths}}
+  strict_mode: false
+```
+Find test-related debt markers (TODO: add tests, FIXME: test fails).
 
 ## Test Priority Factors
 
-Files need more tests when they have:
-- **High Defect Probability**: Statistically likely to contain bugs
-- **High Cyclomatic Complexity**: Many paths to cover
-- **High Churn**: Frequently changing, needs regression protection
-- **Single Owner**: Tests serve as documentation when the owner is unavailable
+| Factor | Weight | Rationale |
+|--------|--------|-----------|
+| High defect probability | Critical | Statistically likely to have bugs |
+| High cyclomatic complexity | High | Many code paths to cover |
+| High churn rate | High | Needs regression protection |
+| Single owner | Medium | Tests as documentation |
+| No existing tests | Medium | Coverage gap |
+| Critical business logic | High | High impact if broken |
 
-## Output Format
+## Test Case Estimation
 
-Provide test recommendations with:
-1. **Critical Coverage Gaps**: Files with high risk and likely low coverage
-2. **Complexity Hotspots**: Functions needing thorough path coverage
-3. **Regression Priorities**: High-churn files needing change detection
-4. **Test Case Estimates**: Approximate test cases needed based on cyclomatic complexity
-5. **Testing Strategy**: Unit vs integration test recommendations per area
+Based on cyclomatic complexity (McCabe):
+- Complexity 1-5: 3-5 test cases
+- Complexity 6-10: 6-10 test cases
+- Complexity 11-20: 11-20 test cases
+- Complexity 20+: Consider refactoring first
+
+## Output
+
+### Test Targeting Report
+
+**Scope**: {{.paths}}
+**History Window**: {{.days}} days
+**Coverage Target**: {{.coverage_threshold}}%
+
+---
+
+### Executive Summary
+
+| Priority | Files | Estimated Test Cases |
+|----------|-------|---------------------|
+| Critical | | |
+| High | | |
+| Medium | | |
+| Total | | |
+
+### Critical Coverage Gaps
+
+Files with high risk and likely insufficient coverage:
+
+| File | Defect Probability | Hotspot Score | Complexity | Priority |
+|------|-------------------|---------------|------------|----------|
+| | | | | CRITICAL |
+
+### Test Investment Priorities
+
+Ranked by expected defect detection value:
+
+| Rank | File | Risk Score | Est. Test Cases | ROI |
+|------|------|------------|-----------------|-----|
+| 1 | | | | High |
+| 2 | | | | High |
+| 3 | | | | Medium |
+
+### Complexity Breakdown
+
+Functions requiring thorough path coverage:
+
+| Function | File | Cyclomatic | Min Test Cases | Coverage Strategy |
+|----------|------|------------|----------------|-------------------|
+| | | | | Branch coverage |
+| | | | | Boundary testing |
+| | | | | Error path testing |
+
+### Regression Test Priorities
+
+High-churn files needing change detection tests:
+
+| File | Commits ({{.days}}d) | Churn Score | Test Strategy |
+|------|---------------------|-------------|---------------|
+| | | | Snapshot/golden tests |
+| | | | Integration tests |
+
+### Documentation Tests
+
+Single-owner files where tests serve as documentation:
+
+| File | Owner | Lines | Documentation Need |
+|------|-------|-------|-------------------|
+| | | | High - explains behavior |
+
+### Test Debt
+
+Existing test-related technical debt:
+
+| File | Line | Marker | Issue |
+|------|------|--------|-------|
+| | | TODO | Missing test |
+| | | FIXME | Flaky test |
+| | | HACK | Test workaround |
+
+---
+
+### Testing Strategy by Area
+
+#### Unit Tests Needed
+| File/Function | Reason | Approach |
+|---------------|--------|----------|
+| | High complexity | Path coverage |
+
+#### Integration Tests Needed
+| Component | Reason | Approach |
+|-----------|--------|----------|
+| | Cross-module | End-to-end flow |
+
+#### Regression Tests Needed
+| Area | Reason | Approach |
+|------|--------|----------|
+| | High churn | Golden files/snapshots |
+
+### Test Case Estimates
+
+| File | Cyclomatic Sum | Min Cases | Effort (hours) |
+|------|----------------|-----------|----------------|
+| | | | |
+| **Total** | | | |
+
+### Coverage Investment Plan
+
+#### This Sprint
+- [ ] [Highest priority file] - [N] test cases
+- [ ] [Second file] - [N] test cases
+
+#### Next Sprint
+- [ ] [Medium priority items]
+
+#### Backlog
+- [ ] [Lower priority items]
+
+---
+
+### Metrics to Track
+
+After implementing tests:
+- Coverage increase per file
+- Defect escape rate
+- Test execution time
+- Flaky test rate
+
+**Next Steps**: After writing tests, use `quality-gate` to verify coverage meets thresholds.


### PR DESCRIPTION
## Summary

Enhances MCP prompts with Go `text/template` support for dynamic content interpolation. Prompts now define their own default values in YAML frontmatter, keeping configuration colocated with the prompt definitions rather than in global code.

## Changes Made

### Core Implementation (`prompts.go`)
- Add `Default` field to `promptArgument` struct for frontmatter-defined defaults
- Replace global `argumentDefaults()` with `extractDefaults()` that reads from frontmatter
- Parse templates at registration time for early error detection
- Add template functions: `default`, `join`, `split`, `lower`, `upper`, `contains`
- Graceful fallback to raw body on template parse/execution errors

### Prompt Enhancements (all 11 prompts)
- Add structured YAML frontmatter with `name`, `title`, `description`, `arguments`
- Each argument specifies `name`, `description`, `required`, and `default`
- Add "When to Use" sections for clear guidance
- Add workflow sections with exact tool parameters
- Add structured output templates for consistent reports
- All template variables now have corresponding defaults defined

### New Prompt
- `pr-review.md`: CI/CD quality gate for pull requests using JIT defect prediction

## Testing

- All existing tests pass
- `TestPromptFiles` validates all 11 prompt files parse correctly
- `TestRegisterPrompts` verifies prompt registration
- Lint passes with no issues