### PR TITLE
Fix stored XSS in generated HTML reports

### DIFF
--- a/src/report/render.rs
+++ b/src/report/render.rs
@@ -7,8 +7,8 @@ use std::path::Path;
 
 use flate2::write::GzEncoder;
 use flate2::Compression;
-use minijinja::{context, Environment, Value};
-use pulldown_cmark::{html, Options, Parser};
+use minijinja::{context, AutoEscape, Environment, Value};
+use pulldown_cmark::{html, Event, Options, Parser};
 
 use crate::core::Language;
 use crate::core::Result;
@@ -26,6 +26,7 @@ impl Renderer {
     /// Create a new renderer with the embedded template.
     pub fn new() -> Result<Self> {
         let mut env = Environment::new();
+        env.set_auto_escape_callback(|_| AutoEscape::Html);
 
         // Add template filters (equivalent to Go's template.FuncMap)
         env.add_filter("rel_path", rel_path);
@@ -419,11 +420,13 @@ fn markdown_filter(s: &str) -> Value {
     options.insert(Options::ENABLE_STRIKETHROUGH);
     options.insert(Options::ENABLE_TABLES);
 
-    let parser = Parser::new_ext(s, options);
+    let parser = Parser::new_ext(s, options).filter_map(|event| match event {
+        Event::Html(_) | Event::InlineHtml(_) => None,
+        event => Some(event),
+    });
     let mut html_output = String::new();
     html::push_html(&mut html_output, parser);
 
-    // Mark as safe HTML (won't be escaped)
     Value::from_safe_string(html_output)
 }
 
@@ -538,9 +541,17 @@ fn truncate_path(s: &str, n: usize) -> String {
     format!(".../{}/{}", truncated_prefix, filename)
 }
 
-/// Convert value to JSON string.
-fn tojson_filter(value: Value) -> String {
-    serde_json::to_string(&value).unwrap_or_else(|_| "null".to_string())
+/// Convert a value to JSON that is safe to embed in HTML script elements.
+fn tojson_filter(value: Value) -> Value {
+    let json = serde_json::to_string(&value).unwrap_or_else(|_| "null".to_string());
+    let escaped = json
+        .replace('&', r"\u0026")
+        .replace('<', r"\u003c")
+        .replace('>', r"\u003e")
+        .replace('\'', r"\u0027")
+        .replace('\u{2028}', r"\u2028")
+        .replace('\u{2029}', r"\u2029");
+    Value::from_safe_string(escaped)
 }
 
 /// Format number with thousands separator.
@@ -728,7 +739,8 @@ fn instability_class(instability: f64) -> &'static str {
 
 fn minify_html_output(input: &[u8]) -> Vec<u8> {
     let cfg = minify_html::Cfg {
-        minify_js: true,
+        // JS minification decodes JSON's script-safe Unicode escapes back into literal tags.
+        minify_js: false,
         minify_css: true,
         ..Default::default()
     };
@@ -739,12 +751,12 @@ fn minify_html_output(input: &[u8]) -> Vec<u8> {
 // JSON Table Data Builders
 // ============================================================================
 
-/// Serialize rows as a JSON array-of-arrays string for simple-datatables `data` option.
-fn rows_to_json(rows: &[Vec<String>]) -> String {
-    serde_json::to_string(rows).unwrap_or_else(|_| "[]".to_string())
+/// Convert rows to a template value for simple-datatables' `data` option.
+fn rows_to_json(rows: &[Vec<String>]) -> Value {
+    Value::from_serialize(rows)
 }
 
-fn build_hotspots_json(files: &[HotspotItem], roots: &[String]) -> String {
+fn build_hotspots_json(files: &[HotspotItem], roots: &[String]) -> Value {
     let rows: Vec<Vec<String>> = files
         .iter()
         .map(|item| {
@@ -764,7 +776,7 @@ fn build_hotspots_json(files: &[HotspotItem], roots: &[String]) -> String {
     rows_to_json(&rows)
 }
 
-fn build_satd_json(items: &[SATDItem], roots: &[String]) -> String {
+fn build_satd_json(items: &[SATDItem], roots: &[String]) -> Value {
     let rows: Vec<Vec<String>> = items
         .iter()
         .map(|item| {
@@ -787,7 +799,7 @@ fn build_satd_json(items: &[SATDItem], roots: &[String]) -> String {
     rows_to_json(&rows)
 }
 
-fn build_churn_json(files: &[ChurnFile]) -> String {
+fn build_churn_json(files: &[ChurnFile]) -> Value {
     let rows: Vec<Vec<String>> = files
         .iter()
         .map(|item| {
@@ -808,7 +820,7 @@ fn build_churn_json(files: &[ChurnFile]) -> String {
     rows_to_json(&rows)
 }
 
-fn build_cohesion_json(classes: &[CohesionClass]) -> String {
+fn build_cohesion_json(classes: &[CohesionClass]) -> Value {
     let rows: Vec<Vec<String>> = classes
         .iter()
         .map(|item| {
@@ -832,7 +844,7 @@ fn build_cohesion_json(classes: &[CohesionClass]) -> String {
     rows_to_json(&rows)
 }
 
-fn build_graph_json(nodes: &[GraphNode], roots: &[String]) -> String {
+fn build_graph_json(nodes: &[GraphNode], roots: &[String]) -> Value {
     let rows: Vec<Vec<String>> = nodes
         .iter()
         .map(|node| {
@@ -856,7 +868,7 @@ fn build_graph_json(nodes: &[GraphNode], roots: &[String]) -> String {
     rows_to_json(&rows)
 }
 
-fn build_tdg_json(files: &[TdgFile], roots: &[String]) -> String {
+fn build_tdg_json(files: &[TdgFile], roots: &[String]) -> Value {
     let rows: Vec<Vec<String>> = files
         .iter()
         .map(|item| {
@@ -882,7 +894,7 @@ fn build_tdg_json(files: &[TdgFile], roots: &[String]) -> String {
     rows_to_json(&rows)
 }
 
-fn build_temporal_json(couplings: &[TemporalCoupling], roots: &[String]) -> String {
+fn build_temporal_json(couplings: &[TemporalCoupling], roots: &[String]) -> Value {
     let rows: Vec<Vec<String>> = couplings
         .iter()
         .map(|item| {
@@ -913,6 +925,101 @@ fn html_escape(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
+
+    fn write_fixture(path: &Path, value: serde_json::Value) {
+        fs::write(path, serde_json::to_vec(&value).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn test_renderer_escapes_repo_data_in_html_and_scripts() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let insights_dir = data_dir.path().join("insights");
+        fs::create_dir(&insights_dir).unwrap();
+
+        write_fixture(
+            &data_dir.path().join("ownership.json"),
+            json!({
+                "summary": {
+                    "total_files": 2,
+                    "bus_factor": 1,
+                    "top_contributors": [
+                        { "name": "');alert(document.domain);//", "files_owned": 1 },
+                        { "name": "Normal Author", "files_owned": 1 }
+                    ]
+                }
+            }),
+        );
+        write_fixture(
+            &data_dir.path().join("trend.json"),
+            json!({
+                "points": [{
+                    "date": "2026-08-01",
+                    "score": 75,
+                    "notable_commits": ["</script><script>alert(1)</script>"]
+                }]
+            }),
+        );
+        write_fixture(
+            &data_dir.path().join("hotspots.json"),
+            json!({
+                "files": [{
+                    "path": "x');fetch('http://evil')//.rs",
+                    "hotspot_score": 0.9,
+                    "commits": 3,
+                    "avg_cognitive": 4.0
+                }]
+            }),
+        );
+        write_fixture(
+            &data_dir.path().join("flags.json"),
+            json!({
+                "flags": [{
+                    "flag_key": "<svg onload=alert(1)>",
+                    "provider": "test"
+                }]
+            }),
+        );
+        write_fixture(
+            &insights_dir.join("summary.json"),
+            json!({
+                "executive_summary": "<img src=x onerror=alert(1)> hello **bold**"
+            }),
+        );
+
+        let mut output = Vec::new();
+        Renderer::new()
+            .unwrap()
+            .render(data_dir.path(), &mut output)
+            .unwrap();
+        let html = String::from_utf8(output).unwrap();
+
+        assert!(!html.contains("<script>alert"));
+        assert!(!html.contains("');alert("));
+        assert!(!html.contains("x');fetch("));
+        assert!(!html.contains("<img src=x onerror=alert(1)>"));
+        assert!(!html.contains("onerror=alert"));
+        assert!(!html.contains("<svg onload=alert(1)>"));
+        assert!(html.contains(r"\u003c/script\u003e\u003cscript\u003ealert(1)"));
+        assert!(html.contains(r"x\u0027);fetch(\u0027http://evil\u0027)//.rs"));
+        assert!(html.contains(r#"window.__td_hotspots=[["\u003ccode\u003e"#));
+        assert!(!html.contains("window.__td_hotspots=[[&#34;"));
+        assert!(html.contains("hello"));
+        assert!(html.contains("&lt;svg onload=alert(1)>"));
+        assert!(html.contains("Normal Author"));
+        assert!(html.contains("<strong>bold</strong>"));
+    }
+
+    #[test]
+    fn test_tojson_escapes_script_sensitive_characters() {
+        let encoded = tojson_filter(Value::from("<>&'\u{2028}\u{2029}"));
+
+        assert_eq!(
+            encoded.as_str(),
+            Some(r#""\u003c\u003e\u0026\u0027\u2028\u2029""#)
+        );
+        assert!(encoded.is_safe());
+    }
 
     #[test]
     fn test_score_class() {
@@ -1121,8 +1228,8 @@ mod tests {
             },
         ];
         let roots = vec!["/root".to_string()];
-        let json = build_hotspots_json(&files, &roots);
-        let parsed: Vec<Vec<String>> = serde_json::from_str(&json).unwrap();
+        let json = tojson_filter(build_hotspots_json(&files, &roots));
+        let parsed: Vec<Vec<String>> = serde_json::from_str(json.as_str().unwrap()).unwrap();
         assert_eq!(parsed.len(), 2);
         assert_eq!(parsed[0].len(), 5);
         assert!(parsed[0][0].contains("<code>"));
@@ -1134,8 +1241,8 @@ mod tests {
 
     #[test]
     fn test_build_temporal_json_empty() {
-        let json = build_temporal_json(&[], &[]);
-        assert_eq!(json, "[]");
+        let json = tojson_filter(build_temporal_json(&[], &[]));
+        assert_eq!(json.as_str(), Some("[]"));
     }
 
     #[test]

--- a/src/report/template.html
+++ b/src/report/template.html
@@ -1321,7 +1321,7 @@
                         </tr>
                     </thead>
                 </table>
-                {% if HotspotsTableJson %}<script>window.__td_hotspots={{ HotspotsTableJson }};</script>{% endif %}
+                {% if HotspotsTableJson %}<script>window.__td_hotspots={{ HotspotsTableJson | tojson }};</script>{% endif %}
             </div>
         </section>
         {% endif %}
@@ -1394,7 +1394,7 @@
                         </tr>
                     </thead>
                 </table>
-                {% if CohesionTableJson %}<script>window.__td_cohesion={{ CohesionTableJson }};</script>{% endif %}
+                {% if CohesionTableJson %}<script>window.__td_cohesion={{ CohesionTableJson | tojson }};</script>{% endif %}
             </div>
         </section>
         {% endif %}
@@ -1527,7 +1527,7 @@
                         </tr>
                     </thead>
                 </table>
-                {% if GraphTableJson %}<script>window.__td_graph={{ GraphTableJson }};</script>{% endif %}
+                {% if GraphTableJson %}<script>window.__td_graph={{ GraphTableJson | tojson }};</script>{% endif %}
             </div>
             {% endif %}
         </section>
@@ -1594,7 +1594,7 @@
                         </tr>
                     </thead>
                 </table>
-                {% if SATDTableJson %}<script>window.__td_satd={{ SATDTableJson }};</script>{% endif %}
+                {% if SATDTableJson %}<script>window.__td_satd={{ SATDTableJson | tojson }};</script>{% endif %}
             </div>
         </section>
         {% endif %}
@@ -1699,7 +1699,7 @@
                         </tr>
                     </thead>
                 </table>
-                {% if TdgTableJson %}<script>window.__td_tdg={{ TdgTableJson }};</script>{% endif %}
+                {% if TdgTableJson %}<script>window.__td_tdg={{ TdgTableJson | tojson }};</script>{% endif %}
             </div>
             {% endif %}
         </section>
@@ -1826,7 +1826,7 @@
                         </tr>
                     </thead>
                 </table>
-                {% if ChurnTableJson %}<script>window.__td_churn={{ ChurnTableJson }};</script>{% endif %}
+                {% if ChurnTableJson %}<script>window.__td_churn={{ ChurnTableJson | tojson }};</script>{% endif %}
             </div>
             {% endif %}
         </section>
@@ -1922,7 +1922,7 @@
                         </tr>
                     </thead>
                 </table>
-                {% if TemporalTableJson %}<script>window.__td_temporal={{ TemporalTableJson }};</script>{% endif %}
+                {% if TemporalTableJson %}<script>window.__td_temporal={{ TemporalTableJson | tojson }};</script>{% endif %}
             </div>
         </section>
         {% endif %}
@@ -2259,12 +2259,12 @@
                     type: 'radar',
                     data: [{
                         value: [
-                            {{ Score.components.complexity | default(0) }},
-                            {{ Score.components.duplication | default(0) }},
-                            {{ Score.components.cohesion | default(0) }},
-                            {{ Score.components.coupling | default(0) }},
-                            {{ Score.components.satd | default(0) }},
-                            {{ Score.components.smells | default(0) }}
+                            {{ Score.components.complexity | default(0) | tojson }},
+                            {{ Score.components.duplication | default(0) | tojson }},
+                            {{ Score.components.cohesion | default(0) | tojson }},
+                            {{ Score.components.coupling | default(0) | tojson }},
+                            {{ Score.components.satd | default(0) | tojson }},
+                            {{ Score.components.smells | default(0) | tojson }}
                         ],
                         areaStyle: { color: 'rgba(88,166,255,0.2)' },
                         lineStyle: { color: palette.blue, width: 2 },
@@ -2286,8 +2286,8 @@
 
             const data = [
                 {% for item in Hotspots.files %}{
-                    name: '{{ item.path | rel_path(Metadata.paths) | truncate_path(60) }}',
-                    value: [{{ item.commits }}, {{ item.avg_cognitive | round(1) }}, {{ item.hotspot_score | round(3) }}]
+                    name: {{ item.path | rel_path(Metadata.paths) | truncate_path(60) | tojson }},
+                    value: [{{ item.commits | tojson }}, {{ item.avg_cognitive | round(1) | tojson }}, {{ item.hotspot_score | round(3) | tojson }}]
                 }{% if not loop.last %},{% endif %}
                 {% endfor %}
             ];
@@ -2382,7 +2382,7 @@
                         offsetCenter: [0, '60%']
                     },
                     title: { show: false },
-                    data: [{ value: {{ Duplicates.duplication_ratio | round(1) }} }]
+                    data: [{ value: {{ Duplicates.duplication_ratio | round(1) | tojson }} }]
                 }]
             });
         })();
@@ -2394,8 +2394,8 @@
     {% if Trend %}
     <script>
         var trendsDataRaw = {
-            labels: [{% for p in Trend.points %}'{{ p.date }}'{% if not loop.last %}, {% endif %}{% endfor %}],
-            scores: [{% for p in Trend.points %}{{ p.score }}{% if not loop.last %}, {% endif %}{% endfor %}]
+            labels: [{% for p in Trend.points %}{{ p.date | tojson }}{% if not loop.last %}, {% endif %}{% endfor %}],
+            scores: [{% for p in Trend.points %}{{ p.score | tojson }}{% if not loop.last %}, {% endif %}{% endfor %}]
         };
 
         function formatDateLabel(isoDate) {
@@ -2426,7 +2426,7 @@
         var notableCommitsByPeriod = {};
         var trendPointCommits = [
             {% for p in Trend.points %}
-            {% if p.notable_commits %}{ date: '{{ p.date }}', commits: {{ p.notable_commits | tojson }} }{% if not loop.last %},{% endif %}
+            {% if p.notable_commits %}{ date: {{ p.date | tojson }}, commits: {{ p.notable_commits | tojson }} }{% if not loop.last %},{% endif %}
             {% endif %}
             {% endfor %}
         ];
@@ -2501,7 +2501,7 @@
             var chart = initChart(el);
 
             var trendLineData = trendsData.labels.map(function(_, i) {
-                return ({{ Trend.intercept }} + {{ Trend.slope }} * i).toFixed(1);
+                return ({{ Trend.intercept | tojson }} + {{ Trend.slope | tojson }} * i).toFixed(1);
             });
 
             var yMin = Math.min.apply(null, trendsData.scores) - 5;
@@ -2592,7 +2592,7 @@
             if (!el) return;
             var chart = initChart(el);
 
-            var componentLabelsRaw = [{% for p in Trend.points %}'{{ p.date }}'{% if not loop.last %}, {% endif %}{% endfor %}];
+            var componentLabelsRaw = [{% for p in Trend.points %}{{ p.date | tojson }}{% if not loop.last %}, {% endif %}{% endfor %}];
             var componentLabels = componentLabelsRaw.map(formatDateLabel);
 
             var componentColors = {
@@ -2675,28 +2675,28 @@
                 series: [
                     {
                         name: 'Complexity', type: 'line', smooth: 0.3, symbol: 'circle', symbolSize: 4,
-                        data: [{% for p in Trend.points %}{{ p.components.complexity | default(0) }}{% if not loop.last %}, {% endif %}{% endfor %}],
+                        data: [{% for p in Trend.points %}{{ p.components.complexity | default(0) | tojson }}{% if not loop.last %}, {% endif %}{% endfor %}],
                         lineStyle: { color: '#3fb950' }, itemStyle: { color: '#3fb950' },
                         markLine: { silent: true, symbol: 'none', data: componentMarkLines }
                     },
                     {
                         name: 'Duplication', type: 'line', smooth: 0.3, symbol: 'circle', symbolSize: 4,
-                        data: [{% for p in Trend.points %}{{ p.components.duplication | default(0) }}{% if not loop.last %}, {% endif %}{% endfor %}],
+                        data: [{% for p in Trend.points %}{{ p.components.duplication | default(0) | tojson }}{% if not loop.last %}, {% endif %}{% endfor %}],
                         lineStyle: { color: '#58a6ff' }, itemStyle: { color: '#58a6ff' }
                     },
                     {
                         name: 'Coupling', type: 'line', smooth: 0.3, symbol: 'circle', symbolSize: 4,
-                        data: [{% for p in Trend.points %}{{ p.components.coupling | default(0) }}{% if not loop.last %}, {% endif %}{% endfor %}],
+                        data: [{% for p in Trend.points %}{{ p.components.coupling | default(0) | tojson }}{% if not loop.last %}, {% endif %}{% endfor %}],
                         lineStyle: { color: '#d29922' }, itemStyle: { color: '#d29922' }
                     },
                     {
                         name: 'Cohesion', type: 'line', smooth: 0.3, symbol: 'circle', symbolSize: 4,
-                        data: [{% for p in Trend.points %}{{ p.components.cohesion | default(0) }}{% if not loop.last %}, {% endif %}{% endfor %}],
+                        data: [{% for p in Trend.points %}{{ p.components.cohesion | default(0) | tojson }}{% if not loop.last %}, {% endif %}{% endfor %}],
                         lineStyle: { color: '#a371f7' }, itemStyle: { color: '#a371f7' }
                     },
                     {
                         name: 'Smells', type: 'line', smooth: 0.3, symbol: 'circle', symbolSize: 4,
-                        data: [{% for p in Trend.points %}{{ p.components.smells | default(0) }}{% if not loop.last %}, {% endif %}{% endfor %}],
+                        data: [{% for p in Trend.points %}{{ p.components.smells | default(0) | tojson }}{% if not loop.last %}, {% endif %}{% endfor %}],
                         lineStyle: { color: '#f85149' }, itemStyle: { color: '#f85149' }
                     }
                 ]
@@ -2719,8 +2719,8 @@
             if (!el) return;
             var chart = initChart(el);
 
-            var names = [{% for o in Ownership.top_owners %}'{{ o.name }}'{% if not loop.last %}, {% endif %}{% endfor %}];
-            var values = [{% for o in Ownership.top_owners %}{{ o.files_owned }}{% if not loop.last %}, {% endif %}{% endfor %}];
+            var names = [{% for o in Ownership.top_owners %}{{ o.name | tojson }}{% if not loop.last %}, {% endif %}{% endfor %}];
+            var values = [{% for o in Ownership.top_owners %}{{ o.files_owned | tojson }}{% if not loop.last %}, {% endif %}{% endfor %}];
             var barColors = [palette.blue, palette.green, palette.yellow, palette.purple, palette.red, palette.gray, palette.blue, palette.green, palette.yellow, palette.purple];
 
             chart.setOption({


### PR DESCRIPTION
## Summary

Anyone who could land a commit in an analyzed repo could execute script in `omen report` HTML output: the minijinja template was registered without autoescaping, `tojson` did not escape script-closing sequences, and inline charts interpolated author names/file paths/dates directly into JS string literals.

- Autoescaping enabled for all HTML interpolation (`set_auto_escape_callback`)
- `tojson` now emits script-safe JSON (`<`, `>`, `&`, `'`, U+2028/9 escaped) and is used for every inline-script value; no raw `'{{ ... }}'` JS literals remain
- `markdown_filter` strips raw HTML events, so LLM insight text renders markdown but cannot inject markup
- JS minification disabled: minify-js decoded the protective Unicode escapes back into literal `</script>` tags (CSS minification retained)
- Regression test renders the full report with hostile author names (`');alert(document.domain);//`), commit messages (`</script><script>alert(1)</script>`), file paths, flag keys, and insight markdown, asserting payloads are neutralized while legitimate content still renders

## Verification

`cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` (1831 unit + 46 integration + 11 property + 3 doc) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)