### PR TITLE
Fix Graphify audit findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,11 @@ Cargo.lock
 # Omen generated files
 .omen/
 
+# Graphify generated files
+/graphify-out/
+/GRAPH_REPORT.md
+/graph.json
+
 # Profiling data
 perf.data
 perf.data.old

--- a/src/analyzers/complexity.rs
+++ b/src/analyzers/complexity.rs
@@ -378,7 +378,7 @@ fn find_function_at_line<'a>(
         // Only descend if line is within this node's range
         if start <= line && line <= end {
             let kind = node.kind();
-            if kind.contains("function") || kind.contains("method") || kind == "impl_item" {
+            if kind.contains("function") || kind.contains("method") {
                 return Some(node);
             }
 
@@ -929,6 +929,39 @@ fn nested(x: i32, y: i32) {
         // Nested if should have higher cognitive complexity
         assert!(result.functions[0].metrics.cognitive >= 2);
         assert!(result.functions[0].metrics.max_nesting >= 2);
+    }
+
+    #[test]
+    fn test_complexity_rust_impl_methods_are_measured_individually() {
+        let code = br#"
+struct Service;
+
+impl Service {
+    fn simple(&self) {
+        println!("simple");
+    }
+
+    fn branchy(&self, x: i32) {
+        if x > 0 {
+            println!("positive");
+        }
+    }
+}
+"#;
+        let result = parse_and_analyze(code, Language::Rust, "test.rs");
+        let simple = result
+            .functions
+            .iter()
+            .find(|f| f.name == "simple")
+            .expect("simple method should be extracted");
+        let branchy = result
+            .functions
+            .iter()
+            .find(|f| f.name == "branchy")
+            .expect("branchy method should be extracted");
+
+        assert_eq!(simple.metrics.cyclomatic, 1);
+        assert!(branchy.metrics.cyclomatic > simple.metrics.cyclomatic);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use rayon::ThreadPoolBuilder;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 use omen::cli::{
-    Cli, Command, ComplexityArgs, McpSubcommand, MutationArgs, MutationSubcommand,
+    AnalyzerArgs, Cli, Command, ComplexityArgs, McpSubcommand, MutationArgs, MutationSubcommand,
     MutationTrainArgs, OutputFormat, ReportSubcommand, ScoreArgs, ScoreSubcommand,
     SearchSubcommand,
 };
@@ -150,14 +150,19 @@ fn run_with_path(cli: &Cli, path: &PathBuf) -> omen::core::Result<()> {
             if args.check {
                 run_complexity_check(path, &config, args)?;
             } else {
-                run_analyzer::<omen::analyzers::complexity::Analyzer>(path, &config, format)?;
+                run_analyzer::<omen::analyzers::complexity::Analyzer>(
+                    path,
+                    &config,
+                    format,
+                    Some(&args.common),
+                )?;
             }
         }
         Command::Diff(args) => {
             run_diff_analyzer(path, args.target.as_deref(), format)?;
         }
-        Command::Changes(_) => {
-            run_changes_analyzer(path, &config, format)?;
+        Command::Changes(args) => {
+            run_changes_analyzer(path, &config, format, args)?;
         }
         Command::Satd(_)
         | Command::Deadcode(_)
@@ -174,7 +179,7 @@ fn run_with_path(cli: &Cli, path: &PathBuf) -> omen::core::Result<()> {
             dispatch_analyzer(&cli.command, path, &config, format)?;
         }
         Command::Churn(args) => {
-            run_churn_analyzer(path, &config, format, args.days)?;
+            run_churn_analyzer(path, &config, format, args.days, &args.common)?;
         }
         Command::Flags(args) => {
             // Merge CLI --provider option into config
@@ -185,7 +190,12 @@ fn run_with_path(cli: &Cli, path: &PathBuf) -> omen::core::Result<()> {
             if args.stale_days > 0 {
                 config.feature_flags.stale_days = args.stale_days;
             }
-            run_analyzer::<omen::analyzers::flags::Analyzer>(path, &config, format)?;
+            run_analyzer::<omen::analyzers::flags::Analyzer>(
+                path,
+                &config,
+                format,
+                Some(&args.common),
+            )?;
         }
         Command::Score(cmd) => {
             if cmd.args.check {
@@ -264,7 +274,7 @@ fn run_with_path(cli: &Cli, path: &PathBuf) -> omen::core::Result<()> {
                         }
                     }
                     None => {
-                        run_analyzer::<omen::score::Analyzer>(path, &config, format)?;
+                        run_analyzer::<omen::score::Analyzer>(path, &config, format, None)?;
                     }
                 }
             }
@@ -371,7 +381,7 @@ fn run_with_path(cli: &Cli, path: &PathBuf) -> omen::core::Result<()> {
             run_report(path, &config, &cmd.subcommand)?;
         }
         Command::Search(ref cmd) => {
-            run_search(&cli.path, &config, cmd.subcommand.clone(), format)?;
+            run_search(path, &config, cmd.subcommand.clone(), format)?;
         }
         Command::Mutation(ref cmd) => match &cmd.subcommand {
             Some(MutationSubcommand::Train(args)) => {
@@ -411,46 +421,70 @@ fn dispatch_analyzer(
     format: Format,
 ) -> omen::core::Result<()> {
     match command {
-        Command::Satd(_) => run_analyzer::<omen::analyzers::satd::Analyzer>(path, config, format),
-        Command::Deadcode(_) => {
-            run_analyzer::<omen::analyzers::deadcode::Analyzer>(path, config, format)
+        Command::Satd(args) => {
+            run_analyzer::<omen::analyzers::satd::Analyzer>(path, config, format, Some(args))
         }
-        Command::Clones(_) => {
-            run_analyzer::<omen::analyzers::duplicates::Analyzer>(path, config, format)
+        Command::Deadcode(args) => {
+            run_analyzer::<omen::analyzers::deadcode::Analyzer>(path, config, format, Some(args))
         }
-        Command::Defect(_) => {
-            run_analyzer::<omen::analyzers::defect::Analyzer>(path, config, format)
+        Command::Clones(args) => {
+            run_analyzer::<omen::analyzers::duplicates::Analyzer>(path, config, format, Some(args))
         }
-        Command::Tdg(_) => run_analyzer::<omen::analyzers::tdg::Analyzer>(path, config, format),
-        Command::Graph(_) => run_analyzer::<omen::analyzers::graph::Analyzer>(path, config, format),
-        Command::Hotspot(_) => {
-            run_analyzer::<omen::analyzers::hotspot::Analyzer>(path, config, format)
+        Command::Defect(args) => {
+            run_analyzer::<omen::analyzers::defect::Analyzer>(path, config, format, Some(args))
         }
-        Command::Temporal(_) => {
-            run_analyzer::<omen::analyzers::temporal::Analyzer>(path, config, format)
+        Command::Tdg(args) => {
+            run_analyzer::<omen::analyzers::tdg::Analyzer>(path, config, format, Some(args))
         }
-        Command::Ownership(_) => {
-            run_analyzer::<omen::analyzers::ownership::Analyzer>(path, config, format)
+        Command::Graph(args) => {
+            run_analyzer::<omen::analyzers::graph::Analyzer>(path, config, format, Some(args))
         }
-        Command::Cohesion(_) => {
-            run_analyzer::<omen::analyzers::cohesion::Analyzer>(path, config, format)
+        Command::Hotspot(args) => {
+            run_analyzer::<omen::analyzers::hotspot::Analyzer>(path, config, format, Some(args))
         }
-        Command::Repomap(_) => {
-            run_analyzer::<omen::analyzers::repomap::Analyzer>(path, config, format)
+        Command::Temporal(args) => {
+            run_analyzer::<omen::analyzers::temporal::Analyzer>(path, config, format, Some(args))
         }
-        Command::Smells(_) => {
-            run_analyzer::<omen::analyzers::smells::Analyzer>(path, config, format)
+        Command::Ownership(args) => {
+            run_analyzer::<omen::analyzers::ownership::Analyzer>(path, config, format, Some(args))
+        }
+        Command::Cohesion(args) => {
+            run_analyzer::<omen::analyzers::cohesion::Analyzer>(path, config, format, Some(args))
+        }
+        Command::Repomap(args) => {
+            run_analyzer::<omen::analyzers::repomap::Analyzer>(path, config, format, Some(args))
+        }
+        Command::Smells(args) => {
+            run_analyzer::<omen::analyzers::smells::Analyzer>(path, config, format, Some(args))
         }
         _ => unreachable!("dispatch_analyzer called with non-dispatched command"),
     }
+}
+
+fn filtered_file_set(
+    path: &PathBuf,
+    config: &Config,
+    args: Option<&AnalyzerArgs>,
+) -> omen::core::Result<FileSet> {
+    let mut file_set = FileSet::from_path(path, config)?;
+    if let Some(args) = args {
+        if let Some(ref glob) = args.glob {
+            file_set = file_set.filter_by_glob(glob);
+        }
+        if let Some(ref exclude) = args.exclude {
+            file_set = file_set.exclude_by_glob(exclude);
+        }
+    }
+    Ok(file_set)
 }
 
 fn run_analyzer<A: Analyzer + Default>(
     path: &PathBuf,
     config: &Config,
     format: Format,
+    args: Option<&AnalyzerArgs>,
 ) -> omen::core::Result<()> {
-    let file_set = FileSet::from_path(path, config)?;
+    let file_set = filtered_file_set(path, config, args)?;
 
     // Show analysis progress
     let spinner = if is_tty() {
@@ -502,9 +536,14 @@ fn run_diff_analyzer(path: &Path, target: Option<&str>, format: Format) -> omen:
     Ok(())
 }
 
-fn run_changes_analyzer(path: &Path, config: &Config, format: Format) -> omen::core::Result<()> {
-    let file_set = FileSet::from_path(path, config)?;
+fn run_changes_analyzer(
+    path: &Path,
+    config: &Config,
+    format: Format,
+    args: &AnalyzerArgs,
+) -> omen::core::Result<()> {
     let path_buf = path.to_path_buf();
+    let file_set = filtered_file_set(&path_buf, config, Some(args))?;
     let ctx = build_context(&path_buf, &file_set, config);
     let analyzer = omen::analyzers::changes::Analyzer::new().with_days(config.changes.days);
     let result = analyzer.analyze(&ctx)?;
@@ -517,7 +556,7 @@ fn run_complexity_check(
     config: &Config,
     args: &ComplexityArgs,
 ) -> omen::core::Result<()> {
-    let file_set = FileSet::from_path(path, config)?;
+    let file_set = filtered_file_set(path, config, Some(&args.common))?;
     let ctx = build_context(path, &file_set, config);
 
     let analyzer = omen::analyzers::complexity::Analyzer::default();
@@ -592,8 +631,9 @@ fn run_churn_analyzer(
     config: &Config,
     format: Format,
     days: u32,
+    args: &AnalyzerArgs,
 ) -> omen::core::Result<()> {
-    let file_set = FileSet::from_path(path, config)?;
+    let file_set = filtered_file_set(path, config, Some(args))?;
     let ctx = build_context(path, &file_set, config);
     let analyzer = omen::analyzers::churn::Analyzer::new().with_days(days);
     let result = analyzer.analyze(&ctx)?;

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -363,7 +363,7 @@ impl McpServer {
         // Try to open a git repository at the path
         let git_root = GitRepo::open(&path).ok().map(|r| r.root().to_path_buf());
 
-        let mut ctx = AnalysisContext::new(&file_set, &self.config, Some(&self.root_path));
+        let mut ctx = AnalysisContext::new(&file_set, &self.config, Some(&path));
         if let Some(ref git_path) = git_root {
             ctx = ctx.with_git_path(git_path);
         }
@@ -816,6 +816,31 @@ mod tests {
         assert!(result.is_ok());
         let response = result.unwrap();
         assert!(response.get("content").is_some());
+    }
+
+    #[test]
+    fn test_handle_tool_call_uses_requested_path_as_analysis_root() {
+        let (server, _server_root) = create_test_server();
+        let target_dir = TempDir::new().unwrap();
+        std::fs::write(
+            target_dir.path().join("target.rs"),
+            "fn target_function() {}\n",
+        )
+        .unwrap();
+
+        let params = json!({
+            "name": "complexity",
+            "arguments": {"path": target_dir.path().to_str().unwrap()}
+        });
+        let response = server.handle_tool_call(Some(params)).unwrap();
+        let text = response["content"][0]["text"]
+            .as_str()
+            .expect("tool response text should be a string");
+
+        assert!(
+            text.contains("target_function"),
+            "expected MCP analysis to read files from requested path, got {text}"
+        );
     }
 
     #[test]

--- a/src/semantic/sync.rs
+++ b/src/semantic/sync.rs
@@ -71,8 +71,8 @@ impl<'a> SyncManager<'a> {
 
         // Find files to remove (deleted or moved)
         for indexed_path in &indexed_files {
-            let full_path = root_path.join(indexed_path);
-            if !current_files.contains(&full_path) {
+            let indexed_current_path = indexed_path_for_comparison(indexed_path, root_path);
+            if !current_files.contains(&indexed_current_path) {
                 self.cache.remove_file(indexed_path)?;
                 stats.removed += 1;
             }
@@ -81,16 +81,19 @@ impl<'a> SyncManager<'a> {
         // Check each current file for changes
         let files_to_index: Vec<_> = current_files
             .iter()
-            .filter(|path| {
-                let rel_path = path
-                    .strip_prefix(root_path)
-                    .unwrap_or(path)
-                    .to_string_lossy()
-                    .to_string();
+            .filter_map(|path| {
+                let full_path = root_path.join(path);
+                let rel_path = path.to_string_lossy().to_string();
 
-                self.check_file_changed(path, &rel_path).unwrap_or(true)
+                if self
+                    .check_file_changed(&full_path, &rel_path)
+                    .unwrap_or(true)
+                {
+                    Some(full_path)
+                } else {
+                    None
+                }
             })
-            .cloned()
             .collect();
 
         stats.checked = current_files.len();
@@ -308,6 +311,13 @@ fn parse_file(path: &Path, root_path: &Path) -> Result<ParsedFile> {
     })
 }
 
+fn indexed_path_for_comparison(indexed_path: &str, root_path: &Path) -> PathBuf {
+    let path = Path::new(indexed_path);
+    path.strip_prefix(root_path)
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|_| path.to_path_buf())
+}
+
 /// Statistics from a sync operation.
 #[derive(Debug, Default, Clone)]
 pub struct SyncStats {
@@ -428,5 +438,56 @@ mod tests {
         assert_eq!(stats.removed, 0);
         assert_eq!(stats.symbols, 0);
         assert_eq!(stats.errors, 0);
+    }
+
+    #[test]
+    fn test_sync_indexes_files_relative_to_root_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let nested = temp.path().join("only_in_temp");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(
+            nested.join("unique_semantic_sync_fixture.rs"),
+            "fn indexed_symbol() {}\n",
+        )
+        .unwrap();
+
+        let config = crate::config::Config::default();
+        let file_set = FileSet::from_path(temp.path(), &config).unwrap();
+        let cache = EmbeddingCache::in_memory().unwrap();
+        let sync = SyncManager::new(&cache);
+
+        let stats = sync.sync(&file_set, temp.path()).unwrap();
+
+        assert_eq!(stats.checked, 1);
+        assert_eq!(stats.indexed, 1);
+        assert_eq!(stats.errors, 0);
+        assert_eq!(cache.symbol_count().unwrap(), 1);
+
+        let stats2 = sync.sync(&file_set, temp.path()).unwrap();
+        assert_eq!(stats2.checked, 1);
+        assert_eq!(stats2.indexed, 0);
+        assert_eq!(stats2.removed, 0);
+        assert_eq!(stats2.errors, 0);
+        assert_eq!(cache.symbol_count().unwrap(), 1);
+    }
+
+    #[test]
+    fn test_sync_matches_absolute_indexed_paths_to_relative_file_set() {
+        let temp = tempfile::tempdir().unwrap();
+        let file_path = temp.path().join("legacy_absolute_path.rs");
+        std::fs::write(&file_path, "fn legacy_symbol() {}\n").unwrap();
+
+        let config = crate::config::Config::default();
+        let file_set = FileSet::from_path(temp.path(), &config).unwrap();
+        let cache = EmbeddingCache::in_memory().unwrap();
+        cache
+            .record_file_indexed(file_path.to_string_lossy().as_ref(), "legacy-hash")
+            .unwrap();
+
+        let sync = SyncManager::new(&cache);
+        let stats = sync.sync(&file_set, temp.path()).unwrap();
+
+        assert_eq!(stats.checked, 1);
+        assert_eq!(stats.removed, 0);
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -376,10 +376,56 @@ fn test_glob_filter() {
         .expect("command runs");
 
     let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("complexity output should be valid JSON");
+    let files = parsed["files"]
+        .as_array()
+        .expect("files should be an array");
     assert!(
-        stdout.contains(".py"),
-        "expected .py files in filtered output"
+        !files.is_empty(),
+        "expected filtered output to include files"
     );
+    for file in files {
+        let path = file["path"].as_str().expect("file path should be a string");
+        assert!(
+            path.ends_with(".py"),
+            "expected only Python files in filtered output, got {path}"
+        );
+    }
+}
+
+#[test]
+fn test_exclude_filter() {
+    let output = omen()
+        .args([
+            "-p",
+            fixtures_dir(),
+            "-f",
+            "json",
+            "complexity",
+            "-e",
+            "*.py",
+        ])
+        .output()
+        .expect("command runs");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("complexity output should be valid JSON");
+    let files = parsed["files"]
+        .as_array()
+        .expect("files should be an array");
+    assert!(
+        !files.is_empty(),
+        "expected output to include non-Python files"
+    );
+    for file in files {
+        let path = file["path"].as_str().expect("file path should be a string");
+        assert!(
+            !path.ends_with(".py"),
+            "expected Python files to be excluded, got {path}"
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- ran Graphify static extraction on the repo: 4,446 nodes, 7,548 links, 280 communities
- fixed security/path correctness issues in MCP and semantic search indexing
- fixed usability issue where CLI glob/exclude filters were parsed but ignored
- fixed staff-maintainability issue where Rust impl methods inherited whole-impl complexity
- added regression coverage for the fixed behavior
- ignored Graphify-generated outputs so local graph artifacts stay out of git

## Findings by lens
- Security: MCP tool calls built AnalysisContext from the server root instead of the requested path; semantic indexing read relative paths from the process cwd.
- Usability: analyzer --glob and --exclude flags did not scope most command output; search now uses the resolved repo path.
- Staff: Rust method complexity could be inflated by returning impl_item before the actual method node.
- Coverage: added red/green tests for CLI filters, MCP requested paths, semantic indexing root handling, and Rust impl method complexity.
- Compliance: graphify-out/, GRAPH_REPORT.md, and root graph.json are ignored.

## Verification
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- git diff --check
- git check-ignore -v graphify-out/ GRAPH_REPORT.md graph.json
- uvx --from graphifyy graphify update .
- uvx --from graphifyy graphify diagnose multigraph --json --graph graphify-out/graph.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path handling for multi-repository analysis scenarios
  * Enhanced semantic indexing to correctly identify files relative to repository roots

* **Refactor**
  * Consolidated analyzer command dispatch for consistent filtering behavior across all analysis commands

* **Tests**
  * Updated integration tests to validate JSON output structure

* **Chores**
  * Added Graphify-generated artifacts to build configuration ignore list

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panbanda/omen/pull/414?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->