### PR TITLE
Fix correctness bugs across analyzers (closes #452, #453, #454)

### DIFF
--- a/src/analyzers/changes.rs
+++ b/src/analyzers/changes.rs
@@ -66,7 +66,7 @@ use chrono::{DateTime, TimeZone, Utc};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
-use crate::core::{AnalysisContext, Analyzer as AnalyzerTrait, Result};
+use crate::core::{percentile, AnalysisContext, Analyzer as AnalyzerTrait, Result};
 use crate::git::GitRepo;
 
 /// Weights for change-level defect prediction features.
@@ -252,7 +252,7 @@ impl AnalyzerTrait for Analyzer {
         if !complexity_values.is_empty() {
             let mut sorted = complexity_values.clone();
             sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-            normalization.max_file_complexity = percentile(&sorted, 95).max(1.0);
+            normalization.max_file_complexity = percentile(&sorted, 95.0).max(1.0);
         }
 
         // First pass: compute all risk scores
@@ -267,8 +267,8 @@ impl AnalyzerTrait for Analyzer {
         sorted_scores.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
 
         let risk_thresholds = RiskThresholds {
-            high_threshold: percentile(&sorted_scores, HIGH_RISK_PERCENTILE),
-            medium_threshold: percentile(&sorted_scores, MEDIUM_RISK_PERCENTILE),
+            high_threshold: percentile(&sorted_scores, HIGH_RISK_PERCENTILE as f64),
+            medium_threshold: percentile(&sorted_scores, MEDIUM_RISK_PERCENTILE as f64),
         };
 
         // Second pass: build commit risks with risk levels
@@ -331,8 +331,8 @@ impl AnalyzerTrait for Analyzer {
                 low_risk_count,
                 bug_fix_count,
                 avg_risk_score,
-                p50_risk_score: percentile(&sorted_scores, 50),
-                p95_risk_score: percentile(&sorted_scores, 95),
+                p50_risk_score: percentile(&sorted_scores, 50.0),
+                p95_risk_score: percentile(&sorted_scores, 95.0),
             },
             weights: self.weights.clone(),
             normalization,
@@ -863,13 +863,13 @@ fn calculate_normalization_stats(commits: &[CommitFeatures]) -> NormalizationSta
     entropy.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
 
     NormalizationStats {
-        max_lines_added: percentile(&lines_added, 95).max(1.0) as i32,
-        max_lines_deleted: percentile(&lines_deleted, 95).max(1.0) as i32,
-        max_num_files: percentile(&num_files, 95).max(1.0) as i32,
-        max_unique_changes: percentile(&unique_changes, 95).max(1.0) as i32,
-        max_num_developers: percentile(&num_developers, 95).max(1.0) as i32,
-        max_author_experience: percentile(&author_experience, 95).max(1.0) as i32,
-        max_entropy: percentile(&entropy, 95).max(1.0),
+        max_lines_added: percentile(&lines_added, 95.0).max(1.0) as i32,
+        max_lines_deleted: percentile(&lines_deleted, 95.0).max(1.0) as i32,
+        max_num_files: percentile(&num_files, 95.0).max(1.0) as i32,
+        max_unique_changes: percentile(&unique_changes, 95.0).max(1.0) as i32,
+        max_num_developers: percentile(&num_developers, 95.0).max(1.0) as i32,
+        max_author_experience: percentile(&author_experience, 95.0).max(1.0) as i32,
+        max_entropy: percentile(&entropy, 95.0).max(1.0),
         // File-level stats are set to defaults here; caller updates from actual data.
         max_file_complexity: 15.0,
         max_file_churn: 1.0,
@@ -1081,14 +1081,6 @@ fn generate_recommendations(
 }
 
 /// Calculate percentile from sorted slice.
-fn percentile(sorted: &[f64], p: usize) -> f64 {
-    if sorted.is_empty() {
-        return 0.0;
-    }
-    let idx = (p as f64 / 100.0 * (sorted.len() - 1) as f64).round() as usize;
-    sorted[idx.min(sorted.len() - 1)]
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1158,12 +1150,12 @@ mod tests {
 
     #[test]
     fn test_percentile_calculation() {
-        let values = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0];
+        let values: Vec<f64> = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0];
         // P50 with 10 items: idx = round(0.5 * 9) = 5, value = 6.0
-        assert!((percentile(&values, 50) - 6.0).abs() < 0.001);
+        assert!((percentile(&values, 50.0) - 6.0).abs() < 0.001);
         // P95 with 10 items: idx = round(0.95 * 9) = 9, value = 10.0
-        assert!((percentile(&values, 95) - 10.0).abs() < 0.001);
-        assert_eq!(percentile(&[], 50), 0.0);
+        assert!((percentile(&values, 95.0) - 10.0).abs() < 0.001);
+        assert_eq!(percentile::<f64>(&[], 50.0), 0.0);
     }
 
     #[test]

--- a/src/analyzers/churn.rs
+++ b/src/analyzers/churn.rs
@@ -26,7 +26,7 @@ use std::io::{BufRead, BufReader};
 use chrono::{DateTime, TimeZone, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::core::{AnalysisContext, Analyzer as AnalyzerTrait, Error, Result};
+use crate::core::{percentile, AnalysisContext, Analyzer as AnalyzerTrait, Error, Result};
 use crate::git::GitRepo;
 
 /// Churn analyzer using git log.
@@ -73,7 +73,8 @@ impl AnalyzerTrait for Analyzer {
         let start = Instant::now();
 
         let git_path = ctx.git_path.unwrap_or(ctx.root);
-        let repo_root = git_path
+        let analysis_root = ctx
+            .root
             .to_str()
             .ok_or_else(|| Error::git("Invalid repository path"))?;
 
@@ -91,10 +92,33 @@ impl AnalyzerTrait for Analyzer {
         let commits = repo.log_with_stats(since.as_deref(), None)?;
 
         // Convert to file metrics
-        let file_metrics = commits_to_file_metrics(&commits);
+        let mut file_metrics = commits_to_file_metrics(&commits);
+        let repo_root = repo.root().canonicalize().map_err(Error::Io)?;
+        let analysis_root_canonical = ctx.root.canonicalize().map_err(Error::Io)?;
+        let prefix = analysis_root_canonical
+            .strip_prefix(&repo_root)
+            .map_err(|_| Error::git("Analysis path is outside the discovered repository"))?;
+        let allowed: HashMap<String, String> = ctx
+            .files
+            .iter()
+            .map(|path| {
+                (
+                    prefix.join(path).to_string_lossy().replace('\\', "/"),
+                    path.to_string_lossy().replace('\\', "/"),
+                )
+            })
+            .collect();
+        file_metrics.retain(|repo_path, metrics| {
+            let Some(relative_path) = allowed.get(repo_path) else {
+                return false;
+            };
+            metrics.relative_path.clone_from(relative_path);
+            metrics.path = format!("./{relative_path}");
+            true
+        });
 
         // Build analysis from metrics
-        let analysis = build_analysis(file_metrics, repo_root, self.days);
+        let analysis = build_analysis(file_metrics, analysis_root, self.days);
 
         tracing::info!(
             "Churn analysis completed in {:?}: {} files",
@@ -409,17 +433,8 @@ fn calculate_statistics(summary: &mut Summary, files: &[FileMetrics]) {
     let mut scores: Vec<f64> = files.iter().map(|f| f.churn_score).collect();
     scores.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
 
-    summary.p50_churn_score = percentile(&scores, 50);
-    summary.p95_churn_score = percentile(&scores, 95);
-}
-
-/// Calculate percentile from sorted slice.
-fn percentile(sorted: &[f64], p: usize) -> f64 {
-    if sorted.is_empty() {
-        return 0.0;
-    }
-    let idx = (p * sorted.len()) / 100;
-    sorted[idx.min(sorted.len() - 1)]
+    summary.p50_churn_score = percentile(&scores, 50.0);
+    summary.p95_churn_score = percentile(&scores, 95.0);
 }
 
 /// Identify hotspot and stable files.
@@ -514,6 +529,55 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_churn_discovers_repo_and_limits_results_to_analysis_subdirectory() {
+        use crate::config::Config;
+        use crate::core::{AnalysisContext, Analyzer as _, FileSet};
+
+        let temp = tempfile::tempdir().unwrap();
+        for args in [
+            vec!["init"],
+            vec!["config", "user.email", "test@example.com"],
+            vec!["config", "user.name", "Test User"],
+        ] {
+            assert!(std::process::Command::new("git")
+                .args(args)
+                .current_dir(temp.path())
+                .status()
+                .unwrap()
+                .success());
+        }
+        std::fs::create_dir_all(temp.path().join("src/output")).unwrap();
+        std::fs::write(
+            temp.path().join("src/output/report.rs"),
+            "pub fn report() {}\n",
+        )
+        .unwrap();
+        std::fs::write(temp.path().join("outside.rs"), "pub fn outside() {}\n").unwrap();
+        assert!(std::process::Command::new("git")
+            .args(["add", "."])
+            .current_dir(temp.path())
+            .status()
+            .unwrap()
+            .success());
+        assert!(std::process::Command::new("git")
+            .args(["commit", "-m", "initial"])
+            .current_dir(temp.path())
+            .status()
+            .unwrap()
+            .success());
+
+        let subdir = temp.path().join("src/output");
+        let config = Config::default();
+        let files = FileSet::from_path(&subdir, &config).unwrap();
+        let ctx = AnalysisContext::new(&files, &config, Some(&subdir)).with_git_path(&subdir);
+        let result = Analyzer::new().with_days(u32::MAX).analyze(&ctx).unwrap();
+
+        assert_eq!(result.files.len(), 1);
+        assert_eq!(result.files[0].relative_path, "report.rs");
+        assert_eq!(result.files[0].path, "./report.rs");
+    }
+
+    #[test]
     fn test_analyzer_creation() {
         let analyzer = Analyzer::new();
         assert_eq!(analyzer.name(), "churn");
@@ -554,15 +618,15 @@ mod tests {
 
     #[test]
     fn test_percentile() {
-        let sorted = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0];
-        assert!((percentile(&sorted, 50) - 6.0).abs() < 0.001);
-        assert!((percentile(&sorted, 90) - 10.0).abs() < 0.001);
+        let sorted: Vec<f64> = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0];
+        assert!((percentile(&sorted, 50.0) - 6.0).abs() < 0.001);
+        assert!((percentile(&sorted, 90.0) - 9.0).abs() < 0.001);
     }
 
     #[test]
     fn test_percentile_empty() {
         let sorted: Vec<f64> = vec![];
-        assert_eq!(percentile(&sorted, 50), 0.0);
+        assert_eq!(percentile(&sorted, 50.0), 0.0);
     }
 
     #[test]
@@ -854,25 +918,23 @@ mod tests {
         // 20 values: 0.05, 0.10, ..., 1.00
         let sorted: Vec<f64> = (1..=20).map(|i| i as f64 * 0.05).collect();
 
-        // p50: index = (50 * 20) / 100 = 10 -> sorted[10] = 0.55
-        assert!((percentile(&sorted, 50) - 0.55).abs() < 1e-9);
+        assert!((percentile(&sorted, 50.0) - 0.55).abs() < 1e-9);
 
-        // p95: index = (95 * 20) / 100 = 19 -> sorted[19] = 1.0
-        assert!((percentile(&sorted, 95) - 1.0).abs() < 1e-9);
+        assert!((percentile(&sorted, 95.0) - 0.95).abs() < 1e-9);
 
         // p0: index = 0 -> sorted[0] = 0.05
-        assert!((percentile(&sorted, 0) - 0.05).abs() < 1e-9);
+        assert!((percentile(&sorted, 0.0) - 0.05).abs() < 1e-9);
 
         // p100: index = 20, clamped to 19 -> sorted[19] = 1.0
-        assert!((percentile(&sorted, 100) - 1.0).abs() < 1e-9);
+        assert!((percentile(&sorted, 100.0) - 1.0).abs() < 1e-9);
     }
 
     #[test]
     fn test_percentile_single_element() {
-        let sorted = vec![0.42];
-        assert!((percentile(&sorted, 0) - 0.42).abs() < 1e-9);
-        assert!((percentile(&sorted, 50) - 0.42).abs() < 1e-9);
-        assert!((percentile(&sorted, 100) - 0.42).abs() < 1e-9);
+        let sorted: Vec<f64> = vec![0.42];
+        assert!((percentile(&sorted, 0.0) - 0.42).abs() < 1e-9);
+        assert!((percentile(&sorted, 50.0) - 0.42).abs() < 1e-9);
+        assert!((percentile(&sorted, 100.0) - 0.42).abs() < 1e-9);
     }
 
     // --- churn score normalization ---

--- a/src/analyzers/cohesion.rs
+++ b/src/analyzers/cohesion.rs
@@ -28,7 +28,7 @@ use chrono::Utc;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::core::{AnalysisContext, Analyzer as AnalyzerTrait, Language, Result};
+use crate::core::{is_test_file, AnalysisContext, Analyzer as AnalyzerTrait, Language, Result};
 use crate::parser::Parser;
 
 /// Default threshold for WMC above which a class is considered complex.
@@ -263,23 +263,6 @@ impl ClassHierarchy {
             .map(|c| c.len() as u32)
             .unwrap_or(0)
     }
-}
-
-/// Checks if a file is a test file.
-fn is_test_file(path: &Path) -> bool {
-    let path_str = path.to_string_lossy();
-    path_str.ends_with("_test.go")
-        || path_str.ends_with("_test.py")
-        || path_str.ends_with(".test.ts")
-        || path_str.ends_with(".test.js")
-        || path_str.ends_with(".spec.ts")
-        || path_str.ends_with(".spec.js")
-        || path_str.contains("/test/")
-        || path_str.contains("/tests/")
-        || path_str.contains("/__tests__/")
-        || path_str.starts_with("__tests__/")
-        || path_str.starts_with("test/")
-        || path_str.starts_with("tests/")
 }
 
 /// Extracts class metrics from a parsed file.

--- a/src/analyzers/complexity.rs
+++ b/src/analyzers/complexity.rs
@@ -34,7 +34,9 @@ use std::time::Instant;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::core::{AnalysisContext, Analyzer as AnalyzerTrait, Language, Result, SourceFile};
+use crate::core::{
+    percentile, AnalysisContext, Analyzer as AnalyzerTrait, Language, Result, SourceFile,
+};
 use crate::parser::queries::{
     get_decision_node_types, get_flat_node_types, get_nesting_node_types,
 };
@@ -659,24 +661,15 @@ fn build_summary(results: &[FileResult]) -> AnalysisSummary {
         all_cyclomatic.sort_unstable();
         all_cognitive.sort_unstable();
 
-        summary.p50_cyclomatic = percentile(&all_cyclomatic, 50);
-        summary.p90_cyclomatic = percentile(&all_cyclomatic, 90);
-        summary.p95_cyclomatic = percentile(&all_cyclomatic, 95);
-        summary.p50_cognitive = percentile(&all_cognitive, 50);
-        summary.p90_cognitive = percentile(&all_cognitive, 90);
-        summary.p95_cognitive = percentile(&all_cognitive, 95);
+        summary.p50_cyclomatic = percentile(&all_cyclomatic, 50.0);
+        summary.p90_cyclomatic = percentile(&all_cyclomatic, 90.0);
+        summary.p95_cyclomatic = percentile(&all_cyclomatic, 95.0);
+        summary.p50_cognitive = percentile(&all_cognitive, 50.0);
+        summary.p90_cognitive = percentile(&all_cognitive, 90.0);
+        summary.p95_cognitive = percentile(&all_cognitive, 95.0);
     }
 
     summary
-}
-
-/// Calculate percentile value from sorted slice.
-fn percentile(sorted: &[u32], p: usize) -> u32 {
-    if sorted.is_empty() {
-        return 0;
-    }
-    let idx = (p * sorted.len()) / 100;
-    sorted[idx.min(sorted.len() - 1)]
 }
 
 #[cfg(test)]
@@ -848,16 +841,14 @@ mod tests {
     #[test]
     fn test_percentile() {
         let sorted = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-        // p=50 -> idx=(50*10)/100=5 -> sorted[5]=6
-        assert_eq!(percentile(&sorted, 50), 6);
-        // p=90 -> idx=(90*10)/100=9 -> sorted[9]=10
-        assert_eq!(percentile(&sorted, 90), 10);
+        assert_eq!(percentile(&sorted, 50.0), 6);
+        assert_eq!(percentile(&sorted, 90.0), 9);
     }
 
     #[test]
     fn test_percentile_empty() {
         let sorted: Vec<u32> = vec![];
-        assert_eq!(percentile(&sorted, 50), 0);
+        assert_eq!(percentile(&sorted, 50.0), 0);
     }
 
     #[test]

--- a/src/analyzers/deadcode.rs
+++ b/src/analyzers/deadcode.rs
@@ -15,7 +15,7 @@ use std::time::Instant;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::core::{AnalysisContext, Analyzer as AnalyzerTrait, Language, Result};
+use crate::core::{is_test_file, AnalysisContext, Analyzer as AnalyzerTrait, Language, Result};
 use crate::parser::{self, Parser};
 
 /// Dead code analyzer.
@@ -46,6 +46,15 @@ impl Analyzer {
     /// Analyze a single file for definitions and usages.
     fn analyze_file(&self, path: &std::path::Path) -> Result<FileDeadCode> {
         let result = self.parser.parse_file(path)?;
+        Ok(collect_file_data(&result))
+    }
+
+    fn analyze_content(&self, path: &std::path::Path, content: Vec<u8>) -> Result<FileDeadCode> {
+        let language =
+            Language::detect(path).ok_or_else(|| crate::core::Error::UnsupportedLanguage {
+                path: path.to_path_buf(),
+            })?;
+        let result = self.parser.parse(&content, language, path)?;
         Ok(collect_file_data(&result))
     }
 }
@@ -90,8 +99,13 @@ impl AnalyzerTrait for Analyzer {
         let file_results: Vec<FileDeadCode> = files
             .par_iter()
             .filter_map(|path| {
-                let full_path = ctx.root.join(path);
-                self.analyze_file(&full_path).ok()
+                if ctx.content_source.is_some() {
+                    ctx.read_file(path)
+                        .ok()
+                        .and_then(|content| self.analyze_content(path, content).ok())
+                } else {
+                    self.analyze_file(&ctx.root.join(path)).ok()
+                }
             })
             .collect();
 
@@ -1129,20 +1143,6 @@ fn is_generated_file(path: &str) -> bool {
     false
 }
 
-fn is_test_file(path: &str) -> bool {
-    path.ends_with("_test.go")
-        || path.ends_with("_test.py")
-        || path.ends_with(".test.ts")
-        || path.ends_with(".test.js")
-        || path.ends_with(".spec.ts")
-        || path.ends_with(".spec.js")
-        || path.ends_with("_spec.rb")
-        || path.ends_with("_test.rb")
-        || path.contains("/test/")
-        || path.contains("/tests/")
-        || path.contains("/__tests__/")
-}
-
 fn is_entry_point(name: &str, def: &Definition) -> bool {
     // Standard entry points
     if name == "main" || name == "init" || name == "Main" {
@@ -1293,6 +1293,44 @@ pub struct AnalysisSummary {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_analyzer_uses_content_source_for_historical_commits() {
+        use crate::config::Config;
+        use crate::core::{AnalysisContext, Analyzer as _, FileSet, FilesystemSource};
+        use std::path::PathBuf;
+        use std::sync::Arc;
+
+        let current = tempfile::tempdir().unwrap();
+        let historical = tempfile::tempdir().unwrap();
+        std::fs::write(
+            current.path().join("code.ts"),
+            "export function currentVersion() {}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            historical.path().join("code.ts"),
+            "function historicalUnused() {}\n",
+        )
+        .unwrap();
+        let files =
+            FileSet::from_files(current.path().to_path_buf(), vec![PathBuf::from("code.ts")]);
+        let config = Config::default();
+        let source = Arc::new(FilesystemSource::new(historical.path()));
+        let ctx =
+            AnalysisContext::new(&files, &config, Some(current.path())).with_content_source(source);
+
+        let result = Analyzer::new().analyze(&ctx).unwrap();
+
+        assert!(result
+            .items
+            .iter()
+            .any(|item| item.name == "historicalUnused"));
+        assert!(!result
+            .items
+            .iter()
+            .any(|item| item.name == "currentVersion"));
+    }
 
     #[test]
     fn test_analyzer_creation() {

--- a/src/analyzers/defect.rs
+++ b/src/analyzers/defect.rs
@@ -14,7 +14,7 @@ use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::analyzers::{complexity, duplicates, graph};
-use crate::core::{AnalysisContext, Analyzer as AnalyzerTrait, Result};
+use crate::core::{percentile, AnalysisContext, Analyzer as AnalyzerTrait, Result};
 use crate::git::GitRepo;
 
 /// Risk level categories (PMAT-compatible).
@@ -678,14 +678,6 @@ fn sigmoid(raw_score: f32) -> f32 {
 }
 
 /// Calculate percentile from sorted values.
-fn percentile(sorted: &[f32], p: f32) -> f32 {
-    if sorted.is_empty() {
-        return 0.0;
-    }
-    let idx = ((p / 100.0) * (sorted.len() - 1) as f32).round() as usize;
-    sorted[idx.min(sorted.len() - 1)]
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -755,7 +747,7 @@ mod tests {
 
     #[test]
     fn test_percentile() {
-        let values = vec![0.1, 0.2, 0.3, 0.4, 0.5];
+        let values: Vec<f32> = vec![0.1, 0.2, 0.3, 0.4, 0.5];
         assert!((percentile(&values, 50.0) - 0.3).abs() < 0.001);
         assert!((percentile(&values, 0.0) - 0.1).abs() < 0.001);
         assert!((percentile(&values, 100.0) - 0.5).abs() < 0.001);

--- a/src/analyzers/duplicates.rs
+++ b/src/analyzers/duplicates.rs
@@ -20,7 +20,7 @@ use std::collections::{HashMap, HashSet};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::core::{AnalysisContext, Analyzer as AnalyzerTrait, Result};
+use crate::core::{percentile, AnalysisContext, Analyzer as AnalyzerTrait, Result};
 
 /// Clone type classification.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -1344,15 +1344,6 @@ fn hash_band(values: &[u64], seed: u64) -> u64 {
 }
 
 /// Calculate percentile from sorted values.
-fn percentile(sorted: &[f64], p: f64) -> f64 {
-    if sorted.is_empty() {
-        return 0.0;
-    }
-
-    let idx = ((p / 100.0) * (sorted.len() - 1) as f64).round() as usize;
-    sorted[idx.min(sorted.len() - 1)]
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1490,7 +1481,7 @@ mod tests {
 
     #[test]
     fn test_percentile() {
-        let values = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+        let values: Vec<f64> = vec![1.0, 2.0, 3.0, 4.0, 5.0];
         assert!((percentile(&values, 50.0) - 3.0).abs() < 0.001);
         assert!((percentile(&values, 0.0) - 1.0).abs() < 0.001);
         assert!((percentile(&values, 100.0) - 5.0).abs() < 0.001);

--- a/src/analyzers/outline.rs
+++ b/src/analyzers/outline.rs
@@ -94,8 +94,12 @@ impl OutlineResult {
 /// Analyze a single file and return its outline.
 pub fn outline_file(path: &Path) -> Result<FileOutline> {
     let file = SourceFile::load(path)?;
+    outline_source(&file)
+}
+
+fn outline_source(file: &SourceFile) -> Result<FileOutline> {
     let parser = Parser::new();
-    let result = parser.parse_source(&file)?;
+    let result = parser.parse_source(file)?;
 
     let imports: Vec<String> = extract_imports(&result)
         .into_iter()
@@ -171,7 +175,7 @@ pub fn outline_file(path: &Path) -> Result<FileOutline> {
 
     let loc = file.lines_of_code() as u32;
     let language = result.language.to_string();
-    let file_str = path.to_string_lossy().to_string();
+    let file_str = file.path.to_string_lossy().to_string();
 
     Ok(FileOutline {
         file: file_str,
@@ -208,11 +212,20 @@ impl AnalyzerTrait for Analyzer {
     }
 
     fn analyze(&self, ctx: &AnalysisContext<'_>) -> Result<Self::Output> {
-        let files: Vec<PathBuf> = ctx.files.iter().map(|p| ctx.root.join(p)).collect();
+        let files: Vec<PathBuf> = ctx.files.iter().cloned().collect();
 
         let mut file_outlines: Vec<FileOutline> = files
             .par_iter()
-            .filter_map(|path| outline_file(path).ok())
+            .filter_map(|path| {
+                if ctx.content_source.is_some() {
+                    let content = ctx.read_file(path).ok()?;
+                    let language = crate::core::Language::detect(path)?;
+                    let file = SourceFile::from_content(path, language, content);
+                    outline_source(&file).ok()
+                } else {
+                    outline_file(&ctx.root.join(path)).ok()
+                }
+            })
             .map(|mut fo| {
                 // Make paths relative to root
                 if let Ok(rel) = Path::new(&fo.file).strip_prefix(ctx.root) {
@@ -234,6 +247,41 @@ impl AnalyzerTrait for Analyzer {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_analyzer_uses_content_source_for_historical_commits() {
+        use crate::config::Config;
+        use crate::core::{AnalysisContext, Analyzer as _, FileSet, FilesystemSource};
+        use std::sync::Arc;
+
+        let current = tempfile::tempdir().unwrap();
+        let historical = tempfile::tempdir().unwrap();
+        std::fs::write(
+            current.path().join("code.ts"),
+            "export function currentVersion() {}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            historical.path().join("code.ts"),
+            "export function historicalVersion() {}\n",
+        )
+        .unwrap();
+        let files =
+            FileSet::from_files(current.path().to_path_buf(), vec![PathBuf::from("code.ts")]);
+        let config = Config::default();
+        let source = Arc::new(FilesystemSource::new(historical.path()));
+        let ctx =
+            AnalysisContext::new(&files, &config, Some(current.path())).with_content_source(source);
+
+        let result = Analyzer.analyze(&ctx).unwrap();
+        let names: Vec<&str> = result.files[0]
+            .functions
+            .iter()
+            .map(|f| f.name.as_str())
+            .collect();
+
+        assert_eq!(names, vec!["historicalVersion"]);
+    }
     use std::path::PathBuf;
 
     fn fixture(name: &str) -> PathBuf {

--- a/src/analyzers/repomap.rs
+++ b/src/analyzers/repomap.rs
@@ -15,7 +15,7 @@ use petgraph::Direction;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::core::{AnalysisContext, Analyzer as AnalyzerTrait, Language, Result};
+use crate::core::{is_test_file, AnalysisContext, Analyzer as AnalyzerTrait, Language, Result};
 use crate::parser::{extract_functions, Parser};
 
 /// Repomap analyzer configuration.
@@ -692,24 +692,6 @@ fn extract_call_name(node: &tree_sitter::Node<'_>, source: &[u8]) -> Option<Stri
         }
     }
     None
-}
-
-fn is_test_file(path: &Path) -> bool {
-    // Normalise to forward slashes so Windows paths (using `\`) are handled.
-    let path_str = path.to_string_lossy().replace('\\', "/");
-    path_str.contains("/test")
-        || path_str.contains("/tests/")
-        || path_str.contains("_test.")
-        || path_str.contains("test_")
-        || path_str.ends_with("_test.go")
-        || path_str.ends_with(".test.ts")
-        || path_str.ends_with(".spec.ts")
-        || path_str.ends_with(".test.js")
-        || path_str.ends_with(".spec.js")
-        || path_str.ends_with(".test.tsx")
-        || path_str.ends_with(".spec.tsx")
-        || path_str.ends_with(".test.jsx")
-        || path_str.ends_with(".spec.jsx")
 }
 
 #[cfg(test)]

--- a/src/analyzers/satd.rs
+++ b/src/analyzers/satd.rs
@@ -8,7 +8,7 @@ use rayon::prelude::*;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
-use crate::core::{AnalysisContext, Analyzer as AnalyzerTrait, Result, SourceFile};
+use crate::core::{AnalysisContext, Analyzer as AnalyzerTrait, Language, Result, SourceFile};
 use crate::parser::queries::satd;
 
 /// SATD analyzer.
@@ -153,8 +153,9 @@ impl AnalyzerTrait for Analyzer {
         let (items, total_loc): (Vec<SatdItem>, usize) = files
             .par_iter()
             .filter_map(|path| {
-                let full_path = ctx.root.join(path);
-                SourceFile::load(&full_path).ok()
+                let content = ctx.read_file(path).ok()?;
+                let language = Language::detect(path)?;
+                Some(SourceFile::from_content(*path, language, content))
             })
             .map(|file| {
                 let loc = file.lines_of_code();
@@ -290,6 +291,38 @@ fn severity_from_weight(weight: f64) -> Severity {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_analyzer_uses_content_source_for_historical_commits() {
+        use crate::config::Config;
+        use crate::core::{AnalysisContext, Analyzer as _, FileSet, FilesystemSource};
+        use std::path::PathBuf;
+        use std::sync::Arc;
+
+        let current = tempfile::tempdir().unwrap();
+        let historical = tempfile::tempdir().unwrap();
+        std::fs::write(
+            current.path().join("debt.ts"),
+            "export const clean = true;\n",
+        )
+        .unwrap();
+        std::fs::write(
+            historical.path().join("debt.ts"),
+            "// TODO: historical debt\n",
+        )
+        .unwrap();
+        let files =
+            FileSet::from_files(current.path().to_path_buf(), vec![PathBuf::from("debt.ts")]);
+        let config = Config::default();
+        let source = Arc::new(FilesystemSource::new(historical.path()));
+        let ctx =
+            AnalysisContext::new(&files, &config, Some(current.path())).with_content_source(source);
+
+        let result = Analyzer::new().analyze(&ctx).unwrap();
+
+        assert_eq!(result.items.len(), 1);
+        assert_eq!(result.items[0].file, "debt.ts");
+    }
     use crate::core::Language;
 
     #[test]

--- a/src/analyzers/temporal.rs
+++ b/src/analyzers/temporal.rs
@@ -21,7 +21,7 @@ use std::path::Path;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 
-use crate::core::{AnalysisContext, Analyzer as AnalyzerTrait, Error, Result};
+use crate::core::{is_test_file, AnalysisContext, Analyzer as AnalyzerTrait, Error, Result};
 use crate::git::GitRepo;
 
 /// Default minimum number of co-changes to consider files coupled.
@@ -353,51 +353,6 @@ pub struct Summary {
     pub max_coupling_strength: f64,
     /// Total number of files analyzed.
     pub total_files_analyzed: usize,
-}
-
-/// Returns true if the path looks like a test file.
-fn is_test_file(path: &str) -> bool {
-    let lower = path.to_lowercase();
-    let parts: Vec<&str> = lower.split('/').collect();
-
-    // Directory-based patterns
-    for part in &parts {
-        match *part {
-            "test" | "tests" | "spec" | "specs" | "__tests__" | "__mocks__" | "test_helpers"
-            | "testdata" | "fixtures" => return true,
-            _ => {}
-        }
-        // Java/Maven convention: src/test/...
-        if *part == "src" {
-            if let Some(next_idx) = parts.iter().position(|p| *p == *part) {
-                if parts.get(next_idx + 1) == Some(&"test") {
-                    return true;
-                }
-            }
-        }
-    }
-
-    // Filename-based patterns
-    if let Some(filename) = parts.last() {
-        // _test.go, _test.rb, etc.
-        if filename.contains("_test.") || filename.contains("_spec.") {
-            return true;
-        }
-        // test_*.py
-        if filename.starts_with("test_") {
-            return true;
-        }
-        // *.test.ts, *.spec.js, etc.
-        let dot_parts: Vec<&str> = filename.split('.').collect();
-        if dot_parts.len() >= 3 {
-            let second_last = dot_parts[dot_parts.len() - 2];
-            if second_last == "test" || second_last == "spec" {
-                return true;
-            }
-        }
-    }
-
-    false
 }
 
 #[cfg(test)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -159,8 +159,8 @@ pub struct AnalyzerArgs {
     pub glob: Option<String>,
 
     /// Exclude files matching pattern
-    #[arg(short, long)]
-    pub exclude: Option<String>,
+    #[arg(short, long, action = clap::ArgAction::Append)]
+    pub exclude: Vec<String>,
 
     /// Analyze only files changed since the given git ref
     #[arg(long)]
@@ -1084,9 +1084,13 @@ mod tests {
     }
 
     #[test]
-    fn test_analyzer_args_exclude() {
-        let args = parse_complexity_args(&["omen", "complexity", "-e", "test"]);
-        assert_eq!(args.common.exclude, Some("test".to_string()));
+    fn test_analyzer_args_exclude_is_repeatable() {
+        let args =
+            parse_complexity_args(&["omen", "complexity", "-e", "tests/**", "-e", "fixtures/**"]);
+        assert_eq!(
+            args.common.exclude,
+            vec!["tests/**".to_string(), "fixtures/**".to_string()]
+        );
     }
 
     #[test]

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -7,6 +7,7 @@ mod file_set;
 mod language;
 pub mod progress;
 mod source_file;
+mod utils;
 
 pub use analyzer::{AnalysisContext, AnalysisResult, Analyzer, Summary};
 pub use content_source::{ContentSource, FilesystemSource, TreeSource};
@@ -15,3 +16,33 @@ pub use file_set::FileSet;
 pub use language::Language;
 pub use progress::{create_progress, create_spinner, is_tty, ProgressBuilder, ProgressTracker};
 pub use source_file::SourceFile;
+pub use utils::{is_test_file, percentile};
+
+#[cfg(test)]
+mod shared_helper_tests {
+    use super::{is_test_file, percentile};
+    use std::path::Path;
+
+    #[test]
+    fn test_percentile_uses_rounded_len_minus_one_index() {
+        let values: Vec<u32> = (1..=10).collect();
+        assert_eq!(percentile(&values, 90.0), 9);
+    }
+
+    #[test]
+    fn test_percentile_handles_empty_and_endpoints() {
+        assert_eq!(percentile::<u32>(&[], 90.0), 0);
+        assert_eq!(percentile(&[10, 20, 30], 0.0), 10);
+        assert_eq!(percentile(&[10, 20, 30], 100.0), 30);
+    }
+
+    #[test]
+    fn test_is_test_file_uses_path_components_not_substrings() {
+        assert!(!is_test_file(Path::new("src/contest_runner.rs")));
+        assert!(!is_test_file(Path::new("test.rs")));
+        assert!(is_test_file(Path::new("src/test_utils.rs")));
+        assert!(is_test_file(Path::new("packages/app/__tests__/app.ts")));
+        assert!(is_test_file(Path::new("src/test/java/FooTest.java")));
+        assert!(is_test_file(Path::new("spec/models/user_spec.rb")));
+    }
+}

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -1,0 +1,52 @@
+use std::path::Path;
+
+/// Return the percentile at the rounded `p / 100 * (len - 1)` index.
+///
+/// This definition selects the nearest observed value without interpolation.
+/// The input must already be sorted. Empty inputs return `T::default()`.
+pub fn percentile<T: Copy + Default>(sorted: &[T], p: f64) -> T {
+    if sorted.is_empty() {
+        return T::default();
+    }
+
+    let percentile = p.clamp(0.0, 100.0);
+    let index = (percentile / 100.0 * (sorted.len() - 1) as f64).round() as usize;
+    sorted[index]
+}
+
+/// Return whether a path follows a supported test-file convention.
+pub fn is_test_file(path: impl AsRef<Path>) -> bool {
+    let path = path.as_ref();
+    let normalized = path.to_string_lossy().replace('\\', "/").to_lowercase();
+    let parts: Vec<&str> = normalized.split('/').collect();
+
+    if parts.iter().any(|part| {
+        matches!(
+            *part,
+            "test"
+                | "tests"
+                | "spec"
+                | "specs"
+                | "__tests__"
+                | "__mocks__"
+                | "test_helpers"
+                | "testdata"
+                | "fixtures"
+        )
+    }) {
+        return true;
+    }
+
+    let Some(filename) = parts.last() else {
+        return false;
+    };
+    filename.starts_with("test_")
+        || filename.contains("_test.")
+        || filename.contains("_spec.")
+        || (filename.matches('.').count() >= 2
+            && filename
+                .split('.')
+                .rev()
+                .nth(1)
+                .is_some_and(|segment| segment == "test" || segment == "spec"))
+}

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -28,8 +28,8 @@ impl GitRepo {
     /// Open a git repository at the given path.
     pub fn open(path: impl AsRef<Path>) -> Result<Self> {
         let path = path.as_ref();
-        let repo =
-            gix::open(path).map_err(|e| Error::git(format!("Failed to open repository: {e}")))?;
+        let repo = gix::discover(path)
+            .map_err(|e| Error::git(format!("Failed to discover repository: {e}")))?;
         let root = repo
             .workdir()
             .ok_or_else(|| Error::git("Not a work tree"))?

--- a/src/main.rs
+++ b/src/main.rs
@@ -229,7 +229,10 @@ fn run_with_path(cli: &Cli, path: &PathBuf) -> omen::core::Result<()> {
                                         println!("## Component Trends\n");
                                         println!("| Component | Slope | Correlation |");
                                         println!("|-----------|-------|-------------|");
-                                        for (name, stats) in &trend_data.component_trends {
+                                        let mut component_trends: Vec<_> =
+                                            trend_data.component_trends.iter().collect();
+                                        component_trends.sort_by_key(|(name, _)| *name);
+                                        for (name, stats) in component_trends {
                                             println!(
                                                 "| {} | {:.2} | {:.3} |",
                                                 name, stats.slope, stats.correlation
@@ -484,7 +487,7 @@ fn filtered_file_set(
         if let Some(ref glob) = args.glob {
             file_set = file_set.filter_by_glob(glob);
         }
-        if let Some(ref exclude) = args.exclude {
+        for exclude in &args.exclude {
             file_set = file_set.exclude_by_glob(exclude);
         }
     }
@@ -1247,7 +1250,7 @@ fn run_mutation(
     }
 
     // Apply exclude filter if specified
-    if let Some(ref pattern) = args.common.exclude {
+    for pattern in &args.common.exclude {
         file_set = file_set.exclude_by_glob(pattern);
     }
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -180,6 +180,7 @@ impl McpServer {
         tool_name: &str,
         mut value: serde_json::Value,
         args: &serde_json::Value,
+        git_skipped_reason: Option<&str>,
     ) -> std::result::Result<serde_json::Value, String> {
         let limit = args["limit"].as_u64().unwrap_or(50) as usize;
         let offset = args["offset"].as_u64().unwrap_or(0) as usize;
@@ -189,13 +190,16 @@ impl McpServer {
         // Count returned items by summing array lengths AFTER truncation.
         let returned = count_items(&value);
 
-        let envelope = json!({
+        let mut envelope = json!({
             "tool": tool_name,
             "total_items": total_items,
             "returned": returned,
             "offset": offset,
             "result": value
         });
+        if let Some(reason) = git_skipped_reason {
+            envelope["git_skipped_reason"] = json!(reason);
+        }
 
         Ok(json!({
             "content": [{
@@ -495,7 +499,10 @@ impl McpServer {
             .map_err(|e| format!("Failed to create file set: {}", e))?;
 
         // Try to open a git repository at the path
-        let git_root = GitRepo::open(&path).ok().map(|r| r.root().to_path_buf());
+        let (git_root, git_skipped_reason) = match GitRepo::open(&path) {
+            Ok(repo) => (Some(repo.root().to_path_buf()), None),
+            Err(error) => (None, Some(error.to_string())),
+        };
 
         let mut ctx = AnalysisContext::new(&file_set, &self.config, Some(&path));
         if let Some(ref git_path) = git_root {
@@ -544,7 +551,7 @@ impl McpServer {
             _ => Err(format!("Unknown tool: {}", tool_name)),
         }?;
 
-        self.tool_response(tool_name, result, &arguments)
+        self.tool_response(tool_name, result, &arguments, git_skipped_reason.as_deref())
     }
 
     fn run_analyzer<A: Analyzer + Default>(
@@ -602,7 +609,7 @@ impl McpServer {
 
         let value =
             serde_json::to_value(&context).map_err(|e| format!("Serialization failed: {}", e))?;
-        self.tool_response("context", value, arguments)
+        self.tool_response("context", value, arguments, None)
     }
 
     fn handle_diff(
@@ -628,7 +635,7 @@ impl McpServer {
         let value =
             serde_json::to_value(&result).map_err(|e| format!("Serialization failed: {}", e))?;
 
-        self.tool_response("diff", value, arguments)
+        self.tool_response("diff", value, arguments, None)
     }
 
     fn handle_semantic_search(&self, arguments: &Value) -> std::result::Result<Value, String> {
@@ -723,7 +730,7 @@ impl McpServer {
         let result =
             serde_json::to_value(&output).map_err(|e| format!("Serialization failed: {}", e))?;
 
-        self.tool_response("semantic_search", result, arguments)
+        self.tool_response("semantic_search", result, arguments, None)
     }
 
     fn handle_semantic_search_hyde(&self, arguments: &Value) -> std::result::Result<Value, String> {
@@ -830,7 +837,7 @@ impl McpServer {
         let result =
             serde_json::to_value(&output).map_err(|e| format!("Serialization failed: {}", e))?;
 
-        self.tool_response("semantic_search_hyde", result, arguments)
+        self.tool_response("semantic_search_hyde", result, arguments, None)
     }
 
     fn handle_outline(
@@ -876,7 +883,7 @@ impl McpServer {
         let value =
             serde_json::to_value(&result).map_err(|e| format!("Serialization failed: {}", e))?;
 
-        self.tool_response("outline", value, arguments)
+        self.tool_response("outline", value, arguments, None)
     }
 
     fn handle_impact(
@@ -916,7 +923,7 @@ impl McpServer {
         let value =
             serde_json::to_value(&report).map_err(|e| format!("Serialization failed: {}", e))?;
 
-        self.tool_response("impact", value, arguments)
+        self.tool_response("impact", value, arguments, None)
     }
 
     fn handle_get_symbol(
@@ -956,7 +963,7 @@ impl McpServer {
         let value =
             serde_json::to_value(&report).map_err(|e| format!("Serialization failed: {}", e))?;
 
-        self.tool_response("get_symbol", value, arguments)
+        self.tool_response("get_symbol", value, arguments, None)
     }
 }
 
@@ -1206,7 +1213,10 @@ mod tests {
         let text = response["content"][0]["text"].as_str().unwrap();
 
         assert!(text.contains("hints"));
-        assert!(text.contains("mcp_entrypoint"));
+        assert!(
+            text.contains("mcp_entrypoint"),
+            "expected context to contain requested symbol, got {text}"
+        );
     }
 
     #[test]
@@ -1796,7 +1806,9 @@ mod tests {
         let (server, _temp_dir) = create_test_server();
         let value = json!({"items": [1, 2, 3, 4, 5]});
         let args = json!({});
-        let resp = server.tool_response("test_tool", value, &args).unwrap();
+        let resp = server
+            .tool_response("test_tool", value, &args, None)
+            .unwrap();
         let text = resp["content"][0]["text"].as_str().unwrap();
         let envelope: serde_json::Value = serde_json::from_str(text).unwrap();
         assert_eq!(envelope["tool"].as_str().unwrap(), "test_tool");
@@ -1807,10 +1819,28 @@ mod tests {
     }
 
     #[test]
+    fn test_tool_response_envelope_reports_skipped_git_data() {
+        let (server, _temp_dir) = create_test_server();
+        let resp = server
+            .tool_response(
+                "score",
+                json!({"components": {}}),
+                &json!({}),
+                Some("not a git repository"),
+            )
+            .unwrap();
+        let text = resp["content"][0]["text"].as_str().unwrap();
+        let envelope: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(envelope["git_skipped_reason"], "not a git repository");
+    }
+
+    #[test]
     fn test_tool_response_is_compact() {
         let (server, _temp_dir) = create_test_server();
         let value = json!({"items": [1, 2, 3]});
-        let resp = server.tool_response("test", value, &json!({})).unwrap();
+        let resp = server
+            .tool_response("test", value, &json!({}), None)
+            .unwrap();
         let text = resp["content"][0]["text"].as_str().unwrap();
         // Compact: only one line (no internal newlines)
         assert_eq!(text.trim().lines().count(), 1);
@@ -1821,7 +1851,9 @@ mod tests {
         let (server, _temp_dir) = create_test_server();
         let items: Vec<i64> = (0..100).collect();
         let value = json!({"items": items});
-        let resp = server.tool_response("test", value, &json!({})).unwrap();
+        let resp = server
+            .tool_response("test", value, &json!({}), None)
+            .unwrap();
         let text = resp["content"][0]["text"].as_str().unwrap();
         let envelope: serde_json::Value = serde_json::from_str(text).unwrap();
         let returned = envelope["returned"].as_u64().unwrap();
@@ -1835,7 +1867,7 @@ mod tests {
         let items: Vec<i64> = (0..100).collect();
         let value = json!({"items": items});
         let resp = server
-            .tool_response("test", value, &json!({"limit": 0}))
+            .tool_response("test", value, &json!({"limit": 0}), None)
             .unwrap();
         let text = resp["content"][0]["text"].as_str().unwrap();
         let envelope: serde_json::Value = serde_json::from_str(text).unwrap();
@@ -1848,7 +1880,7 @@ mod tests {
         let items: Vec<i64> = (0..20).collect();
         let value = json!({"items": items});
         let resp = server
-            .tool_response("test", value, &json!({"limit": 5, "offset": 10}))
+            .tool_response("test", value, &json!({"limit": 5, "offset": 10}), None)
             .unwrap();
         let text = resp["content"][0]["text"].as_str().unwrap();
         let envelope: serde_json::Value = serde_json::from_str(text).unwrap();
@@ -1867,7 +1899,7 @@ mod tests {
         let smells: Vec<i64> = (0..10).collect();
         let value = json!({"components": components, "smells": smells});
         let resp = server
-            .tool_response("test", value, &json!({"limit": 5}))
+            .tool_response("test", value, &json!({"limit": 5}), None)
             .unwrap();
         let text = resp["content"][0]["text"].as_str().unwrap();
         let envelope: serde_json::Value = serde_json::from_str(text).unwrap();
@@ -1890,7 +1922,7 @@ mod tests {
         let items: Vec<i64> = (0..60).collect();
         let value = json!({"items": items});
         let resp = server
-            .tool_response("test", value, &json!({"limit": 50}))
+            .tool_response("test", value, &json!({"limit": 50}), None)
             .unwrap();
         let text = resp["content"][0]["text"].as_str().unwrap();
         let envelope: serde_json::Value = serde_json::from_str(text).unwrap();

--- a/src/score/mod.rs
+++ b/src/score/mod.rs
@@ -43,10 +43,13 @@ impl AnalyzerTrait for Analyzer {
         macro_rules! run_analyzer {
             ($name:expr, $weight:expr, $analyzer:expr, $score_fn:expr, $details:expr) => {
                 if $weight > 0.0 {
-                    if let Ok(result) = $analyzer.analyze(ctx) {
-                        let score = $score_fn(&result);
-                        let details = $details(&result);
-                        acc.add($name, $weight, score, details);
+                    match $analyzer.analyze(ctx) {
+                        Ok(result) => {
+                            let score = $score_fn(&result);
+                            let details = $details(&result);
+                            acc.add($name, $weight, score, details);
+                        }
+                        Err(error) => acc.skip($name, error.to_string()),
                     }
                 }
             };
@@ -55,49 +58,55 @@ impl AnalyzerTrait for Analyzer {
         // Complexity needs inline handling: skip when no functions are detected,
         // otherwise p90_cyclomatic == 0 produces a false perfect score of 100.
         if self.weights.complexity > 0.0 {
-            if let Ok(result) = crate::analyzers::complexity::Analyzer::new().analyze(ctx) {
-                if result.summary.total_functions > 0 {
-                    let score = calculate_complexity_score(&result);
-                    acc.add(
-                        "complexity",
-                        self.weights.complexity,
-                        score,
-                        format!(
-                            "Analyzed {} files, p90 cyclomatic: {}, avg: {:.1}",
-                            result.files.len(),
-                            result.summary.p90_cyclomatic,
-                            result.summary.avg_cyclomatic
-                        ),
-                    );
+            match crate::analyzers::complexity::Analyzer::new().analyze(ctx) {
+                Ok(result) => {
+                    if result.summary.total_functions > 0 {
+                        let score = calculate_complexity_score(&result);
+                        acc.add(
+                            "complexity",
+                            self.weights.complexity,
+                            score,
+                            format!(
+                                "Analyzed {} files, p90 cyclomatic: {}, avg: {:.1}",
+                                result.files.len(),
+                                result.summary.p90_cyclomatic,
+                                result.summary.avg_cyclomatic
+                            ),
+                        );
+                    }
                 }
+                Err(error) => acc.skip("complexity", error.to_string()),
             }
         }
 
         // SATD needs file_count from ctx, so handle inline
         if self.weights.satd > 0.0 {
-            if let Ok(result) = crate::analyzers::satd::Analyzer::new().analyze(ctx) {
-                let score = calculate_satd_score(&result, ctx.files.files().len());
-                let high_priority = result
-                    .items
-                    .iter()
-                    .filter(|i| {
-                        matches!(
-                            i.severity,
-                            crate::analyzers::satd::Severity::Critical
-                                | crate::analyzers::satd::Severity::High
-                        )
-                    })
-                    .count();
-                acc.add(
-                    "satd",
-                    self.weights.satd,
-                    score,
-                    format!(
-                        "Found {} debt items ({} high priority)",
-                        result.items.len(),
-                        high_priority
-                    ),
-                );
+            match crate::analyzers::satd::Analyzer::new().analyze(ctx) {
+                Ok(result) => {
+                    let score = calculate_satd_score(&result, ctx.files.files().len());
+                    let high_priority = result
+                        .items
+                        .iter()
+                        .filter(|i| {
+                            matches!(
+                                i.severity,
+                                crate::analyzers::satd::Severity::Critical
+                                    | crate::analyzers::satd::Severity::High
+                            )
+                        })
+                        .count();
+                    acc.add(
+                        "satd",
+                        self.weights.satd,
+                        score,
+                        format!(
+                            "Found {} debt items ({} high priority)",
+                            result.items.len(),
+                            high_priority
+                        ),
+                    );
+                }
+                Err(error) => acc.skip("satd", error.to_string()),
             }
         }
 
@@ -209,6 +218,7 @@ impl AnalyzerTrait for Analyzer {
 #[derive(Default)]
 struct ScoreAccumulator {
     components: HashMap<String, ScoreComponent>,
+    skipped_components: Vec<SkippedComponent>,
     weighted_sum: f64,
     total_weight: f64,
 }
@@ -227,6 +237,13 @@ impl ScoreAccumulator {
         self.total_weight += weight;
     }
 
+    fn skip(&mut self, name: &str, reason: String) {
+        self.skipped_components.push(SkippedComponent {
+            name: name.to_string(),
+            reason,
+        });
+    }
+
     fn into_analysis(self, files_analyzed: usize) -> Result<Analysis> {
         let overall_score = if self.total_weight > 0.0 {
             self.weighted_sum / self.total_weight
@@ -240,6 +257,7 @@ impl ScoreAccumulator {
             overall_score,
             grade,
             components: self.components,
+            skipped_components: self.skipped_components,
             summary: AnalysisSummary {
                 files_analyzed,
                 analyzers_run,
@@ -655,7 +673,14 @@ pub struct Analysis {
     pub overall_score: f64,
     pub grade: String,
     pub components: HashMap<String, ScoreComponent>,
+    pub skipped_components: Vec<SkippedComponent>,
     pub summary: AnalysisSummary,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkippedComponent {
+    pub name: String,
+    pub reason: String,
 }
 
 impl Analysis {
@@ -1128,6 +1153,7 @@ mod tests {
             overall_score: 85.0,
             grade: "B".to_string(),
             components: HashMap::new(),
+            skipped_components: Vec::new(),
             summary: AnalysisSummary {
                 files_analyzed: 10,
                 analyzers_run: 3,
@@ -1158,6 +1184,7 @@ mod tests {
             overall_score: 85.0,
             grade: "B".to_string(),
             components: HashMap::new(),
+            skipped_components: Vec::new(),
             summary: AnalysisSummary::default(),
         };
         assert!(analysis.check_threshold(80.0).is_ok());
@@ -1169,6 +1196,7 @@ mod tests {
             overall_score: 72.0,
             grade: "C".to_string(),
             components: HashMap::new(),
+            skipped_components: Vec::new(),
             summary: AnalysisSummary::default(),
         };
         assert!(analysis.check_threshold(80.0).is_err());
@@ -1180,6 +1208,7 @@ mod tests {
             overall_score: 80.0,
             grade: "B".to_string(),
             components: HashMap::new(),
+            skipped_components: Vec::new(),
             summary: AnalysisSummary::default(),
         };
         assert!(analysis.check_threshold(80.0).is_ok());

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -104,8 +104,10 @@ fn test_clones_runs_successfully() {
 
 #[test]
 fn test_defect_requires_git_repo() {
+    let temp = TempDir::new().unwrap();
+    std::fs::write(temp.path().join("sample.rs"), "pub fn sample() {}\n").unwrap();
     omen()
-        .args(["-p", fixtures_dir(), "-f", "json", "defect"])
+        .args(["-p", temp.path().to_str().unwrap(), "-f", "json", "defect"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("git"));
@@ -509,6 +511,138 @@ fn test_exclude_filter() {
             "expected Python files to be excluded, got {path}"
         );
     }
+}
+
+fn write_complexity_exclude_fixture(temp: &TempDir) {
+    let branchy = r#"
+export function branchy(a: boolean, b: boolean, c: boolean, d: boolean, e: boolean, f: boolean) {
+  if (a) return 1;
+  if (b) return 2;
+  if (c) return 3;
+  if (d) return 4;
+  if (e) return 5;
+  if (f) return 6;
+  return 0;
+}
+"#;
+    for path in [
+        "src/branchy.ts",
+        "packages/alpha/src/branchy.ts",
+        "packages/alpha/test/setup.ts",
+        "packages/alpha/test/helper.test.ts",
+    ] {
+        let path = temp.path().join(path);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, branchy).unwrap();
+    }
+    std::fs::write(
+        temp.path().join("omen.toml"),
+        "[complexity]\ncyclomatic_error = 3\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn test_complexity_check_excludes_nested_test_directory() {
+    let temp = TempDir::new().unwrap();
+    write_complexity_exclude_fixture(&temp);
+
+    omen()
+        .args([
+            "-p",
+            temp.path().to_str().unwrap(),
+            "complexity",
+            "--check",
+            "-e",
+            "packages/alpha/test/**",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Complexity threshold exceeded in 2 function(s)",
+        ));
+}
+
+#[test]
+fn test_complexity_check_honors_config_excludes() {
+    let temp = TempDir::new().unwrap();
+    write_complexity_exclude_fixture(&temp);
+    std::fs::write(
+        temp.path().join("omen.toml"),
+        "exclude = [\"packages/alpha/test/**\"]\n\n[complexity]\ncyclomatic_error = 3\n",
+    )
+    .unwrap();
+
+    omen()
+        .args(["-p", temp.path().to_str().unwrap(), "complexity", "--check"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Complexity threshold exceeded in 2 function(s)",
+        ));
+}
+
+#[test]
+fn test_config_excludes_apply_to_satd_results() {
+    let temp = TempDir::new().unwrap();
+    std::fs::create_dir_all(temp.path().join("excluded")).unwrap();
+    std::fs::write(temp.path().join("keep.ts"), "// TODO: keep\n").unwrap();
+    std::fs::write(temp.path().join("excluded/debt.ts"), "// TODO: exclude\n").unwrap();
+    std::fs::write(
+        temp.path().join("omen.toml"),
+        "exclude = [\"excluded/**\"]\n",
+    )
+    .unwrap();
+
+    let output = omen()
+        .args(["-p", temp.path().to_str().unwrap(), "-f", "json", "satd"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let findings = parsed["items"].as_array().unwrap();
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0]["file"], "keep.ts");
+}
+
+#[test]
+fn test_score_records_git_components_skipped_outside_repository() {
+    use omen::core::{AnalysisContext, Analyzer as _, FileSet};
+
+    let temp = TempDir::new().unwrap();
+    let config = omen::config::Config::default();
+    let files = FileSet::from_path(temp.path(), &config).unwrap();
+    let ctx = AnalysisContext::new(&files, &config, Some(temp.path()));
+    let weights = omen::score::ScoreWeights {
+        churn: 1.0,
+        ownership: 1.0,
+        defect: 1.0,
+        complexity: 0.0,
+        satd: 0.0,
+        deadcode: 0.0,
+        duplicates: 0.0,
+        cohesion: 0.0,
+        tdg: 0.0,
+        coupling: 0.0,
+        smells: 0.0,
+    };
+
+    let result = omen::score::Analyzer::with_weights(weights)
+        .analyze(&ctx)
+        .unwrap();
+    let names: Vec<&str> = result
+        .skipped_components
+        .iter()
+        .map(|component| component.name.as_str())
+        .collect();
+
+    assert!(names.contains(&"churn"));
+    assert!(names.contains(&"ownership"));
+    assert!(names.contains(&"defect"));
+    assert!(result
+        .skipped_components
+        .iter()
+        .all(|component| !component.reason.is_empty()));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes a cluster of correctness bugs found during a repo-wide audit, including the three open `complexity --exclude` issues.

- **complexity `--exclude` (closes #452, #453, #454)**: `-e` is now repeatable, and both CLI patterns and config `exclude_patterns` reach the file walker and `--check` violation counting. Reproduced #454's fixture as a test (4 -> 2 violations).
- **ContentSource**: `satd`, `deadcode`, and `outline` read file contents through `ctx.read_file`, so historical/trend analysis uses the analyzed commit's contents instead of the working tree (matching the existing `smells` regression test).
- **Unified percentile**: five divergent implementations (two different formulas) replaced by one documented `core::percentile`. p90-style values shift where the old formula disagreed — expectations recomputed by hand.
- **Unified is_test_file**: four divergent implementations replaced by one component-wise `core::is_test_file`; `src/contest_runner.rs` is no longer a false-positive test file.
- **Score transparency**: failed components are recorded in `skipped_components` (name + reason) instead of silently vanishing from the weighted average.
- **Subdirectory analysis**: `gix::open` -> `gix::discover` so `-p <subdir>` works for git analyzers; churn scopes history to the subdirectory; MCP surfaces `git_skipped_reason`.
- **Deterministic** `score trend` markdown (sorted component rows).

## Verification

`cargo fmt --check`, full `cargo test` (1837 lib + 50 integration + property/doc) pass; clippy clean. The three complexity exclude integration tests reproduce and verify the reported bugs.

Closes #452
Closes #453
Closes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)