### PR TITLE
feat(context): add token budget estimation for LLM context windows

### DIFF
--- a/internal/output/tokens.go
+++ b/internal/output/tokens.go
@@ -1,0 +1,95 @@
+package output
+
+import (
+	"fmt"
+	"unicode/utf8"
+)
+
+// TokenBudgetInfo contains token estimation and budget usage information.
+type TokenBudgetInfo struct {
+	Tokens       int     // Estimated token count
+	Budget       int     // Token budget (context window size)
+	BudgetLabel  string  // Human-readable budget label (e.g., "8k", "128k")
+	UsagePercent float64 // Percentage of budget used
+	Remaining    int     // Estimated tokens remaining
+}
+
+// Common context window sizes for LLMs
+const (
+	Budget8K   = 8000
+	Budget16K  = 16000
+	Budget32K  = 32000
+	Budget64K  = 64000
+	Budget128K = 128000
+	Budget200K = 200000
+)
+
+// DefaultBudget is the default context window size for estimation.
+const DefaultBudget = Budget128K
+
+// CharsPerToken is the approximate character-to-token ratio.
+// Research suggests:
+// - Anthropic recommends ~3.5 chars/token for English text
+// - Code typically has ~4 chars/token due to syntax, identifiers
+// We use 4.0 as a conservative estimate for code-heavy context.
+const CharsPerToken = 4.0
+
+// EstimateTokens returns an approximate token count for the given text.
+// This uses a simple character-based heuristic suitable for code context.
+// For exact counts, use the Anthropic API's countTokens endpoint.
+func EstimateTokens(text string) int {
+	if len(text) == 0 {
+		return 0
+	}
+
+	// Count actual runes (Unicode code points) for more accurate estimation
+	runeCount := utf8.RuneCountInString(text)
+
+	// Apply chars-per-token ratio
+	tokens := float64(runeCount) / CharsPerToken
+
+	return int(tokens + 0.5) // Round to nearest integer
+}
+
+// FormatTokenCount formats a token count for display.
+// Counts >= 1000 are formatted as "X.Xk".
+func FormatTokenCount(tokens int) string {
+	if tokens < 1000 {
+		return fmt.Sprintf("%d", tokens)
+	}
+	return fmt.Sprintf("%.1fk", float64(tokens)/1000)
+}
+
+// GetTokenBudgetInfo calculates token budget information for the given text.
+func GetTokenBudgetInfo(text string, budget int) TokenBudgetInfo {
+	if budget <= 0 {
+		budget = DefaultBudget
+	}
+
+	tokens := EstimateTokens(text)
+	remaining := budget - tokens
+	if remaining < 0 {
+		remaining = 0
+	}
+
+	return TokenBudgetInfo{
+		Tokens:       tokens,
+		Budget:       budget,
+		BudgetLabel:  formatBudgetLabel(budget),
+		UsagePercent: float64(tokens) / float64(budget) * 100,
+		Remaining:    remaining,
+	}
+}
+
+// formatBudgetLabel creates a human-readable label for a budget size.
+func formatBudgetLabel(budget int) string {
+	if budget >= 1000 {
+		return fmt.Sprintf("%dk", budget/1000)
+	}
+	return fmt.Sprintf("%d", budget)
+}
+
+// BudgetTiers returns common budget tiers for display/selection.
+func BudgetTiers() []int {
+	return []int{Budget8K, Budget16K, Budget32K, Budget64K, Budget128K, Budget200K}
+}

--- a/internal/output/tokens_test.go
+++ b/internal/output/tokens_test.go
@@ -1,0 +1,102 @@
+package output
+
+import (
+	"testing"
+)
+
+func TestEstimateTokens(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		minRange int // Minimum expected tokens
+		maxRange int // Maximum expected tokens
+	}{
+		{
+			name:     "empty string",
+			text:     "",
+			minRange: 0,
+			maxRange: 0,
+		},
+		{
+			name:     "simple sentence",
+			text:     "Hello, world!",
+			minRange: 2,
+			maxRange: 5,
+		},
+		{
+			name:     "code snippet",
+			text:     "func main() { fmt.Println(\"hello\") }",
+			minRange: 8,
+			maxRange: 15,
+		},
+		{
+			name: "multiline code",
+			text: `func Add(a int, b int) int {
+	return a + b
+}`,
+			minRange: 10,
+			maxRange: 20,
+		},
+		{
+			name:     "1000 characters",
+			text:     string(make([]byte, 1000)),
+			minRange: 200,
+			maxRange: 350,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := EstimateTokens(tt.text)
+			if got < tt.minRange || got > tt.maxRange {
+				t.Errorf("EstimateTokens() = %v, want between %v and %v", got, tt.minRange, tt.maxRange)
+			}
+		})
+	}
+}
+
+func TestFormatTokenCount(t *testing.T) {
+	tests := []struct {
+		tokens   int
+		expected string
+	}{
+		{100, "100"},
+		{1000, "1.0k"},
+		{1500, "1.5k"},
+		{10000, "10.0k"},
+		{100000, "100.0k"},
+		{1000000, "1000.0k"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			got := FormatTokenCount(tt.tokens)
+			if got != tt.expected {
+				t.Errorf("FormatTokenCount(%d) = %v, want %v", tt.tokens, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTokenBudgetInfo(t *testing.T) {
+	// Test 8k budget (around 32,000 chars at 4 chars/token)
+	text8k := string(make([]byte, 8000)) // ~2k tokens
+	info := GetTokenBudgetInfo(text8k, 8000)
+
+	if info.Tokens < 1500 || info.Tokens > 2500 {
+		t.Errorf("Expected ~2000 tokens, got %d", info.Tokens)
+	}
+
+	if info.Budget != 8000 {
+		t.Errorf("Expected budget 8000, got %d", info.Budget)
+	}
+
+	// Usage should be around 25% (2k/8k)
+	if info.UsagePercent < 20 || info.UsagePercent > 35 {
+		t.Errorf("Expected ~25%% usage, got %.1f%%", info.UsagePercent)
+	}
+
+	if info.BudgetLabel != "8k" {
+		t.Errorf("Expected budget label '8k', got '%s'", info.BudgetLabel)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `--tokens` flag to show estimated token count
- Adds `--budget` flag to set target context window size (default 128k)
- Displays usage percentage to help users optimize context

## Research Basis
LLMs have limited context windows (8k-200k tokens). Anthropic research suggests ~3.5-4 chars/token for English/code. This feature helps users:
- Prevent context overflow that causes truncation
- Make informed decisions about `--full` vs default limits
- Optimize for their specific model's context size

## Usage
```bash
omen context . --tokens                    # Shows tokens vs 128k default
omen context . --tokens --budget 8000      # Shows tokens vs 8k budget
omen context . --focus main.go --tokens    # Works with focused context
```

## Test Plan
- [x] TDD tests for token estimation (EstimateTokens, FormatTokenCount)
- [x] Tests for TokenBudgetInfo calculation
- [x] Manual verification with various context sizes