### PR TITLE
fix: apply exclude patterns to git-based analyzers

### DIFF
--- a/omen.toml
+++ b/omen.toml
@@ -50,6 +50,15 @@ patterns = [
 
     # Lock files
     "go.sum",
+    "go.mod",
+
+    # Documentation
+    "**/README.md",
+    "**/CHANGELOG.md",
+
+    # Release please
+    ".release-please-manifest.json",
+    "release-please-config.json",
 ]
 
 [cache]

--- a/pkg/analyzer/satd/satd.go
+++ b/pkg/analyzer/satd/satd.go
@@ -143,12 +143,11 @@ func defaultTestPatterns() []*regexp.Regexp {
 	}
 }
 
-// omen:ignore - documentation describes SATD markers, not actual debt
 // defaultPatterns returns the standard SATD detection patterns.
-// Severity levels: Critical (security), High (defects), Medium (design), Low (todos)
+// Severity levels: Critical (security), High (defects), Medium (design), Low (todos) omen:ignore
 func defaultPatterns() []pattern {
 	return []pattern{
-		// Critical severity - Security concerns
+		// Critical severity - Security concerns omen:ignore
 		{regexp.MustCompile(`(?i)\b(SECURITY|VULN|VULNERABILITY|CVE|XSS)\b[:\s]*(.+)?`), CategorySecurity, SeverityCritical},
 		{regexp.MustCompile(`(?i)\bUNSAFE\b[:\s]*(.+)?`), CategorySecurity, SeverityCritical},
 

--- a/pkg/analyzer/score/normalize.go
+++ b/pkg/analyzer/score/normalize.go
@@ -97,7 +97,6 @@ func NormalizeDuplication(ratio float64) int {
 	return clamp(int(math.Round(score)), 0, 100)
 }
 
-// omen:ignore - documentation describes SATD markers, not actual debt
 // -----------------------------------------------------------------------------
 // Self-Admitted Technical Debt (SATD) Normalization
 // -----------------------------------------------------------------------------
@@ -105,12 +104,12 @@ func NormalizeDuplication(ratio float64) int {
 // Uses SEVERITY-WEIGHTED scoring rather than raw item counts.
 //
 // Rationale:
-// - Not all debt is equal: a SECURITY marker is far worse than a NOTE
+// - Not all debt is equal: a SECURITY marker is far worse than a NOTE omen:ignore
 // - Raw counts penalize well-documented codebases that track their debt
 // - Density (per KLOC) scales appropriately with codebase size
 //
 // Severity weights (based on remediation urgency):
-// - Critical (SECURITY, VULN): 4.0 - Immediate security risk
+// - Critical (SECURITY, VULN): 4.0 - Immediate security risk omen:ignore
 // - High (FIXME, BUG): 2.0 - Known defects requiring fix
 // - Medium (HACK, REFACTOR): 1.0 - Design compromises
 // - Low (TODO, NOTE): 0.25 - Future work, minimal impact


### PR DESCRIPTION
## Summary
- Fix git-based analyzers (churn, temporal coupling, changes) to respect exclude patterns from `omen.toml`
- Add `shouldExcludePath()` helper using gitignore pattern matching
- Add `omen:ignore` to documentation comments that were being flagged as SATD
- Update `omen.toml` with common exclude patterns (README.md, CHANGELOG.md, go.mod, release-please configs)

## Test plan
- [x] Added tests for `AnalyzeChurn_ExcludePatterns`
- [x] Added tests for `AnalyzeTemporalCoupling_ExcludePatterns`
- [x] Added tests for `AnalyzeChanges_ExcludePatterns`
- [x] All existing tests pass
- [x] Verified excluded files no longer appear in generated reports