### PR TITLE
fix: rename crate to omen-cli and reset version for release-please

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,8 +2188,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
-name = "omen"
-version = "4.0.0"
+name = "omen-cli"
+version = "3.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "omen"
-version = "4.0.0"
+name = "omen-cli"
+version = "3.3.0"
 edition = "2021"
 rust-version = "1.92"
 authors = ["Panbanda"]

--- a/README.md
+++ b/README.md
@@ -623,7 +623,7 @@ brew install panbanda/omen/omen
 ### Cargo Install
 
 ```bash
-cargo install omen
+cargo install omen-cli
 ```
 
 ### Docker


### PR DESCRIPTION
## Summary

- Rename crate from `omen` to `omen-cli` for crates.io publishing
- Reset version to 3.3.0 so release-please can bump to 4.0.0
- Update README with correct `cargo install omen-cli` command

## Context

Release-please won't create a PR if Cargo.toml already has the target version. Both Cargo.toml and manifest must be at 3.3.0 for release-please to properly detect the breaking changes (including `feat!: complete Rust rewrite`) and create the 4.0.0 release.

The previous PR (#207) reset the manifest but not Cargo.toml, and didn't include the crate rename.

## Test plan

- [ ] CI passes
- [ ] After merge, release-please creates a new release PR for omen-cli v4.0.0
- [ ] When that PR merges, binaries build and Docker images are pushed

Generated with Claude Code