### PR TITLE
chore(deps): upgrade tree-sitter packages to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,7 +875,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2378,7 +2378,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2700,7 +2700,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3654,7 +3654,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3933,7 +3933,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3990,7 +3990,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4145,6 +4145,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -4374,7 +4375,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4677,22 +4678,23 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.24.7"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5387dffa7ffc7d2dae12b50c6f7aab8ff79d6210147c6613561fc3d474c6f75"
+checksum = "887bd495d0582c5e3e0d8ece2233666169fa56a9644d172fc22ad179ab2d0538"
 dependencies = [
  "cc",
  "regex",
  "regex-syntax",
+ "serde_json",
  "streaming-iterator",
  "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-bash"
-version = "0.23.3"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329a4d48623ac337d42b1df84e81a1c9dbb2946907c102ca72db158c1964a52e"
+checksum = "9e5ec769279cc91b561d3df0d8a5deb26b0ad40d183127f409494d6d8fc53062"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -4700,9 +4702,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-c"
-version = "0.23.4"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afd2b1bf1585dc2ef6d69e87d01db8adb059006649dd5f96f31aa789ee6e9c71"
+checksum = "a9b2eb57a55fed6b00812912e730b7a275cf4fe98bfd6a5d76263d4438371728"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -4710,9 +4712,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-c-sharp"
-version = "0.23.1"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67f06accca7b45351758663b8215089e643d53bd9a660ce0349314263737fcb0"
+checksum = "c1aac67f1ad71de1d6d39708d34811081c26dfa495658de6c14c34200849357c"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -4730,9 +4732,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-go"
-version = "0.23.4"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13d476345220dbe600147dd444165c5791bf85ef53e28acbedd46112ee18431"
+checksum = "c8560a4d2f835cc0d4d2c2e03cbd0dde2f6114b43bc491164238d333e28b16ea"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -4750,9 +4752,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-javascript"
-version = "0.23.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf40bf599e0416c16c125c3cec10ee5ddc7d1bb8b0c60fa5c4de249ad34dc1b1"
+checksum = "68204f2abc0627a90bdf06e605f5c470aa26fdcb2081ea553a04bdad756693f5"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -4766,9 +4768,9 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-php"
-version = "0.23.11"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f066e94e9272cfe4f1dcb07a1c50c66097eca648f2d7233d299c8ae9ed8c130c"
+checksum = "0d8c17c3ab69052c5eeaa7ff5cd972dd1bc25d1b97ee779fec391ad3b5df5592"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -4776,9 +4778,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-python"
-version = "0.23.6"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d065aaa27f3aaceaf60c1f0e0ac09e1cb9eb8ed28e7bcdaa52129cffc7f4b04"
+checksum = "6bf85fd39652e740bf60f46f4cda9492c3a9ad75880575bf14960f775cb74a1c"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -4796,9 +4798,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-rust"
-version = "0.23.3"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8ccb3e3a3495c8a943f6c3fd24c3804c471fd7f4f16087623c7fa4c0068e8a"
+checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -5121,7 +5123,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,20 +32,20 @@ serde_json = "1.0"
 figment = { version = "0.10", features = ["toml", "env"] }
 
 # Tree-sitter for parsing
-tree-sitter = "0.24"
+tree-sitter = "0.26"
 streaming-iterator = "0.1"
-tree-sitter-go = "0.23"
-tree-sitter-rust = "0.23"
-tree-sitter-python = "0.23"
+tree-sitter-go = "0.25"
+tree-sitter-rust = "0.24"
+tree-sitter-python = "0.25"
 tree-sitter-typescript = "0.23"
-tree-sitter-javascript = "0.23"
+tree-sitter-javascript = "0.25"
 tree-sitter-java = "0.23"
-tree-sitter-c = "0.23"
+tree-sitter-c = "0.24"
 tree-sitter-cpp = "0.23"
 tree-sitter-c-sharp = "0.23"
 tree-sitter-ruby = "0.23"
-tree-sitter-php = "0.23"
-tree-sitter-bash = "0.23"
+tree-sitter-php = "0.24"
+tree-sitter-bash = "0.25"
 
 # Git operations
 gix = { version = "0.78", default-features = false, features = ["blocking-network-client", "blocking-http-transport-reqwest-rust-tls", "revision", "blob-diff", "merge", "blame"] }

--- a/src/analyzers/cohesion.rs
+++ b/src/analyzers/cohesion.rs
@@ -394,12 +394,12 @@ fn extract_go_classes(path: &Path, source: &[u8], tree: &tree_sitter::Tree) -> V
 
     // Phase 1: Collect type declarations that contain struct_type
     let mut struct_defs: Vec<(String, tree_sitter::Node)> = Vec::new();
-    for i in 0..root.child_count() {
+    for i in 0..root.child_count() as u32 {
         let child = match root.child(i) {
             Some(c) if c.kind() == "type_declaration" => c,
             _ => continue,
         };
-        for j in 0..child.child_count() {
+        for j in 0..child.child_count() as u32 {
             if let Some(spec) = child.child(j) {
                 if spec.kind() == "type_spec" && has_child_of_kind(&spec, "struct_type") {
                     if let Some(name) = node_name_text(&spec, source) {
@@ -412,7 +412,7 @@ fn extract_go_classes(path: &Path, source: &[u8], tree: &tree_sitter::Tree) -> V
 
     // Phase 2: Collect method declarations and group by receiver type
     let mut method_map: HashMap<String, Vec<tree_sitter::Node>> = HashMap::new();
-    for i in 0..root.child_count() {
+    for i in 0..root.child_count() as u32 {
         let child = match root.child(i) {
             Some(c) if c.kind() == "method_declaration" => c,
             _ => continue,
@@ -517,7 +517,7 @@ fn collect_nodes_by_kind<'a>(
     source: &[u8],
     out: &mut Vec<(String, tree_sitter::Node<'a>)>,
 ) {
-    for i in 0..root.child_count() {
+    for i in 0..root.child_count() as u32 {
         let child = match root.child(i) {
             Some(c) if c.kind() == kind => c,
             _ => continue,
@@ -534,7 +534,7 @@ fn collect_impl_blocks<'a>(
     source: &[u8],
     out: &mut Vec<(String, tree_sitter::Node<'a>)>,
 ) {
-    for i in 0..root.child_count() {
+    for i in 0..root.child_count() as u32 {
         let child = match root.child(i) {
             Some(c) if c.kind() == "impl_item" => c,
             _ => continue,
@@ -569,7 +569,7 @@ fn extract_go_receiver_type(node: &tree_sitter::Node, source: &[u8]) -> Option<S
     // method_declaration has a "receiver" field containing parameter_list
     let receiver = node.child_by_field_name("receiver")?;
     // Walk through the parameter list to find the type
-    for i in 0..receiver.child_count() {
+    for i in 0..receiver.child_count() as u32 {
         if let Some(param) = receiver.child(i) {
             if param.kind() == "parameter_declaration" {
                 // The type may be a pointer_type (*Server) or type_identifier (Server)
@@ -587,7 +587,7 @@ fn extract_go_base_type(node: &tree_sitter::Node, source: &[u8]) -> Option<Strin
     match node.kind() {
         "pointer_type" => {
             // *Server -> look for the inner type_identifier
-            for i in 0..node.child_count() {
+            for i in 0..node.child_count() as u32 {
                 if let Some(child) = node.child(i) {
                     if child.kind() == "type_identifier" {
                         return std::str::from_utf8(&source[child.byte_range()])
@@ -617,7 +617,7 @@ fn node_name_text(node: &tree_sitter::Node, source: &[u8]) -> Option<String> {
 
 /// Checks if a node has a child of the given kind.
 fn has_child_of_kind(node: &tree_sitter::Node, kind: &str) -> bool {
-    for i in 0..node.child_count() {
+    for i in 0..node.child_count() as u32 {
         if let Some(child) = node.child(i) {
             if child.kind() == kind {
                 return true;
@@ -792,7 +792,7 @@ fn first_child_text_by_kind(
     source: &[u8],
     kinds: &[&str],
 ) -> Option<String> {
-    for i in 0..parent.child_count() {
+    for i in 0..parent.child_count() as u32 {
         let child = parent.child(i)?;
         if kinds.contains(&child.kind()) {
             return std::str::from_utf8(&source[child.byte_range()])
@@ -856,7 +856,7 @@ fn find_child_by_kind<'a>(
     node: &tree_sitter::Node<'a>,
     kind: &str,
 ) -> Option<tree_sitter::Node<'a>> {
-    for i in 0..node.child_count() {
+    for i in 0..node.child_count() as u32 {
         let child = node.child(i)?;
         if child.kind() == kind {
             return Some(child);

--- a/src/analyzers/deadcode.rs
+++ b/src/analyzers/deadcode.rs
@@ -1008,7 +1008,7 @@ fn collect_function_value_refs(
     let args_node = call_node.child_by_field_name("arguments").or_else(|| {
         // Some grammars (Go) use "argument_list" as the node kind
         // rather than a named field
-        (0..call_node.child_count())
+        (0..call_node.child_count() as u32)
             .filter_map(|i| call_node.child(i))
             .find(|c| c.kind() == "argument_list")
     });
@@ -1018,7 +1018,7 @@ fn collect_function_value_refs(
         None => return,
     };
 
-    for i in 0..args_node.child_count() {
+    for i in 0..args_node.child_count() as u32 {
         let arg = match args_node.child(i) {
             Some(a) => a,
             None => continue,

--- a/src/analyzers/mutation/equivalent/features.rs
+++ b/src/analyzers/mutation/equivalent/features.rs
@@ -319,7 +319,7 @@ fn affects_return_value(node: &tree_sitter::Node<'_>) -> bool {
         }
         // In Rust, the last expression in a block is implicitly returned
         if kind == "block" {
-            if let Some(last_child) = parent.child(parent.child_count().saturating_sub(2)) {
+            if let Some(last_child) = parent.child(parent.child_count().saturating_sub(2) as u32) {
                 if last_child.start_byte() <= current.start_byte()
                     && current.end_byte() <= last_child.end_byte()
                 {

--- a/src/analyzers/mutation/operators/go/error.rs
+++ b/src/analyzers/mutation/operators/go/error.rs
@@ -140,9 +140,20 @@ impl GoErrorOperator {
             return None;
         }
 
-        // Check if block contains a return statement with error
+        // Check if block contains a return statement with error.
+        // tree-sitter-go 0.25+ wraps block contents in a `statement_list` node,
+        // so we descend through it when present.
         let mut has_error_return = false;
-        for child in consequence.children(&mut consequence.walk()) {
+        let mut cursor = consequence.walk();
+        let stmt_iter = consequence.children(&mut cursor).flat_map(|child| {
+            if child.kind() == "statement_list" {
+                let mut sub = child.walk();
+                child.children(&mut sub).collect::<Vec<_>>()
+            } else {
+                vec![child]
+            }
+        });
+        for child in stmt_iter {
             if child.kind() == "return_statement" {
                 if let Ok(text) = child.utf8_text(&result.source) {
                     if text.contains("err") {

--- a/src/analyzers/mutation/operators/python/identity.rs
+++ b/src/analyzers/mutation/operators/python/identity.rs
@@ -64,7 +64,7 @@ impl PythonIdentityOperator {
         };
 
         // Look for specific operators in children
-        for i in 0..node.child_count() {
+        for i in 0..node.child_count() as u32 {
             let child = match node.child(i) {
                 Some(c) => c,
                 None => continue,

--- a/src/analyzers/repomap.rs
+++ b/src/analyzers/repomap.rs
@@ -492,7 +492,7 @@ fn get_call_node_kinds(lang: Language) -> Vec<&'static str> {
 /// Extract the function name from a call expression.
 fn extract_call_name(node: &tree_sitter::Node<'_>, source: &[u8]) -> Option<String> {
     // Try to find the function/identifier node
-    for i in 0..node.child_count() {
+    for i in 0..node.child_count() as u32 {
         if let Some(child) = node.child(i) {
             let kind = child.kind();
             if kind == "identifier"
@@ -509,7 +509,7 @@ fn extract_call_name(node: &tree_sitter::Node<'_>, source: &[u8]) -> Option<Stri
                 if let Some(right) = child
                     .child_by_field_name("field")
                     .or_else(|| child.child_by_field_name("property"))
-                    .or_else(|| child.child(child.child_count().saturating_sub(1)))
+                    .or_else(|| child.child(child.child_count().saturating_sub(1) as u32))
                 {
                     let text = right.utf8_text(source).ok()?;
                     return Some(text.to_string());


### PR DESCRIPTION
Supersedes #272 — bundles the renovate dep bumps with the code adaptations needed to compile against the new APIs.

## Dependency bumps
- tree-sitter 0.24 → 0.26
- tree-sitter-bash 0.23 → 0.25
- tree-sitter-c 0.23 → 0.24
- tree-sitter-c-sharp 0.23.1 → 0.23.5
- tree-sitter-go 0.23 → 0.25
- tree-sitter-javascript 0.23 → 0.25
- tree-sitter-php 0.23 → 0.24
- tree-sitter-python 0.23 → 0.25
- tree-sitter-rust 0.23 → 0.24

## Code changes required by the upgrades

**tree-sitter 0.26**: \`Node::child(i)\` now takes \`u32\` instead of \`usize\`. Cast loop indices and \`saturating_sub\` results in:
- \`src/analyzers/cohesion.rs\`
- \`src/analyzers/deadcode.rs\`
- \`src/analyzers/repomap.rs\`
- \`src/analyzers/mutation/equivalent/features.rs\`
- \`src/analyzers/mutation/operators/python/identity.rs\`

**tree-sitter-go 0.25**: Block bodies are now wrapped in a \`statement_list\` node. Updated \`GoErrorOperator::try_mutate_error_return\` to descend through the wrapper when looking for \`return_statement\` children. Without this, \`test_swallow_error_return\` regresses.

## Verification

- \`cargo build\` ✓
- \`cargo clippy --all-targets --all-features -- -D warnings\` ✓
- \`cargo fmt --check\` ✓
- \`cargo test\`: same pass/fail set as \`main\` (the 32 pre-existing failures are git-env-related, identical on both branches).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Updated Tree-sitter core and language grammars to latest versions for improved language support and stability

* **Bug Fixes**
  * Fixed Go error handling in mutation analysis to properly detect return statements in newer AST structures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->