### PR TITLE
perf(mcp): reduce tool description context size by 43%

### DIFF
--- a/internal/mcpserver/descriptions.go
+++ b/internal/mcpserver/descriptions.go
@@ -1,8 +1,7 @@
 package mcpserver
 
-// Tool descriptions with interpretation guidance for LLMs.
-// Each description explains what the tool does, when to use it,
-// how to interpret results, and key thresholds.
+// Tool descriptions optimized for LLM context efficiency.
+// Keep descriptions concise - focus on what the tool does and when to use it.
 
 func describeComplexity() string {
 	return `Measures cyclomatic and cognitive complexity of functions across a codebase.
@@ -10,16 +9,7 @@ func describeComplexity() string {
 USE WHEN:
 - Identifying functions that are hard to test or maintain
 - Finding refactoring candidates before code reviews
-- Assessing overall code quality trends
 - Prioritizing technical debt remediation
-
-INTERPRETING RESULTS:
-- Cyclomatic complexity > 10: function has many code paths, consider splitting
-- Cyclomatic complexity > 20: high risk, strong refactoring candidate
-- Cognitive complexity > 15: function is hard to understand, simplify logic
-- Cognitive complexity > 30: very difficult to maintain
-- MaxNesting > 4: deeply nested code, consider early returns or extraction
-- P90 values show the 90th percentile across all functions (codebase trend)
 
 METRICS RETURNED:
 - Per-function: cyclomatic, cognitive, max_nesting, lines
@@ -34,15 +24,6 @@ USE WHEN:
 - Auditing technical debt before a release
 - Finding forgotten workarounds and temporary fixes
 - Identifying security-related debt markers
-- Tracking debt trends over time
-
-INTERPRETING RESULTS:
-- Severity levels: critical > high > medium > low
-- Critical: Security-related debt (SECURITY, VULN, UNSAFE)
-- High: Known defects (FIXME, BUG, BROKEN)
-- Medium: Design compromises (HACK, KLUDGE, REFACTOR)
-- Low: Future work (TODO, NOTE, OPTIMIZE)
-- Categories: design, defect, requirement, test, performance, security
 
 METRICS RETURNED:
 - Items: list of debt markers with file, line, severity, category
@@ -57,14 +38,6 @@ USE WHEN:
 - Cleaning up code before major refactoring
 - Reducing binary size and compile times
 - Finding orphaned code after feature removal
-- Improving code maintainability
-
-INTERPRETING RESULTS:
-- Confidence score 0.0-1.0: higher means more likely truly unused
-- Confidence > 0.8: high confidence, safe to investigate removal
-- Confidence 0.5-0.8: medium confidence, verify usage manually
-- Confidence < 0.5: lower confidence, may have dynamic usage
-- Exported symbols may be used by external packages
 
 METRICS RETURNED:
 - Unused items: functions, methods, variables with confidence scores
@@ -80,15 +53,7 @@ func describeChurn() string {
 USE WHEN:
 - Finding unstable or problematic code areas
 - Identifying files that may need architectural attention
-- Discovering hidden complexity not visible in static analysis
 - Planning refactoring priorities based on change patterns
-
-INTERPRETING RESULTS:
-- ChurnScore: normalized 0-100, higher means more volatile
-- High churn + high complexity = prime refactoring target
-- Many unique authors on one file may indicate unclear ownership
-- Frequent small changes may indicate poor abstraction
-- Files with high additions AND deletions are being reworked
 
 METRICS RETURNED:
 - Per-file: commits, lines added/deleted, unique authors, churn score
@@ -105,14 +70,6 @@ USE WHEN:
 - Finding copy-paste code that should be refactored
 - Identifying candidates for shared utilities or abstractions
 - Reducing maintenance burden from duplicated logic
-- Preparing for DRY (Don't Repeat Yourself) improvements
-
-INTERPRETING RESULTS:
-- Similarity threshold: 0.0-1.0, higher means more similar
-- Exact clones (1.0): identical code blocks
-- Near clones (0.8-0.99): minor variations, likely copy-paste
-- Similar blocks (0.6-0.8): related logic, consider abstraction
-- Clone groups show all instances of the same duplicated code
 
 METRICS RETURNED:
 - Clone groups: sets of similar code blocks
@@ -129,14 +86,6 @@ USE WHEN:
 - Prioritizing code review focus areas
 - Identifying high-risk files before releases
 - Planning testing effort allocation
-- Making data-driven refactoring decisions
-
-INTERPRETING RESULTS:
-- Defect probability: 0.0-1.0, higher means higher risk
-- > 0.7: High risk, prioritize review and testing
-- 0.4-0.7: Medium risk, worth attention
-- < 0.4: Lower risk, but not immune to bugs
-- Combines: complexity, churn, ownership diffusion, code age
 
 METRICS RETURNED:
 - Per-file: defect probability, contributing factors
@@ -153,24 +102,6 @@ USE WHEN:
 - Reviewing recent commits for bug risk before release
 - Identifying risky changes that need extra review
 - Prioritizing code review effort on high-risk commits
-- Understanding which types of changes introduce defects
-
-INTERPRETING RESULTS:
-- Risk score: 0-1, higher means more likely to introduce bugs
-- High risk (>0.7): commit should be carefully reviewed
-- Medium risk (0.4-0.7): worth extra attention
-- Low risk (<0.4): typical commit, standard review
-- Bug fix commits indicate prior defects in touched files
-
-JIT FACTORS (from Kamei et al. research):
-- LA (lines added): more lines = more risk
-- LD (lines deleted): fewer deletions is safer
-- LT (lines in touched files): larger files = more risk
-- FIX: bug fix commits indicate problematic areas
-- NDEV (developers on files): more developers = more risk
-- AGE (average file age): older files may be stable or legacy
-- NUC (unique changes): high entropy = higher risk
-- EXP (developer experience): less experience = more risk
 
 METRICS RETURNED:
 - Per-commit: hash, author, message, risk score, risk level
@@ -186,15 +117,7 @@ func describeTDG() string {
 USE WHEN:
 - Finding areas where debt is increasing over time
 - Prioritizing debt paydown by impact
-- Tracking debt trends across releases
 - Identifying files that consistently accumulate debt
-
-INTERPRETING RESULTS:
-- TDG score: composite metric, higher means more accumulated debt
-- Combines: complexity, SATD markers, code smells, coupling
-- Hotspot files: high TDG + high churn = urgent attention
-- Stable files with high TDG: legacy debt, plan remediation
-- Rising TDG trend: debt is accumulating, investigate causes
 
 METRICS RETURNED:
 - Per-file: TDG score, component scores
@@ -210,20 +133,11 @@ USE WHEN:
 - Finding circular dependencies
 - Identifying tightly coupled modules
 - Planning module extraction or refactoring
-- Visualizing import/export relationships
-
-INTERPRETING RESULTS:
-- Edges show dependency direction (A depends on B)
-- High in-degree: many dependents, changes have wide impact
-- High out-degree: many dependencies, potentially fragile
-- Cycles indicate circular dependencies (problematic)
-- Isolated nodes may be dead code or entry points
 
 METRICS RETURNED:
 - Nodes: files/modules/functions depending on scope
 - Edges: dependency relationships with counts
 - Metrics (when enabled): in-degree, out-degree per node
-- Output can be used with graph visualization tools
 
 Scope options: file (default), function, module.`
 }
@@ -235,14 +149,6 @@ USE WHEN:
 - Finding the most problematic files in a codebase
 - Prioritizing refactoring for maximum impact
 - Identifying code that changes often but is hard to change safely
-- Making the case for technical debt investment
-
-INTERPRETING RESULTS:
-- Hotspot score combines churn and complexity metrics
-- High churn + high complexity = highest priority hotspot
-- High churn + low complexity = frequently changing but manageable
-- Low churn + high complexity = complex but stable, lower priority
-- Top hotspots are the best refactoring candidates
 
 METRICS RETURNED:
 - Per-file: hotspot score, churn metrics, complexity metrics
@@ -259,14 +165,6 @@ USE WHEN:
 - Discovering implicit dependencies not visible in code
 - Finding files that should be co-located or merged
 - Identifying architectural issues (shotgun surgery)
-- Understanding change propagation patterns
-
-INTERPRETING RESULTS:
-- Co-change count: number of commits where both files changed
-- Coupling strength: higher means stronger implicit dependency
-- Files always changing together may belong in same module
-- Unexpected couplings may indicate hidden dependencies
-- High coupling across module boundaries = architectural smell
 
 METRICS RETURNED:
 - File pairs with co-change frequency
@@ -282,15 +180,7 @@ func describeOwnership() string {
 USE WHEN:
 - Identifying knowledge silos and single points of failure
 - Finding code that needs knowledge transfer
-- Assessing team distribution across the codebase
 - Planning for team member transitions
-
-INTERPRETING RESULTS:
-- Bus factor: minimum contributors whose absence would halt work
-- Bus factor = 1: critical risk, only one person knows this code
-- Bus factor = 2-3: moderate risk, knowledge should be spread
-- Ownership percentage: contribution share per author
-- Dominant owner > 80%: potential knowledge silo
 
 METRICS RETURNED:
 - Per-file: contributors, contribution percentages, bus factor
@@ -308,17 +198,6 @@ USE WHEN:
 - Assessing class/struct design quality
 - Finding classes that do too much (god classes)
 - Identifying tightly coupled components
-- Measuring inheritance hierarchy depth
-
-INTERPRETING RESULTS:
-- LCOM (Lack of Cohesion): higher = less cohesive, consider splitting
-- LCOM > 0.8: class likely has multiple responsibilities
-- WMC (Weighted Methods per Class): method complexity sum
-- WMC > 20: class may be too complex
-- CBO (Coupling Between Objects): number of dependencies
-- CBO > 10: high coupling, harder to change in isolation
-- DIT (Depth of Inheritance Tree): inheritance levels
-- DIT > 4: deep hierarchy, may be over-engineered
 
 METRICS RETURNED:
 - Per-class/struct: LCOM, WMC, CBO, DIT, RFC, NOC
@@ -333,14 +212,6 @@ USE WHEN:
 - Understanding the most important functions/types in a codebase
 - Finding entry points and core abstractions
 - Getting oriented in an unfamiliar codebase
-- Identifying central components that many things depend on
-
-INTERPRETING RESULTS:
-- PageRank score: importance based on reference graph
-- Higher rank = more referenced by other code
-- Top symbols are likely core abstractions or entry points
-- Types/interfaces with high rank are key domain concepts
-- Functions with high rank are frequently called utilities
 
 METRICS RETURNED:
 - Ranked list of symbols (functions, types, methods)
@@ -357,30 +228,6 @@ USE WHEN:
 - Auditing architecture before major refactoring
 - Finding structural problems that cause maintenance pain
 - Identifying components that violate design principles
-- Preparing architecture review documentation
-
-INTERPRETING RESULTS:
-Severity levels (critical > high > medium > low):
-
-CYCLIC DEPENDENCIES (critical):
-- Circular imports/dependencies between modules
-- Makes changes risky, testing difficult
-- Should be broken with dependency inversion
-
-HUB COMPONENTS (high):
-- High fan-in AND fan-out (connects everything)
-- Changes here affect many parts of the system
-- Consider splitting or using interfaces
-
-GOD COMPONENTS (high):
-- Extremely high coupling, does too much
-- Fan-in > threshold AND fan-out > threshold
-- Strong refactoring candidate
-
-UNSTABLE DEPENDENCIES (medium):
-- Stable module depends on unstable module
-- Violates Stable Dependencies Principle
-- Can cause cascading changes
 
 METRICS RETURNED:
 - Smells: type, severity, components involved, description
@@ -396,7 +243,6 @@ func describeFlags() string {
 USE WHEN:
 - Auditing feature flag usage before cleanup sprints
 - Finding stale flags that should be removed
-- Identifying complex flag implementations
 - Planning feature flag debt remediation
 
 SUPPORTED PROVIDERS:
@@ -405,25 +251,6 @@ SUPPORTED PROVIDERS:
 - Unleash (JS/TS, Go)
 - PostHog (JS/TS, Python, Go, Java, Ruby)
 - Flipper (Ruby)
-
-INTERPRETING RESULTS:
-Priority levels (CRITICAL > HIGH > MEDIUM > LOW):
-- CRITICAL: Very stale (>90 days) + high complexity
-- HIGH: Stale flags (>30 days) or high file spread
-- MEDIUM: Moderate staleness or complexity
-- LOW: Recent flags with low complexity
-
-COMPLEXITY METRICS:
-- FileSpread: Number of files containing flag references
-- MaxNestingDepth: Deepest conditional nesting level
-- DecisionPoints: Total flag check locations
-- CoupledFlags: Other flags used in same conditionals
-
-STALENESS METRICS (requires git):
-- DaysSinceIntro: Days since flag first appeared
-- DaysSinceModified: Days since last flag-related change
-- Authors: Contributors who touched the flag
-- StalenessScore: 0-1 score, higher = more stale
 
 METRICS RETURNED:
 - Per-flag: key, provider, references, complexity, staleness, priority
@@ -473,31 +300,12 @@ USE WHEN:
 - Tracking code quality improvements or degradation over time
 - Preparing quarterly engineering reviews with historical data
 - Identifying when code quality changes occurred
-- Correlating score changes with releases or refactoring efforts
-- Generating health reports that need historical context
-
-INTERPRETING RESULTS:
-- Points: Score snapshots at regular intervals (daily/weekly/monthly)
-- Slope: Score change per period (positive = improving, negative = degrading)
-- R-squared: Goodness of fit (0-1), higher means more consistent trend
-- Correlation: -1 to 1, strength of linear relationship over time
-
-TREND PATTERNS:
-- Steady improvement (positive slope): refactoring efforts working
-- Steady decline (negative slope): technical debt accumulating
-- Flat trend (slope near 0): stable codebase, no major changes
-- High variance (low R-squared): inconsistent quality, investigate spikes
-
-COMPONENT TRENDS:
-Each component (complexity, duplication, SATD, etc.) has its own trend stats.
-Look for diverging trends - one component improving while others decline.
 
 METRICS RETURNED:
 - points: Array of {date, commit_sha, score, components}
 - slope, intercept, r_squared, correlation: Overall regression stats
 - component_trends: Per-component trend statistics
 - start_score, end_score, total_change: Summary values
-- period, since, snapped: Analysis parameters
 
 Requires git repository. Analysis time depends on history length and sampling period.`
 }
@@ -509,7 +317,6 @@ USE WHEN:
 - About to modify a file and need to understand its context
 - Need to understand a function's complexity, callers, and dependencies
 - Want to assess risk before touching unfamiliar code
-- Need focused analysis instead of whole-codebase metrics
 
 INPUT RESOLUTION:
 The focus parameter is resolved in this order:
@@ -518,10 +325,6 @@ The focus parameter is resolved in this order:
 3. Basename search - if looks like filename (has extension)
 4. Symbol search - if repo map is available and name matches a symbol
 
-AMBIGUOUS MATCHES:
-If multiple files or symbols match, returns an error with candidates.
-Retry with a more specific path or the full symbol file:line.
-
 METRICS RETURNED:
 For files:
 - Complexity: cyclomatic/cognitive totals, per-function breakdown
@@ -529,10 +332,5 @@ For files:
 
 For symbols:
 - Definition: file, line, kind (function/method/type)
-- Complexity: metrics for the specific function
-
-OUTPUT FORMATS:
-- toon (default): Structured key-value format
-- json: Machine-readable JSON
-- markdown: Human-readable with tables`
+- Complexity: metrics for the specific function`
 }

--- a/internal/mcpserver/mcp_test.go
+++ b/internal/mcpserver/mcp_test.go
@@ -64,9 +64,6 @@ func TestToolDescriptions(t *testing.T) {
 			if !contains(desc, "USE WHEN:") {
 				t.Errorf("%s description missing USE WHEN section", name)
 			}
-			if !contains(desc, "INTERPRETING RESULTS:") {
-				t.Errorf("%s description missing INTERPRETING RESULTS section", name)
-			}
 			if !contains(desc, "METRICS RETURNED:") {
 				t.Errorf("%s description missing METRICS RETURNED section", name)
 			}


### PR DESCRIPTION
## Summary

Reduces MCP tool description token consumption by ~43% (from ~18K to ~10K tokens) by removing verbose "INTERPRETING RESULTS" sections that were adding significant context overhead when tools are loaded into LLM conversations.

## Changes Made

- **descriptions.go**: Condensed 18 of 19 tool descriptions by removing INTERPRETING RESULTS sections
  - Kept `describeScore()` verbose since it's the primary health check tool where interpretation guidance is most valuable
  - Reduced file size from ~20KB to ~11KB
- **mcp_test.go**: Removed test assertion requiring INTERPRETING RESULTS section

## Testing

- All MCP server tests pass
- Full test suite passes
- Verified MCP server builds and runs correctly

## Notes

- Interpretation guidance remains available via MCP prompts in `internal/mcpserver/prompts/`
- Tool descriptions still contain USE WHEN and METRICS RETURNED sections for tool selection context
- This is a context optimization - no functional changes to analyzer behavior