### PR TITLE
chore: consolidate homebrew tap to panbanda/brews

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,7 +180,7 @@ jobs:
           EOF
 
           if [ -n "$HOMEBREW_TAP_GITHUB_TOKEN" ]; then
-            git clone "https://x-access-token:${HOMEBREW_TAP_GITHUB_TOKEN}@github.com/panbanda/homebrew-omen.git" tap
+            git clone "https://x-access-token:${HOMEBREW_TAP_GITHUB_TOKEN}@github.com/panbanda/homebrew-brews.git" tap
             mkdir -p tap/Formula
             cp omen.rb tap/Formula/omen.rb
 

--- a/README.md
+++ b/README.md
@@ -825,7 +825,7 @@ Go, Rust, Python, TypeScript, JavaScript, TSX/JSX, Java, C, C++, C#, Ruby, PHP, 
 ### Homebrew (macOS/Linux)
 
 ```bash
-brew install panbanda/omen/omen
+brew install panbanda/brews/omen
 ```
 
 ### Cargo Install


### PR DESCRIPTION
## Summary
- Update release workflow to publish formula to `panbanda/homebrew-brews` instead of `panbanda/homebrew-omen`
- Update README install instructions to use `brew install panbanda/brews/omen`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Homebrew installation tap location and corresponding installation instructions in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->