### PR TITLE
feat(context): add related test files to focused context

### DIFF
--- a/cmd/omen/context.go
+++ b/cmd/omen/context.go
@@ -36,6 +36,7 @@ func init() {
 	contextCmd.Flags().Bool("include-metrics", false, "Include complexity and quality metrics")
 	contextCmd.Flags().Bool("include-graph", false, "Include dependency graph")
 	contextCmd.Flags().Bool("include-calls", false, "Include callers/callees for focused context (enables code navigation)")
+	contextCmd.Flags().Bool("include-tests", false, "Include related test files in focused context")
 	contextCmd.Flags().Bool("repo-map", false, "Generate PageRank-ranked symbol map")
 	contextCmd.Flags().Int("top", defaultMaxSymbols, "Number of top symbols to include in repo map")
 	contextCmd.Flags().Bool("full", false, "Include all files without limits (use analyzers directly for detailed output)")
@@ -55,7 +56,8 @@ func runContext(cmd *cobra.Command, args []string) error {
 	// If --focus is provided, run focused context
 	if focus != "" {
 		includeCalls, _ := cmd.Flags().GetBool("include-calls")
-		return runFocusedContext(cmd, focus, paths, includeCalls)
+		includeTests, _ := cmd.Flags().GetBool("include-tests")
+		return runFocusedContext(cmd, focus, paths, includeCalls, includeTests)
 	}
 
 	scanSvc := scannerSvc.New()
@@ -220,7 +222,7 @@ func runContext(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func runFocusedContext(cmd *cobra.Command, focus string, paths []string, includeCalls bool) error {
+func runFocusedContext(cmd *cobra.Command, focus string, paths []string, includeCalls, includeTests bool) error {
 	baseDir := "."
 	if len(paths) > 0 {
 		baseDir = paths[0]
@@ -233,6 +235,7 @@ func runFocusedContext(cmd *cobra.Command, focus string, paths []string, include
 		Focus:        focus,
 		BaseDir:      baseDir,
 		IncludeGraph: includeCalls,
+		IncludeTests: includeTests,
 	})
 
 	// If not found, try with repo map for symbol lookup
@@ -248,6 +251,7 @@ func runFocusedContext(cmd *cobra.Command, focus string, paths []string, include
 					BaseDir:      baseDir,
 					RepoMap:      repoMapResult,
 					IncludeGraph: includeCalls,
+					IncludeTests: includeTests,
 				})
 			}
 		}
@@ -355,6 +359,13 @@ func runFocusedContext(cmd *cobra.Command, focus string, paths []string, include
 			}
 			fmt.Println()
 		}
+	}
+
+	// Related test file
+	if result.RelatedTestFile != "" {
+		fmt.Println("## Related Test File")
+		fmt.Printf("- **Path**: %s\n", result.RelatedTestFile)
+		fmt.Println()
 	}
 
 	return nil

--- a/internal/service/analysis/related_tests.go
+++ b/internal/service/analysis/related_tests.go
@@ -1,0 +1,149 @@
+package analysis
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// findRelatedTestFile finds the test file for a given source file.
+// Returns empty string if no related test file is found.
+//
+// This supports common test naming conventions across languages:
+// - Go: foo.go -> foo_test.go
+// - Python: foo.py -> test_foo.py or foo_test.py
+// - TypeScript/JavaScript: foo.ts -> foo.test.ts or foo.spec.ts
+// - Ruby: foo.rb -> foo_spec.rb (RSpec)
+// - Java: Foo.java -> FooTest.java
+// - Rust: foo.rs -> tests/foo_test.rs
+func findRelatedTestFile(sourcePath string, candidates []string) string {
+	// Don't find tests for test files
+	if isTestFile(sourcePath) {
+		return ""
+	}
+
+	dir := filepath.Dir(sourcePath)
+	base := filepath.Base(sourcePath)
+	ext := filepath.Ext(base)
+	name := strings.TrimSuffix(base, ext)
+
+	// Build potential test file patterns based on language conventions
+	var patterns []string
+
+	switch ext {
+	case ".go":
+		// Go: foo.go -> foo_test.go
+		patterns = append(patterns, filepath.Join(dir, name+"_test.go"))
+
+	case ".py":
+		// Python: foo.py -> test_foo.py or foo_test.py
+		patterns = append(patterns, filepath.Join(dir, "test_"+name+".py"))
+		patterns = append(patterns, filepath.Join(dir, name+"_test.py"))
+		// Also check tests/ subdirectory
+		patterns = append(patterns, filepath.Join("tests", "test_"+name+".py"))
+
+	case ".ts", ".tsx":
+		// TypeScript: foo.ts -> foo.test.ts or foo.spec.ts
+		patterns = append(patterns, filepath.Join(dir, name+".test"+ext))
+		patterns = append(patterns, filepath.Join(dir, name+".spec"+ext))
+		// Also check __tests__ directory
+		patterns = append(patterns, filepath.Join(dir, "__tests__", name+".test"+ext))
+
+	case ".js", ".jsx":
+		// JavaScript: same patterns as TypeScript
+		patterns = append(patterns, filepath.Join(dir, name+".test"+ext))
+		patterns = append(patterns, filepath.Join(dir, name+".spec"+ext))
+		patterns = append(patterns, filepath.Join(dir, "__tests__", name+".test"+ext))
+
+	case ".rb":
+		// Ruby (RSpec): foo.rb -> foo_spec.rb or spec/foo_spec.rb
+		patterns = append(patterns, filepath.Join(dir, name+"_spec.rb"))
+		// Handle lib/models/user.rb -> spec/models/user_spec.rb
+		if strings.HasPrefix(dir, "lib/") {
+			specDir := strings.Replace(dir, "lib/", "spec/", 1)
+			patterns = append(patterns, filepath.Join(specDir, name+"_spec.rb"))
+		}
+		// Also check spec/ at same level
+		patterns = append(patterns, filepath.Join("spec", filepath.Base(dir), name+"_spec.rb"))
+
+	case ".java":
+		// Java: Foo.java -> FooTest.java (in test/java path)
+		patterns = append(patterns, filepath.Join(dir, name+"Test.java"))
+		// Handle src/main/java/... -> src/test/java/...
+		if strings.Contains(dir, "src/main/java") {
+			testDir := strings.Replace(dir, "src/main/java", "src/test/java", 1)
+			patterns = append(patterns, filepath.Join(testDir, name+"Test.java"))
+		}
+
+	case ".rs":
+		// Rust: foo.rs -> tests/foo_test.rs or foo_test.rs
+		patterns = append(patterns, filepath.Join(dir, name+"_test.rs"))
+		patterns = append(patterns, filepath.Join("tests", name+"_test.rs"))
+
+	case ".c", ".cpp", ".h", ".hpp":
+		// C/C++: foo.c -> foo_test.c or test_foo.c
+		patterns = append(patterns, filepath.Join(dir, name+"_test"+ext))
+		patterns = append(patterns, filepath.Join(dir, "test_"+name+ext))
+		patterns = append(patterns, filepath.Join("tests", name+"_test"+ext))
+
+	case ".cs":
+		// C#: Foo.cs -> FooTests.cs or FooTest.cs
+		patterns = append(patterns, filepath.Join(dir, name+"Tests.cs"))
+		patterns = append(patterns, filepath.Join(dir, name+"Test.cs"))
+	}
+
+	// Check candidates against patterns
+	candidateSet := make(map[string]bool)
+	for _, c := range candidates {
+		candidateSet[c] = true
+	}
+
+	for _, pattern := range patterns {
+		if candidateSet[pattern] {
+			return pattern
+		}
+	}
+
+	return ""
+}
+
+// isTestFile returns true if the path appears to be a test file.
+func isTestFile(path string) bool {
+	base := filepath.Base(path)
+	dir := filepath.Dir(path)
+
+	// Check directory patterns
+	if strings.Contains(dir, "__tests__") || strings.HasPrefix(dir, "tests/") || strings.HasPrefix(dir, "test/") {
+		return true
+	}
+
+	ext := filepath.Ext(base)
+	name := strings.TrimSuffix(base, ext)
+
+	switch ext {
+	case ".go":
+		return strings.HasSuffix(name, "_test")
+
+	case ".py":
+		return strings.HasPrefix(name, "test_") || strings.HasSuffix(name, "_test")
+
+	case ".ts", ".tsx", ".js", ".jsx":
+		return strings.HasSuffix(name, ".test") || strings.HasSuffix(name, ".spec")
+
+	case ".rb":
+		return strings.HasSuffix(name, "_spec")
+
+	case ".java":
+		return strings.HasSuffix(name, "Test") || strings.HasSuffix(name, "Tests")
+
+	case ".rs":
+		return strings.HasSuffix(name, "_test")
+
+	case ".c", ".cpp", ".h", ".hpp":
+		return strings.HasSuffix(name, "_test") || strings.HasPrefix(name, "test_")
+
+	case ".cs":
+		return strings.HasSuffix(name, "Test") || strings.HasSuffix(name, "Tests")
+	}
+
+	return false
+}

--- a/internal/service/analysis/related_tests_test.go
+++ b/internal/service/analysis/related_tests_test.go
@@ -1,0 +1,162 @@
+package analysis
+
+import (
+	"testing"
+)
+
+// TestFindRelatedTestFile tests discovery of test files for source files.
+// Research justification: LLMs benefit from seeing tests alongside source code
+// because tests demonstrate expected usage patterns and edge cases. This is
+// especially valuable given the "Lost in the Middle" phenomenon where LLMs
+// perform best on context boundaries - tests provide natural examples at the
+// boundary of implementation.
+func TestFindRelatedTestFile(t *testing.T) {
+	tests := []struct {
+		name       string
+		sourcePath string
+		candidates []string // Available files in directory
+		wantTest   string   // Expected test file, empty if none
+	}{
+		{
+			name:       "Go source file with _test suffix",
+			sourcePath: "pkg/analyzer/complexity/complexity.go",
+			candidates: []string{
+				"pkg/analyzer/complexity/complexity.go",
+				"pkg/analyzer/complexity/complexity_test.go",
+				"pkg/analyzer/complexity/options.go",
+			},
+			wantTest: "pkg/analyzer/complexity/complexity_test.go",
+		},
+		{
+			name:       "Python source with test_ prefix",
+			sourcePath: "src/utils/parser.py",
+			candidates: []string{
+				"src/utils/parser.py",
+				"src/utils/test_parser.py",
+			},
+			wantTest: "src/utils/test_parser.py",
+		},
+		{
+			name:       "Python source with _test suffix",
+			sourcePath: "src/utils/parser.py",
+			candidates: []string{
+				"src/utils/parser.py",
+				"src/utils/parser_test.py",
+			},
+			wantTest: "src/utils/parser_test.py",
+		},
+		{
+			name:       "TypeScript source with .test. pattern",
+			sourcePath: "src/components/Button.tsx",
+			candidates: []string{
+				"src/components/Button.tsx",
+				"src/components/Button.test.tsx",
+			},
+			wantTest: "src/components/Button.test.tsx",
+		},
+		{
+			name:       "TypeScript source with .spec. pattern",
+			sourcePath: "src/services/api.ts",
+			candidates: []string{
+				"src/services/api.ts",
+				"src/services/api.spec.ts",
+			},
+			wantTest: "src/services/api.spec.ts",
+		},
+		{
+			name:       "JavaScript source in __tests__ directory",
+			sourcePath: "src/utils/format.js",
+			candidates: []string{
+				"src/utils/format.js",
+				"src/utils/__tests__/format.test.js",
+			},
+			wantTest: "src/utils/__tests__/format.test.js",
+		},
+		{
+			name:       "Ruby source with _spec suffix (RSpec)",
+			sourcePath: "lib/models/user.rb",
+			candidates: []string{
+				"lib/models/user.rb",
+				"spec/models/user_spec.rb",
+			},
+			wantTest: "spec/models/user_spec.rb",
+		},
+		{
+			name:       "Java source with Test suffix",
+			sourcePath: "src/main/java/com/example/UserService.java",
+			candidates: []string{
+				"src/main/java/com/example/UserService.java",
+				"src/test/java/com/example/UserServiceTest.java",
+			},
+			wantTest: "src/test/java/com/example/UserServiceTest.java",
+		},
+		{
+			name:       "Rust source with tests module pattern",
+			sourcePath: "src/parser.rs",
+			candidates: []string{
+				"src/parser.rs",
+				"tests/parser_test.rs",
+			},
+			wantTest: "tests/parser_test.rs",
+		},
+		{
+			name:       "No test file exists",
+			sourcePath: "pkg/utils/helper.go",
+			candidates: []string{
+				"pkg/utils/helper.go",
+				"pkg/utils/other.go",
+			},
+			wantTest: "",
+		},
+		{
+			name:       "Test file itself should not match",
+			sourcePath: "pkg/analyzer/complexity_test.go",
+			candidates: []string{
+				"pkg/analyzer/complexity.go",
+				"pkg/analyzer/complexity_test.go",
+			},
+			wantTest: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findRelatedTestFile(tt.sourcePath, tt.candidates)
+			if got != tt.wantTest {
+				t.Errorf("findRelatedTestFile(%q) = %q, want %q", tt.sourcePath, got, tt.wantTest)
+			}
+		})
+	}
+}
+
+// TestIsTestFile tests whether a file is identified as a test file.
+func TestIsTestFile(t *testing.T) {
+	tests := []struct {
+		path   string
+		isTest bool
+	}{
+		{"foo_test.go", true},
+		{"foo.go", false},
+		{"test_foo.py", true},
+		{"foo_test.py", true},
+		{"foo.py", false},
+		{"foo.test.ts", true},
+		{"foo.spec.ts", true},
+		{"foo.ts", false},
+		{"foo_spec.rb", true},
+		{"foo.rb", false},
+		{"FooTest.java", true},
+		{"Foo.java", false},
+		{"__tests__/foo.test.js", true},
+		{"tests/test_foo.py", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := isTestFile(tt.path)
+			if got != tt.isTest {
+				t.Errorf("isTestFile(%q) = %v, want %v", tt.path, got, tt.isTest)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds `--include-tests` flag to discover and display related test files when viewing focused context. When you focus on a source file with `omen context --focus foo.go --include-tests`, Omen will find and display the corresponding test file (e.g., `foo_test.go`).

## Research Justification

Tests are invaluable context for LLMs understanding code because they:

1. **Demonstrate expected usage patterns** - Tests show how functions/classes are meant to be called
2. **Document edge cases** - Test cases often cover boundary conditions and error scenarios
3. **Provide natural context boundaries** - Per Liu et al. 2023 "Lost in the Middle" research, LLMs perform best on content at the beginning and end of context - tests provide natural examples at the implementation boundary
4. **Reduce hallucination risk** - With test examples, LLMs are less likely to suggest APIs that don't match actual usage

## Implementation

### Test File Discovery

Supports common test naming conventions across languages:

| Language | Pattern Examples |
|----------|-----------------|
| Go | `foo.go` -> `foo_test.go` |
| Python | `foo.py` -> `test_foo.py` or `foo_test.py` |
| TypeScript/JS | `foo.ts` -> `foo.test.ts` or `foo.spec.ts` |
| Ruby | `foo.rb` -> `foo_spec.rb` (RSpec) |
| Java | `Foo.java` -> `FooTest.java` |
| Rust | `foo.rs` -> `tests/foo_test.rs` |
| C/C++ | `foo.c` -> `foo_test.c` or `test_foo.c` |

### New Files

- `internal/service/analysis/related_tests.go` - Test file discovery logic
- `internal/service/analysis/related_tests_test.go` - Unit tests (TDD)

### Usage

```bash
# Show focused context with related test file
omen context --focus pkg/parser/parser.go --include-tests

# Output includes:
## Related Test File
- **Path**: pkg/parser/parser_test.go
```

## Test Plan

- [x] Unit tests for `findRelatedTestFile()` with all language conventions
- [x] Unit tests for `isTestFile()` detection
- [x] Integration test with real Go files
- [x] Full test suite passes