### PR TITLE
fix(plugin): use remote git URL for marketplace source

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,10 @@
       "name": "omen",
       "description": "Code analysis skills for Claude Code: complexity hotspots, tech debt, defect prediction, architecture review, and more",
       "version": "1.2.0",
-      "source": "./",
+      "source": {
+        "type": "url",
+        "url": "https://github.com/panbanda/omen.git"
+      },
       "author": {
         "name": "Jonathan Reyes",
         "email": "me@jonathanreyes.com"


### PR DESCRIPTION
## Summary

Updates the plugin marketplace configuration to use a remote git URL instead of a local path, enabling proper installation via the marketplace.

## Changes Made

- Changed `source` field from `"./"` to an object with `type: "url"` and the GitHub repository URL

## Testing

- Verified JSON structure is valid
- All existing tests pass

## Notes

This change is required for the plugin to be installable when users run `/plugin install panbanda/omen`.