### PR TITLE
fix(vcs): sort commits by date in FindCommitsAtIntervals

### DIFF
--- a/internal/vcs/checkout.go
+++ b/internal/vcs/checkout.go
@@ -2,6 +2,7 @@ package vcs
 
 import (
 	"errors"
+	"sort"
 	"time"
 
 	"github.com/go-git/go-git/v6"
@@ -173,6 +174,13 @@ func FindCommitsAtIntervals(repoPath string, period string, since time.Duration,
 	if len(commits) == 0 {
 		return nil, nil
 	}
+
+	// Sort commits by date (newest first). go-git returns commits in graph traversal
+	// order which is NOT chronological - older commits by date can appear before
+	// newer ones in the iteration. findCommitAtOrAfter requires date-sorted order.
+	sort.Slice(commits, func(i, j int) bool {
+		return commits[i].Date.After(commits[j].Date)
+	})
 
 	// Generate interval boundaries
 	boundaries := generateBoundaries(period, since, snap)

--- a/internal/vcs/checkout_test.go
+++ b/internal/vcs/checkout_test.go
@@ -1,6 +1,7 @@
 package vcs
 
 import (
+	"sort"
 	"testing"
 	"time"
 )
@@ -77,6 +78,7 @@ func TestStartOfMonth(t *testing.T) {
 }
 
 func TestFindCommitAtOrAfter(t *testing.T) {
+	// Commits sorted newest-first by date (expected order)
 	commits := []CommitInfo{
 		{SHA: "newer", Date: time.Date(2024, 12, 15, 12, 0, 0, 0, time.UTC)},
 		{SHA: "older", Date: time.Date(2024, 12, 1, 12, 0, 0, 0, time.UTC)},
@@ -125,6 +127,79 @@ func TestFindCommitAtOrAfter(t *testing.T) {
 			}
 			if got.SHA != tt.wantSHA {
 				t.Errorf("got SHA %v, want %v", got.SHA, tt.wantSHA)
+			}
+		})
+	}
+}
+
+func TestFindCommitAtOrAfterWithSorting(t *testing.T) {
+	// Simulates go-git's graph traversal order where commits are NOT sorted by date.
+	// go-git returns commits in graph traversal order, not chronological order.
+	// In a repo with merge commits, older commits (by date) can appear BEFORE
+	// newer commits in the iteration.
+	//
+	// FindCommitsAtIntervals must sort commits by date before calling
+	// findCommitAtOrAfter, which expects newest-first order.
+	unsortedCommits := []CommitInfo{
+		{SHA: "head", Date: time.Date(2025, 12, 9, 12, 0, 0, 0, time.UTC)},       // index 0: newest
+		{SHA: "oldest2016", Date: time.Date(2016, 9, 13, 12, 0, 0, 0, time.UTC)}, // index 1: oldest by DATE but in middle of iteration
+		{SHA: "mid2023", Date: time.Date(2023, 6, 1, 12, 0, 0, 0, time.UTC)},     // index 2
+		{SHA: "late2023", Date: time.Date(2023, 11, 1, 12, 0, 0, 0, time.UTC)},   // index 3
+		{SHA: "early2024", Date: time.Date(2024, 1, 9, 12, 0, 0, 0, time.UTC)},   // index 4: LAST in iteration (but not oldest!)
+	}
+
+	// Before fix: findCommitAtOrAfter with unsorted commits returns wrong results
+	t.Run("unsorted commits return wrong result", func(t *testing.T) {
+		got := findCommitAtOrAfter(unsortedCommits, time.Date(2016, 1, 1, 0, 0, 0, 0, time.UTC))
+		if got == nil || got.SHA != "early2024" {
+			t.Skip("behavior changed - this documents the bug that existed before the fix")
+		}
+		// This is the bug: we asked for commit on/after 2016-01-01 and got 2024-01-09
+	})
+
+	// After fix: sort commits by date (newest first) before calling findCommitAtOrAfter
+	sortedCommits := make([]CommitInfo, len(unsortedCommits))
+	copy(sortedCommits, unsortedCommits)
+	sort.Slice(sortedCommits, func(i, j int) bool {
+		return sortedCommits[i].Date.After(sortedCommits[j].Date)
+	})
+
+	tests := []struct {
+		name    string
+		target  time.Time
+		wantSHA string
+	}{
+		{
+			name:    "finds oldest commit from 2016",
+			target:  time.Date(2016, 1, 1, 0, 0, 0, 0, time.UTC),
+			wantSHA: "oldest2016",
+		},
+		{
+			name:    "finds 2023 commit",
+			target:  time.Date(2023, 5, 1, 0, 0, 0, 0, time.UTC),
+			wantSHA: "mid2023",
+		},
+		{
+			name:    "finds late 2023 commit",
+			target:  time.Date(2023, 10, 1, 0, 0, 0, 0, time.UTC),
+			wantSHA: "late2023",
+		},
+		{
+			name:    "finds early 2024 commit",
+			target:  time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			wantSHA: "early2024",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findCommitAtOrAfter(sortedCommits, tt.target)
+			if got == nil {
+				t.Errorf("expected non-nil commit for target %v", tt.target)
+				return
+			}
+			if got.SHA != tt.wantSHA {
+				t.Errorf("got SHA %v, want %v (target: %v)", got.SHA, tt.wantSHA, tt.target)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Fix trend analysis to correctly traverse full repository history
- Sort commits by date before boundary matching in `FindCommitsAtIntervals`

## Problem

`go-git`'s `repo.Log()` returns commits in graph traversal order, not chronological order. In repos with merge commits, older commits by date can appear before newer ones in the iteration.

`findCommitAtOrAfter` assumes commits are sorted newest-first by date. When searching from the end of the array for the "oldest" commit, it would find the wrong commit if the iteration order didn't match date order.

This caused `omen analyze trend --since=10y` to only return ~2 years of data instead of the full 8+ years of history.

## Solution

Added `sort.Slice` to sort commits by date (newest-first) before calling `findCommitAtOrAfter`, ensuring correct boundary matching regardless of git's traversal order.

## Test plan

- [x] Added `TestFindCommitAtOrAfterWithSorting` demonstrating the fix
- [x] All existing tests pass
- [x] Pre-push hooks pass (score: 90/100)