### PR TITLE
fix(hotspot): apply exclude patterns to hotspot analysis

### DIFF
--- a/cmd/omen/report.go
+++ b/cmd/omen/report.go
@@ -187,7 +187,7 @@ func runReportGenerate(cmd *cobra.Command, args []string) error {
 	// Hotspot analyzer
 	wg.Go(func() {
 		defer tracker.Tick()
-		result, err := svc.AnalyzeHotspots(context.Background(), paths[0], scanResult.Files, analysis.HotspotOptions{
+		result, err := svc.AnalyzeHotspots(context.Background(), paths[0], nil, analysis.HotspotOptions{
 			Days: days,
 		})
 		if err != nil {


### PR DESCRIPTION
## Summary

- Fix hotspot analyzer to respect exclude patterns from config (e.g., filtering out README.md)
- Add `filterHotspotResults()` method to remove excluded files after analysis
- Change report generation to pass `nil` for files, allowing the analyzer to discover churned files from git history

## Test plan

- [x] Added `TestAnalyzeHotspots_NilFiles` - verifies nil files parameter works correctly
- [x] Added `TestAnalyzeHotspots_ExcludePatterns` - verifies excluded files are filtered out
- [x] All existing hotspot tests continue to pass
- [x] Pre-push hooks pass (lint, test, score)