### PR TITLE
fix(ci): add concurrency control to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   issues: write


### PR DESCRIPTION
## Summary

Adds concurrency control to the release workflow to prevent race conditions when multiple pushes to main trigger release-please simultaneously.

## Problem

When PR #90 (v4.2.0 release) was merged shortly after being created, release-please aborted with:

```
There are untagged, merged release PRs outstanding - aborting
```

This happened because two workflow runs were racing - one creating the release PR and another trying to process the merge. The second run found the merged PR but no tag existed yet (since it was supposed to create it).

## Solution

Add a concurrency group with `cancel-in-progress: false` to queue workflow runs instead of running them in parallel:

```yaml
concurrency:
  group: release-${{ github.ref }}
  cancel-in-progress: false
```

## Additional Fix

The v4.2.0 tag was manually created at the PR #90 merge commit to unblock release-please.

---

Generated with [Claude Code](https://claude.com/claude-code)