### PR TITLE
feat(ci): add MCP registry publishing with Docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,7 @@ jobs:
 
     permissions:
       contents: write
+      packages: write
 
     steps:
       - name: Checkout repository
@@ -70,12 +71,20 @@ jobs:
         with:
           go-version: stable
 
+      - name: Login to GitHub Container Registry
+        if: matrix.goos == 'linux'
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release --clean --skip=validate,homebrew
+          args: release --clean --skip=validate,homebrew${{ matrix.goos == 'darwin' && ',docker' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOOS: ${{ matrix.goos }}
@@ -112,7 +121,14 @@ jobs:
           gh release download "$TAG" --pattern "checksums_*.txt" --dir dist
 
           # Merge all checksum files into one
-          cat dist/checksums_*.txt > dist/checksums.txt
+          cat dist/checksums_*.txt | sort > dist/checksums.txt
+
+      - name: Upload consolidated checksums
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ needs.release-please.outputs.tag_name }}"
+          gh release upload "$TAG" dist/checksums.txt --clobber
 
       - name: Generate Homebrew formula
         env:
@@ -176,3 +192,66 @@ jobs:
           git add Formula/omen.rb
           git commit -m "Update omen to ${VERSION}"
           git push
+
+  docker-manifest:
+    name: Create Docker Manifest
+    needs: [release-please, goreleaser]
+    if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      packages: write
+
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push manifest
+        env:
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          VERSION="${TAG#v}"
+          docker manifest create ghcr.io/panbanda/omen:${VERSION} \
+            ghcr.io/panbanda/omen:${VERSION}-amd64 \
+            ghcr.io/panbanda/omen:${VERSION}-arm64
+          docker manifest push ghcr.io/panbanda/omen:${VERSION}
+
+          docker manifest create ghcr.io/panbanda/omen:latest \
+            ghcr.io/panbanda/omen:${VERSION}-amd64 \
+            ghcr.io/panbanda/omen:${VERSION}-arm64
+          docker manifest push ghcr.io/panbanda/omen:latest
+
+  mcp-registry:
+    name: Publish MCP Manifest
+    needs: [release-please, docker-manifest]
+    if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - name: Set up Go
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+        with:
+          go-version: stable
+
+      - name: Publish MCP manifest
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean --skip=announce,archive,aur,aur-source,before,chocolatey,docker,homebrew,ko,makeself,nfpm,nix,notarize,publish,sbom,scoop,sign,snapcraft,validate,winget
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -103,3 +103,65 @@ brews:
     license: "MIT"
     test: |
       system "#{bin}/omen", "--version"
+
+dockers:
+  - id: linux-amd64
+    ids:
+      - linux-amd64
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "ghcr.io/panbanda/omen:{{ .Version }}-amd64"
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.source=https://github.com/panbanda/omen"
+      - "--platform=linux/amd64"
+  - id: linux-arm64
+    ids:
+      - linux-arm64
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - "ghcr.io/panbanda/omen:{{ .Version }}-arm64"
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.source=https://github.com/panbanda/omen"
+      - "--platform=linux/arm64"
+
+docker_manifests:
+  - name_template: "ghcr.io/panbanda/omen:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/panbanda/omen:{{ .Version }}-amd64"
+      - "ghcr.io/panbanda/omen:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/panbanda/omen:latest"
+    image_templates:
+      - "ghcr.io/panbanda/omen:{{ .Version }}-amd64"
+      - "ghcr.io/panbanda/omen:{{ .Version }}-arm64"
+
+mcp:
+  github:
+    name: io.github.panbanda/omen
+    title: Omen
+    description: Multi-language code analysis tools for complexity, technical debt, hotspots, ownership, and defect prediction
+    homepage: https://github.com/panbanda/omen
+    repository:
+      url: https://github.com/panbanda/omen
+      source: github
+      id: panbanda/omen
+    auth:
+      type: github-oidc
+    packages:
+      - identifier: ghcr.io/panbanda/omen
+        registry_type: oci
+        transport:
+          type: stdio
+    transports:
+      - type: stdio

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY omen /omen
+ENTRYPOINT ["/omen"]


### PR DESCRIPTION
## Summary

- Add Docker image builds to release pipeline using GoReleaser
- Push multi-arch images (linux/amd64, linux/arm64) to ghcr.io/panbanda/omen
- Add MCP registry publishing for AI assistant discoverability
- Upload consolidated checksums.txt to releases

## Changes

- Add minimal Dockerfile using distroless base image
- Configure GoReleaser `dockers` for per-arch image builds
- Add `docker-manifest` job to create multi-arch manifest
- Add `mcp-registry` job using GitHub OIDC authentication
- Add Docker login step to Linux goreleaser jobs
- Upload merged checksums.txt in homebrew job

## Test plan

- [ ] Verify goreleaser config validates (`goreleaser check`)
- [ ] Verify Docker images build and push on release
- [ ] Verify multi-arch manifest is created
- [ ] Verify MCP manifest publishes to registry