### PR TITLE
Add agent-ready analysis outputs

### DIFF
--- a/benches/analyzers.rs
+++ b/benches/analyzers.rs
@@ -528,6 +528,30 @@ fn bench_hotspot(c: &mut Criterion) {
     group.finish();
 }
 
+/// Benchmark the context pack used by humans and MCP clients.
+fn bench_context(c: &mut Criterion) {
+    let mut group = c.benchmark_group("context");
+    group.sample_size(20);
+
+    for size in [10, 50].iter() {
+        let temp = create_benchmark_repo(*size);
+        let config = Config::default();
+        let files = FileSet::from_path(temp.path(), &config).unwrap();
+
+        group.throughput(Throughput::Elements(*size as u64));
+        group.bench_with_input(BenchmarkId::new("files", size), size, |b, _| {
+            b.iter(|| {
+                let context =
+                    omen::context::build_context(temp.path(), &files, &config, Some(25), Some(25))
+                        .unwrap();
+                black_box(context.top_symbols.len() + context.risks.len())
+            });
+        });
+    }
+
+    group.finish();
+}
+
 // Group benchmarks: non-git analyzers first (faster), then git-dependent
 criterion_group!(
     name = fast_benches;
@@ -541,6 +565,7 @@ criterion_group!(
         bench_cohesion,
         bench_smells,
         bench_repomap,
+        bench_context,
         bench_flags,
         bench_tdg
 );

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -145,6 +145,10 @@ pub struct AnalyzerArgs {
     /// Exclude files matching pattern
     #[arg(short, long)]
     pub exclude: Option<String>,
+
+    /// Analyze only files changed since the given git ref
+    #[arg(long)]
+    pub changed_since: Option<String>,
 }
 
 #[derive(Args)]
@@ -542,6 +546,7 @@ pub enum OutputFormat {
     Json,
     Markdown,
     Text,
+    Sarif,
 }
 
 #[derive(Clone, Copy, ValueEnum)]
@@ -657,6 +662,14 @@ mod tests {
         assert!(matches!(
             parse(&["omen", "-f", "text", "complexity"]).format,
             OutputFormat::Text
+        ));
+    }
+
+    #[test]
+    fn test_cli_format_sarif() {
+        assert!(matches!(
+            parse(&["omen", "-f", "sarif", "satd"]).format,
+            OutputFormat::Sarif
         ));
     }
 
@@ -981,6 +994,12 @@ mod tests {
     fn test_analyzer_args_glob() {
         let args = parse_complexity_args(&["omen", "complexity", "-g", "*.rs"]);
         assert_eq!(args.common.glob, Some("*.rs".to_string()));
+    }
+
+    #[test]
+    fn test_analyzer_args_changed_since() {
+        let args = parse_complexity_args(&["omen", "complexity", "--changed-since", "main"]);
+        assert_eq!(args.common.changed_since, Some("main".to_string()));
     }
 
     #[test]

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,201 @@
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::analyzers::{complexity, repomap, satd};
+use crate::config::Config;
+use crate::core::{AnalysisContext, Analyzer, FileSet, Language, Result};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Context {
+    pub repository: String,
+    pub file_count: usize,
+    pub languages: Vec<LanguageSummary>,
+    pub top_symbols: Vec<SymbolSummary>,
+    pub risks: Vec<RiskSummary>,
+    pub hints: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LanguageSummary {
+    pub language: String,
+    pub files: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SymbolSummary {
+    pub name: String,
+    pub kind: String,
+    pub file: String,
+    pub line: u32,
+    pub score: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RiskSummary {
+    pub kind: String,
+    pub file: String,
+    pub line: u32,
+    pub message: String,
+    pub severity: String,
+}
+
+pub fn build_context(
+    root: &Path,
+    files: &FileSet,
+    config: &Config,
+    max_symbols: Option<usize>,
+    max_risks: Option<usize>,
+) -> Result<Context> {
+    let ctx = AnalysisContext::new(files, config, Some(root));
+    let repository = root
+        .canonicalize()
+        .ok()
+        .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let languages = summarize_languages(files);
+    let symbol_limit = max_symbols.unwrap_or(25);
+    let risk_limit = max_risks.unwrap_or(25);
+
+    let repomap = repomap::Analyzer::default().analyze(&ctx)?;
+    let top_symbols = repomap
+        .symbols
+        .iter()
+        .take(symbol_limit)
+        .map(|symbol| SymbolSummary {
+            name: symbol.name.clone(),
+            kind: format!("{:?}", symbol.kind).to_lowercase(),
+            file: symbol.file.clone(),
+            line: symbol.line,
+            score: symbol.pagerank,
+        })
+        .collect();
+
+    let risks = summarize_risks(&ctx, risk_limit);
+    let hints = build_hints(files, &languages, &risks);
+
+    Ok(Context {
+        repository,
+        file_count: files.len(),
+        languages,
+        top_symbols,
+        risks,
+        hints,
+    })
+}
+
+fn summarize_languages(files: &FileSet) -> Vec<LanguageSummary> {
+    let mut counts = std::collections::BTreeMap::<String, usize>::new();
+    for file in files.files() {
+        if let Some(language) = Language::detect(file) {
+            *counts
+                .entry(language.display_name().to_string())
+                .or_default() += 1;
+        }
+    }
+
+    counts
+        .into_iter()
+        .map(|(language, files)| LanguageSummary { language, files })
+        .collect()
+}
+
+fn summarize_risks(ctx: &AnalysisContext<'_>, limit: usize) -> Vec<RiskSummary> {
+    let mut risks = Vec::new();
+
+    if let Ok(satd) = satd::Analyzer::default().analyze(ctx) {
+        risks.extend(satd.items.into_iter().map(|item| RiskSummary {
+            kind: "satd".to_string(),
+            file: item.file,
+            line: item.line,
+            message: item.text,
+            severity: format!("{:?}", item.severity).to_lowercase(),
+        }));
+    }
+
+    if let Ok(complexity) = complexity::Analyzer::default().analyze(ctx) {
+        let mut functions: Vec<_> = complexity
+            .files
+            .into_iter()
+            .flat_map(|file| file.functions)
+            .collect();
+        functions.sort_by_key(|func| std::cmp::Reverse(func.metrics.cognitive));
+        risks.extend(functions.into_iter().take(limit).filter_map(|func| {
+            if func.metrics.cognitive < 15 && func.metrics.cyclomatic < 10 {
+                return None;
+            }
+            Some(RiskSummary {
+                kind: "complexity".to_string(),
+                file: func.file,
+                line: func.start_line,
+                message: format!(
+                    "{} has cyclomatic {} and cognitive {} complexity",
+                    func.name, func.metrics.cyclomatic, func.metrics.cognitive
+                ),
+                severity: if func.metrics.cognitive >= 30 || func.metrics.cyclomatic >= 20 {
+                    "high"
+                } else {
+                    "medium"
+                }
+                .to_string(),
+            })
+        }));
+    }
+
+    risks.truncate(limit);
+    risks
+}
+
+fn build_hints(
+    files: &FileSet,
+    languages: &[LanguageSummary],
+    risks: &[RiskSummary],
+) -> Vec<String> {
+    let mut hints = Vec::new();
+    if let Some(primary) = languages.iter().max_by_key(|lang| lang.files) {
+        hints.push(format!(
+            "Start with the {} files; they are the largest language slice.",
+            primary.language
+        ));
+    }
+    if let Some(first) = files.files().first() {
+        hints.push(format!(
+            "Use `{}` as an initial navigation anchor.",
+            first.display()
+        ));
+    }
+    if let Some(risk) = risks.first() {
+        hints.push(format!(
+            "Review `{}` near line {} first for {} risk.",
+            risk.file, risk.line, risk.kind
+        ));
+    }
+    hints
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_context_includes_repo_map_and_risks() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(temp.path().join("src")).unwrap();
+        std::fs::write(
+            temp.path().join("src/lib.rs"),
+            "pub fn entrypoint() { if true { println!(\"hi\"); } }\n// TODO: remove shortcut\n",
+        )
+        .unwrap();
+
+        let config = Config::default();
+        let files = FileSet::from_path(temp.path(), &config).unwrap();
+        let context = build_context(temp.path(), &files, &config, None, None).unwrap();
+
+        assert_eq!(context.file_count, 1);
+        assert_eq!(context.languages[0].language, "Rust");
+        assert!(context.top_symbols.iter().any(|s| s.name == "entrypoint"));
+        assert!(context.risks.iter().any(|r| r.kind == "satd"));
+        assert!(context.hints.iter().any(|h| h.contains("Start with")));
+    }
+}

--- a/src/core/file_set.rs
+++ b/src/core/file_set.rs
@@ -134,6 +134,10 @@ impl FileSet {
                 // Match exclude patterns against relative path so that
                 // patterns like "tests/**" work regardless of absolute root.
                 let rel_path = path.strip_prefix(root).unwrap_or(path);
+                if exclude_built_assets && is_default_ignored_path(rel_path) {
+                    return WalkState::Continue;
+                }
+
                 let rel_str = rel_path.to_string_lossy();
                 if exclude_globs.is_match(&*rel_str) {
                     return WalkState::Continue;
@@ -223,6 +227,23 @@ impl FileSet {
                         .map(|n| glob.is_match(n.to_string_lossy().as_ref()))
                         .unwrap_or(false)
             })
+            .cloned()
+            .collect();
+
+        Self {
+            root: self.root.clone(),
+            files,
+            exclude_patterns: self.exclude_patterns.clone(),
+        }
+    }
+
+    /// Filter files by exact relative paths, returning a new FileSet.
+    pub fn filter_by_paths(&self, paths: &[PathBuf]) -> Self {
+        let wanted: std::collections::HashSet<&Path> = paths.iter().map(PathBuf::as_path).collect();
+        let files: Vec<PathBuf> = self
+            .files
+            .iter()
+            .filter(|f| wanted.contains(f.as_path()))
             .cloned()
             .collect();
 
@@ -323,6 +344,28 @@ fn is_built_asset(path: &Path) -> bool {
     // Strip the real extension, then check if the remaining stem ends with a built suffix
     let stem = &file_name[..file_name.len() - ext.len() - 1];
     BUILT_SUFFIXES.iter().any(|suffix| stem.ends_with(suffix))
+}
+
+fn is_default_ignored_path(path: &Path) -> bool {
+    const DEFAULT_IGNORED_DIRS: &[&str] = &[
+        "node_modules",
+        "target",
+        ".next",
+        "dist",
+        "build",
+        "coverage",
+        ".coverage",
+        ".turbo",
+        ".cache",
+        "vendor",
+    ];
+
+    path.components().any(|component| {
+        component
+            .as_os_str()
+            .to_str()
+            .is_some_and(|name| DEFAULT_IGNORED_DIRS.contains(&name))
+    })
 }
 
 /// Build a compiled GlobSet from a list of patterns.
@@ -475,6 +518,52 @@ mod tests {
         assert_eq!(file_set.len(), 1);
         let files: Vec<_> = file_set.iter().collect();
         assert!(files[0].to_string_lossy().contains("main.rs"));
+    }
+
+    #[test]
+    fn test_file_set_default_excludes_common_generated_directories() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(temp.path().join("src")).unwrap();
+        std::fs::create_dir_all(temp.path().join("node_modules/pkg")).unwrap();
+        std::fs::create_dir_all(temp.path().join("dist")).unwrap();
+        std::fs::create_dir_all(temp.path().join("coverage")).unwrap();
+        std::fs::write(temp.path().join("src/app.ts"), "export const app = 1;").unwrap();
+        std::fs::write(
+            temp.path().join("node_modules/pkg/index.ts"),
+            "export const dep = 1;",
+        )
+        .unwrap();
+        std::fs::write(
+            temp.path().join("dist/bundle.ts"),
+            "export const built = 1;",
+        )
+        .unwrap();
+        std::fs::write(
+            temp.path().join("coverage/generated.ts"),
+            "export const covered = 1;",
+        )
+        .unwrap();
+
+        let file_set = FileSet::from_path_default(temp.path()).unwrap();
+
+        assert_eq!(file_set.files(), &[PathBuf::from("src/app.ts")]);
+    }
+
+    #[test]
+    fn test_filter_by_paths_keeps_known_changed_files() {
+        let file_set = FileSet::from_files(
+            PathBuf::from("/repo"),
+            vec![
+                PathBuf::from("src/main.rs"),
+                PathBuf::from("src/lib.rs"),
+                PathBuf::from("tests/main.rs"),
+            ],
+        );
+
+        let filtered =
+            file_set.filter_by_paths(&[PathBuf::from("src/main.rs"), PathBuf::from("README.md")]);
+
+        assert_eq!(filtered.files(), &[PathBuf::from("src/main.rs")]);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@
 pub mod analyzers;
 pub mod cli;
 pub mod config;
+pub mod context;
 pub mod core;
 pub mod git;
 pub mod mcp;

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,6 +110,7 @@ fn run_with_path(cli: &Cli, path: &PathBuf) -> omen::core::Result<()> {
         OutputFormat::Json => Format::Json,
         OutputFormat::Markdown => Format::Markdown,
         OutputFormat::Text => Format::Text,
+        OutputFormat::Sarif => Format::Sarif,
     };
 
     match &cli.command {
@@ -271,6 +272,7 @@ fn run_with_path(cli: &Cli, path: &PathBuf) -> omen::core::Result<()> {
                                 );
                                 println!("Slope: {:.2}", trend_data.slope);
                             }
+                            Format::Sarif => format.format(&trend_data, &mut stdout())?,
                         }
                     }
                     None => {
@@ -279,9 +281,9 @@ fn run_with_path(cli: &Cli, path: &PathBuf) -> omen::core::Result<()> {
                 }
             }
         }
-        Command::All(_) => {
+        Command::All(args) => {
             use serde_json::{json, Value};
-            let file_set = FileSet::from_path(path, &config)?;
+            let file_set = filtered_file_set(path, &config, Some(args))?;
             let git_root = omen::git::GitRepo::open(path)
                 .ok()
                 .map(|r| r.root().to_path_buf());
@@ -372,7 +374,12 @@ fn run_with_path(cli: &Cli, path: &PathBuf) -> omen::core::Result<()> {
             results.push(run_and_collect!(&ctx, omen::score::Analyzer, "score"));
 
             let combined = json!({ "analyzers": results });
-            println!("{}", serde_json::to_string_pretty(&combined)?);
+            match format {
+                Format::Sarif => format.format_value(&combined, &mut stdout())?,
+                Format::Json | Format::Markdown | Format::Text => {
+                    println!("{}", serde_json::to_string_pretty(&combined)?);
+                }
+            }
         }
         Command::Context(args) => {
             run_context(path, &config, args, format)?;
@@ -468,6 +475,10 @@ fn filtered_file_set(
 ) -> omen::core::Result<FileSet> {
     let mut file_set = FileSet::from_path(path, config)?;
     if let Some(args) = args {
+        if let Some(ref changed_since) = args.changed_since {
+            let changed_files = changed_files_since(path, changed_since)?;
+            file_set = file_set.filter_by_paths(&changed_files);
+        }
         if let Some(ref glob) = args.glob {
             file_set = file_set.filter_by_glob(glob);
         }
@@ -476,6 +487,29 @@ fn filtered_file_set(
         }
     }
     Ok(file_set)
+}
+
+fn changed_files_since(path: &Path, base: &str) -> omen::core::Result<Vec<PathBuf>> {
+    use std::process::Command;
+
+    let output = Command::new("git")
+        .args(["diff", "--name-only", "--diff-filter=ACMR", base, "--"])
+        .current_dir(path)
+        .output()
+        .map_err(omen::core::Error::Io)?;
+
+    if !output.status.success() {
+        return Err(omen::core::Error::git(format!(
+            "failed to list files changed since {base}: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(PathBuf::from)
+        .collect())
 }
 
 fn run_analyzer<A: Analyzer + Default>(
@@ -647,23 +681,14 @@ fn run_context(
     args: &omen::cli::ContextArgs,
     format: Format,
 ) -> omen::core::Result<()> {
-    use serde_json::json;
-
     let file_set = FileSet::from_path(path, config)?;
-    let ctx = build_context(path, &file_set, config);
-
-    // Generate context using repomap analyzer as base
-    let analyzer = omen::analyzers::repomap::Analyzer::default();
-    let repomap_result = analyzer.analyze(&ctx)?;
-
-    // Build context output
-    let context = json!({
-        "target": args.target,
-        "max_tokens": args.max_tokens,
-        "depth": args.depth,
-        "symbol": args.symbol,
-        "repomap": repomap_result,
-    });
+    let context = omen::context::build_context(
+        path,
+        &file_set,
+        config,
+        Some(args.max_tokens.saturating_div(250).clamp(5, 100)),
+        Some(25),
+    )?;
 
     match format {
         Format::Json => println!("{}", serde_json::to_string_pretty(&context)?),
@@ -677,8 +702,21 @@ fn run_context(
             if let Some(ref symbol) = args.symbol {
                 println!("**Symbol:** {}\n", symbol);
             }
-            println!("## Symbol Map\n");
-            println!("{}", serde_json::to_string_pretty(&repomap_result)?);
+            println!("## Languages\n");
+            for language in &context.languages {
+                println!("- {}: {} files", language.language, language.files);
+            }
+            println!("\n## Top Symbols\n");
+            for symbol in &context.top_symbols {
+                println!(
+                    "- `{}` ({}) at {}:{}",
+                    symbol.name, symbol.kind, symbol.file, symbol.line
+                );
+            }
+            println!("\n## Hints\n");
+            for hint in &context.hints {
+                println!("- {}", hint);
+            }
         }
         Format::Text => {
             println!("Repository Context");
@@ -692,8 +730,9 @@ fn run_context(
                 println!("Symbol: {}", symbol);
             }
             println!();
-            format.format(&repomap_result, &mut stdout())?;
+            format.format(&context, &mut stdout())?;
         }
+        Format::Sarif => format.format(&context, &mut stdout())?,
     }
 
     Ok(())
@@ -1191,6 +1230,7 @@ fn run_search(
                         println!();
                     }
                 }
+                Format::Sarif => format.format(&output, &mut stdout())?,
             }
         }
     }
@@ -1384,6 +1424,7 @@ fn run_mutation(
             );
             println!("Duration: {}ms", result.summary.duration_ms);
         }
+        Format::Sarif => format.format(&result, &mut stdout())?,
     }
 
     // Check mode: fail if score below threshold

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -323,6 +323,18 @@ impl McpServer {
                     }
                 },
                 {
+                    "name": "context",
+                    "description": "Build a compact repository context pack with languages, top symbols, risks, and navigation hints",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": "string", "description": "File or directory path"},
+                            "max_symbols": {"type": "integer", "description": "Maximum symbols to include"},
+                            "max_risks": {"type": "integer", "description": "Maximum risks to include"}
+                        }
+                    }
+                },
+                {
                     "name": "semantic_search_hyde",
                     "description": "Search using hypothetical code. Write a code snippet resembling what you want to find. This is matched against the index, producing better results than keyword queries.",
                     "inputSchema": {
@@ -386,6 +398,9 @@ impl McpServer {
             "smells" => self.run_analyzer::<crate::analyzers::smells::Analyzer>(&ctx),
             "flags" => self.run_analyzer::<crate::analyzers::flags::Analyzer>(&ctx),
             "score" => self.run_analyzer::<crate::score::Analyzer>(&ctx),
+            "context" => {
+                return self.handle_context(&path, &file_set, &arguments);
+            }
             "diff" => {
                 return self.handle_diff(&path, &arguments);
             }
@@ -415,6 +430,35 @@ impl McpServer {
             .analyze(ctx)
             .map_err(|e| format!("Analysis failed: {}", e))?;
         serde_json::to_value(result).map_err(|e| format!("Serialization failed: {}", e))
+    }
+
+    fn handle_context(
+        &self,
+        path: &std::path::Path,
+        file_set: &FileSet,
+        arguments: &Value,
+    ) -> std::result::Result<Value, String> {
+        let max_symbols = arguments
+            .get("max_symbols")
+            .and_then(|v| v.as_u64())
+            .map(|v| v as usize);
+        let max_risks = arguments
+            .get("max_risks")
+            .and_then(|v| v.as_u64())
+            .map(|v| v as usize);
+
+        let context =
+            crate::context::build_context(path, file_set, &self.config, max_symbols, max_risks)
+                .map_err(|e| format!("Context failed: {}", e))?;
+
+        let value =
+            serde_json::to_value(&context).map_err(|e| format!("Serialization failed: {}", e))?;
+        Ok(json!({
+            "content": [{
+                "type": "text",
+                "text": serde_json::to_string_pretty(&value).unwrap_or_default()
+            }]
+        }))
     }
 
     fn handle_diff(
@@ -776,6 +820,15 @@ mod tests {
     }
 
     #[test]
+    fn test_handle_tools_list_has_context() {
+        let (server, _temp_dir) = create_test_server();
+        let result = server.handle_tools_list().unwrap();
+        let tools = result.get("tools").unwrap().as_array().unwrap();
+        let has_context = tools.iter().any(|t| t.get("name").unwrap() == "context");
+        assert!(has_context);
+    }
+
+    #[test]
     fn test_handle_tool_call_missing_params() {
         let (server, _temp_dir) = create_test_server();
         let result = server.handle_tool_call(None);
@@ -841,6 +894,26 @@ mod tests {
             text.contains("target_function"),
             "expected MCP analysis to read files from requested path, got {text}"
         );
+    }
+
+    #[test]
+    fn test_handle_tool_call_context() {
+        let (server, temp_dir) = create_test_server();
+        std::fs::write(
+            temp_dir.path().join("test.rs"),
+            "pub fn mcp_entrypoint() {}\n// TODO: remove shortcut\n",
+        )
+        .unwrap();
+
+        let params = json!({
+            "name": "context",
+            "arguments": {"path": temp_dir.path().to_str().unwrap()}
+        });
+        let response = server.handle_tool_call(Some(params)).unwrap();
+        let text = response["content"][0]["text"].as_str().unwrap();
+
+        assert!(text.contains("hints"));
+        assert!(text.contains("mcp_entrypoint"));
     }
 
     #[test]

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -14,6 +14,7 @@ pub enum Format {
     Json,
     Markdown,
     Text,
+    Sarif,
 }
 
 impl Format {
@@ -22,6 +23,7 @@ impl Format {
             Format::Json => format_json(value, writer),
             Format::Markdown => format_markdown(value, writer),
             Format::Text => format_text(value, writer),
+            Format::Sarif => format_sarif(value, writer),
         }
     }
 
@@ -45,6 +47,116 @@ fn format_markdown<W: Write>(value: &Value, writer: &mut W) -> Result<()> {
 fn format_text<W: Write>(value: &Value, writer: &mut W) -> Result<()> {
     format_value_as_text(value, writer, 0)?;
     Ok(())
+}
+
+fn format_sarif<W: Write>(value: &Value, writer: &mut W) -> Result<()> {
+    let mut findings = Vec::new();
+    collect_sarif_findings(value, &mut findings);
+
+    let rules = serde_json::json!([{
+        "id": "omen.finding",
+        "name": "Omen finding",
+        "shortDescription": {"text": "Omen code analysis finding"},
+        "helpUri": "https://github.com/panbanda/omen"
+    }]);
+
+    let results: Vec<Value> = findings
+        .into_iter()
+        .map(|finding| {
+            serde_json::json!({
+                "ruleId": "omen.finding",
+                "level": finding.level,
+                "message": {"text": finding.message},
+                "locations": [{
+                    "physicalLocation": {
+                        "artifactLocation": {"uri": finding.file},
+                        "region": {"startLine": finding.line}
+                    }
+                }]
+            })
+        })
+        .collect();
+
+    let sarif = serde_json::json!({
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [{
+            "tool": {
+                "driver": {
+                    "name": "omen",
+                    "informationUri": "https://github.com/panbanda/omen",
+                    "rules": rules
+                }
+            },
+            "results": results
+        }]
+    });
+
+    format_json(&sarif, writer)
+}
+
+#[derive(Debug)]
+struct SarifFinding {
+    file: String,
+    line: u64,
+    level: &'static str,
+    message: String,
+}
+
+fn collect_sarif_findings(value: &Value, findings: &mut Vec<SarifFinding>) {
+    match value {
+        Value::Object(map) => {
+            if let Some(finding) = sarif_finding_from_object(map) {
+                findings.push(finding);
+            }
+            for child in map.values() {
+                collect_sarif_findings(child, findings);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_sarif_findings(item, findings);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn sarif_finding_from_object(map: &serde_json::Map<String, Value>) -> Option<SarifFinding> {
+    let file = ["file", "path", "file_path"]
+        .iter()
+        .find_map(|key| map.get(*key).and_then(Value::as_str))?;
+    let line = ["line", "start_line", "line_start"]
+        .iter()
+        .find_map(|key| map.get(*key).and_then(Value::as_u64))
+        .unwrap_or(1)
+        .max(1);
+    let message = ["text", "reason", "message", "name", "marker"]
+        .iter()
+        .find_map(|key| map.get(*key).and_then(Value::as_str))
+        .unwrap_or("Omen finding")
+        .to_string();
+    let level = map
+        .get("severity")
+        .and_then(Value::as_str)
+        .map(sarif_level)
+        .unwrap_or("warning");
+
+    Some(SarifFinding {
+        file: file.to_string(),
+        line,
+        level,
+        message,
+    })
+}
+
+fn sarif_level(severity: &str) -> &'static str {
+    match severity.to_ascii_lowercase().as_str() {
+        "critical" | "high" => "error",
+        "medium" => "warning",
+        "low" | "info" | "note" => "note",
+        _ => "warning",
+    }
 }
 
 fn format_value_as_markdown<W: Write>(value: &Value, writer: &mut W, depth: usize) -> Result<()> {
@@ -215,6 +327,27 @@ mod tests {
     #[test]
     fn test_format_default_is_json() {
         assert!(matches!(Format::default(), Format::Json));
+    }
+
+    #[test]
+    fn test_format_sarif_emits_findings_from_items_array() {
+        let value = json!({
+            "items": [{
+                "file": "src/lib.rs",
+                "line": 7,
+                "severity": "high",
+                "marker": "TODO",
+                "text": "TODO: remove shortcut"
+            }]
+        });
+        let mut buf = Vec::new();
+        Format::Sarif.format_value(&value, &mut buf).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("\"version\": \"2.1.0\""));
+        assert!(output.contains("\"artifactLocation\""));
+        assert!(output.contains("src/lib.rs"));
+        assert!(output.contains("\"startLine\": 7"));
+        assert!(output.contains("TODO: remove shortcut"));
     }
 
     #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -50,6 +50,27 @@ fn test_satd_runs_successfully() {
 }
 
 #[test]
+fn test_satd_sarif_output() {
+    omen()
+        .args(["-p", fixtures_dir(), "-f", "sarif", "satd"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"version\": \"2.1.0\""))
+        .stdout(predicate::str::contains("\"runs\""));
+}
+
+#[test]
+fn test_context_json_outputs_context_pack() {
+    omen()
+        .args(["-p", fixtures_dir(), "-f", "json", "context"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"hints\""))
+        .stdout(predicate::str::contains("\"top_symbols\""))
+        .stdout(predicate::str::contains("\"languages\""));
+}
+
+#[test]
 fn test_deadcode_runs_successfully() {
     omen()
         .args(["-p", fixtures_dir(), "-f", "json", "deadcode"])
@@ -169,6 +190,68 @@ fn test_text_output() {
         .args(["-p", fixtures_dir(), "-f", "text", "complexity"])
         .assert()
         .success();
+}
+
+#[test]
+fn test_changed_since_filters_analyzer_files() {
+    let temp = TempDir::new().unwrap();
+    std::fs::create_dir_all(temp.path().join("src")).unwrap();
+    std::fs::write(temp.path().join("src/a.rs"), "fn unchanged() {}\n").unwrap();
+    std::fs::write(temp.path().join("src/b.rs"), "fn changed() {}\n").unwrap();
+
+    std::process::Command::new("git")
+        .args(["init"])
+        .current_dir(temp.path())
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(temp.path())
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(temp.path())
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(temp.path())
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["commit", "-m", "initial"])
+        .current_dir(temp.path())
+        .output()
+        .unwrap();
+
+    std::fs::write(
+        temp.path().join("src/b.rs"),
+        "fn changed() { if true {} }\n",
+    )
+    .unwrap();
+
+    let output = omen()
+        .args([
+            "-p",
+            temp.path().to_str().unwrap(),
+            "-f",
+            "json",
+            "complexity",
+            "--changed-since",
+            "HEAD",
+        ])
+        .output()
+        .expect("command runs");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let files = parsed["files"].as_array().unwrap();
+
+    assert_eq!(files.len(), 1, "expected only changed file: {stdout}");
+    assert!(files[0]["path"].as_str().unwrap().ends_with("src/b.rs"));
+    assert!(!stdout.contains("src/a.rs"));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add an Omen-native agent context pack for CLI and MCP clients with languages, top symbols, risks, and navigation hints
- add SARIF output support for analysis findings
- add --changed-since filtering for analyzer commands and all
- harden default file discovery against common generated/vendor directories
- add benchmark coverage for agent context generation

## Verification
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- git diff --check

## Notes
- No Graphify wrapper or import path is included; this is Omen-native functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--changed-since` argument to analyze only files modified since a specified git reference.
  * Added SARIF output format support for vulnerability reporting across all analyzers.
  * Added context analysis providing repository summary with detected languages, top symbols, security risks, and navigation hints.
  * Added context tool to MCP server for remote analysis requests.

* **Improvements**
  * Automatic exclusion of common generated directories (node_modules, target, dist, coverage, etc.) from analysis.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panbanda/omen/pull/418?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->