### PR TITLE
fix(plugin): use correct source field name in marketplace config

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "description": "Code analysis skills for Claude Code: complexity hotspots, tech debt, defect prediction, architecture review, and more",
       "version": "1.2.0",
       "source": {
-        "type": "url",
+        "source": "url",
         "url": "https://github.com/panbanda/omen.git"
       },
       "author": {


### PR DESCRIPTION
## Summary

Fixes the marketplace plugin source configuration to use the correct field name per the marketplace schema.

## Changes Made

- Changed `"type": "url"` to `"source": "url"` in the source object

## Notes

The marketplace schema expects `source` as the field name, not `type`. This matches the format used in other marketplace plugins like superpowers-marketplace.