### PR TITLE
fix(docker): use distroless/cc base so glibc binary can start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM gcr.io/distroless/cc-debian12:nonroot
 COPY omen /omen
 ENTRYPOINT ["/omen"]


### PR DESCRIPTION
Switch the Dockerfile base image from `gcr.io/distroless/static-debian12:nonroot` to `gcr.io/distroless/cc-debian12:nonroot`.

Users reported that recent `ghcr.io/panbanda/omen` tags fail to run on both amd64 and arm64 with a "missing executable / missing interpreter" error, even though `/omen` exists in the image. Root cause: the release pipeline (`.github/workflows/release.yml`) ships glibc-linked `*-unknown-linux-gnu` binaries, but the previous `distroless/static` base intentionally has no dynamic loader. The kernel returns ENOENT on `/lib64/ld-linux-x86-64.so.2` (and the arm64 equivalent), which surfaces as the misleading entrypoint error.

`distroless/cc` ships glibc and libgcc, matching what the released binaries need. The release tarballs themselves are unchanged, so Homebrew and direct downloads are unaffected.

### Why not switch to musl

A fully-static alternative is to add `*-unknown-linux-musl` targets and keep `distroless/static`. Skipped for this fix because it would change the Linux artifacts downstream consumers already depend on and introduce musl-vs-glibc behavior differences (DNS, threading, locales) needing separate validation. Can revisit as a follow-up if a smaller image is desired.

### Out of scope

`omen` shells out to the `git` binary in several analyzers. Neither `distroless/static` nor `distroless/cc` ship `git`, so analyzers depending on git history will still fail inside the container — pre-existing limitation, not the reported bug. Worth a follow-up to either swap to `debian:stable-slim` or publish an `omen:full` tag.

### Verification

Local smoke test against the current release tarball:

\`\`\`
gh release download omen-vX.Y.Z --pattern 'omen_X.Y.Z_x86_64-unknown-linux-gnu.tar.gz'
tar xzf omen_X.Y.Z_x86_64-unknown-linux-gnu.tar.gz && chmod +x omen
docker build -t omen:test .
docker run --rm omen:test --version
\`\`\`

After release-please cuts the next tag, repeat with the published image on both `linux/amd64` and `linux/arm64`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container base image for runtime compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->