### PR TITLE
feat(scanner): always exclude .omen directory regardless of config

### DIFF
--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -73,6 +73,14 @@ func (s *Scanner) loadExcludePatterns(root string) {
 
 // isExcluded checks if a path matches any exclusion pattern.
 func (s *Scanner) isExcluded(path string, isDir bool) bool {
+	// Always exclude .omen directory (internal tool directory)
+	if isDir {
+		base := filepath.Base(path)
+		if base == ".omen" {
+			return true
+		}
+	}
+
 	if len(s.matchers) == 0 {
 		return false
 	}


### PR DESCRIPTION
## Summary

- Unconditionally excludes `.omen` directory in the scanner, regardless of user config
- Adds test to verify `.omen` is excluded even with empty exclude patterns

## Why

The `.omen` directory is an internal tool directory used for caching and configuration. Previously, it was only excluded via the default config patterns. If a user provided a config that didn't include `.omen/` in the exclude patterns, or if patterns were completely overwritten, the `.omen` directory could be inadvertently scanned and analyzed.

This change makes the exclusion unconditional at the scanner level, ensuring the tool's internal files are never included in analysis results.

## Test plan

- [x] Added `TestScanDirAlwaysExcludesOmenDirectory` test
- [x] Test verifies `.omen` is excluded even with empty exclude patterns and gitignore disabled
- [x] All existing scanner tests pass