### PR TITLE
Harden command execution and filesystem access

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,19 @@
+# cargo-audit configuration. Run: cargo audit
+#
+# The ignored advisories below are transitive dependencies that cannot be
+# upgraded without upstream releases and are not reachable in omen's usage.
+# Everything else must pass. Re-evaluate on each dependency bump.
+
+[advisories]
+ignore = [
+    # rkyv 0.7 out-of-bounds read when DESERIALIZING untrusted rkyv archives
+    # containing Rc/Arc. Pulled only by minify-html -> lightningcss ->
+    # parcel_sourcemap (pinned to rkyv 0.7); omen only minifies its own
+    # generated HTML and never deserializes rkyv archives, so it is unreachable.
+    # Fix requires parcel_sourcemap to move to rkyv >=0.8.
+    "RUSTSEC-2026-0235",
+    # rand unsoundness that only manifests when calling rand::rng() from a
+    # custom global logger. Reaches the tree via the proptest dev-dependency
+    # (tests only) and a transitive rand 0.8; omen does not use this pattern.
+    "RUSTSEC-2026-0097",
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,30 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-targets --all-features
 
+  audit:
+    name: Security audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
+
+      - name: Cache cargo registry and build
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@9458fed45835344deb5e69e06e831be047c96abf # cargo-audit
+        with:
+          tool: cargo-audit
+
+      - name: Audit dependencies
+        run: cargo audit
+
   msrv:
     name: MSRV (1.92.0)
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,9 +186,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.4"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -196,14 +196,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -412,6 +413,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -710,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1160,11 +1172,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1174,8 +1184,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3741,15 +3754,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3822,6 +3836,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3844,6 +3869,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4116,9 +4156,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4498,7 +4538,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2866,6 +2866,7 @@ dependencies = [
  "ignore",
  "indicatif",
  "insta",
+ "libc",
  "minify-html",
  "minijinja",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ flate2 = "1.1"
 # Utilities
 parking_lot = "0.12"
 bstr = "1.11"
+libc = "0.2"
 
 # Semantic search (TF-IDF based, no model download required)
 rusqlite = { version = "0.40", features = ["bundled"] }

--- a/src/analyzers/deadcode.rs
+++ b/src/analyzers/deadcode.rs
@@ -22,6 +22,7 @@ use crate::parser::{self, Parser};
 pub struct Analyzer {
     parser: Parser,
     confidence_threshold: f64,
+    cargo_check: bool,
 }
 
 impl Default for Analyzer {
@@ -35,11 +36,17 @@ impl Analyzer {
         Self {
             parser: Parser::new(),
             confidence_threshold: 0.8,
+            cargo_check: false,
         }
     }
 
     pub fn with_confidence(mut self, threshold: f64) -> Self {
         self.confidence_threshold = threshold.clamp(0.0, 1.0);
+        self
+    }
+
+    pub fn with_cargo_check(mut self, enabled: bool) -> Self {
+        self.cargo_check = enabled;
         self
     }
 
@@ -78,7 +85,7 @@ impl AnalyzerTrait for Analyzer {
         let is_rust_project = cargo_toml.exists();
 
         // For Rust projects, use cargo check for accurate dead code detection
-        let cargo_items = if is_rust_project {
+        let cargo_items = if self.cargo_check && is_rust_project {
             tracing::info!("Detected Cargo.toml, using cargo check for Rust dead code analysis");
             match CargoDeadCodeAnalyzer::analyze(ctx.root) {
                 Ok(analysis) => analysis.items,
@@ -1336,6 +1343,12 @@ mod tests {
     fn test_analyzer_creation() {
         let analyzer = Analyzer::new();
         assert_eq!(analyzer.name(), "deadcode");
+    }
+
+    #[test]
+    fn test_cargo_check_is_opt_in() {
+        assert!(!Analyzer::new().cargo_check);
+        assert!(Analyzer::new().with_cargo_check(true).cargo_check);
     }
 
     #[test]

--- a/src/analyzers/mutation/ci/incremental.rs
+++ b/src/analyzers/mutation/ci/incremental.rs
@@ -36,13 +36,22 @@ impl IncrementalMutation {
     ///
     /// Returns absolute paths to changed files.
     pub fn get_changed_files(&self, repo_path: &Path) -> Result<Vec<PathBuf>> {
+        if self.base_ref.starts_with('-') {
+            return Err(Error::git("base reference must not start with '-'"));
+        }
         // Check if we're in a git repository
         if !repo_path.join(".git").exists() && self.find_git_root(repo_path).is_none() {
             return Err(Error::git("Not a git repository"));
         }
 
         let output = Command::new("git")
-            .args(["diff", "--name-only", &self.base_ref])
+            .args([
+                "diff",
+                "--name-only",
+                "--end-of-options",
+                &self.base_ref,
+                "--",
+            ])
             .current_dir(repo_path)
             .output()
             .map_err(|e| Error::git(format!("Failed to run git diff: {}", e)))?;
@@ -94,6 +103,9 @@ impl IncrementalMutation {
     /// Returns a list of (start_line, end_line) tuples representing
     /// the ranges of lines that were changed.
     pub fn get_changed_lines(&self, file: &Path, repo_path: &Path) -> Result<Vec<(u32, u32)>> {
+        if self.base_ref.starts_with('-') {
+            return Err(Error::git("base reference must not start with '-'"));
+        }
         // Get the relative path from repo root
         let relative_path = file
             .strip_prefix(repo_path)
@@ -101,7 +113,14 @@ impl IncrementalMutation {
             .to_string_lossy();
 
         let output = Command::new("git")
-            .args(["diff", "-U0", &self.base_ref, "--", relative_path.as_ref()])
+            .args([
+                "diff",
+                "-U0",
+                "--end-of-options",
+                &self.base_ref,
+                "--",
+                relative_path.as_ref(),
+            ])
             .current_dir(repo_path)
             .output()
             .map_err(|e| Error::git(format!("Failed to run git diff: {}", e)))?;
@@ -271,6 +290,21 @@ mod tests {
         let inc = IncrementalMutation::new("nonexistent-branch");
         let result = inc.get_changed_files(temp.path());
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_changed_files_rejects_option_like_ref() {
+        let temp = tempfile::tempdir().unwrap();
+        init_git_repo(temp.path());
+        make_commit(temp.path(), "initial");
+
+        let result = IncrementalMutation::new("--output=stolen").get_changed_files(temp.path());
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("must not start with '-'"));
     }
 
     #[test]

--- a/src/analyzers/mutation/mod.rs
+++ b/src/analyzers/mutation/mod.rs
@@ -43,7 +43,10 @@ pub use operators::{
     BitwiseOperator, BoundaryOperator, ConditionalOperator, LiteralOperator, RelationalOperator,
     ReturnValueOperator, StatementOperator, UnaryOperator,
 };
-pub use safety::{atomic_write, has_uncommitted_changes, MutationGuard};
+pub use safety::{
+    atomic_write, has_uncommitted_changes, install_signal_handler, restore_active_mutations,
+    MutationGuard,
+};
 pub use worker::{
     FileLockManager, ProgressUpdate, WorkItem, WorkQueue, WorkerPoolConfig, WorkerPoolHandle,
 };
@@ -101,6 +104,8 @@ pub struct Analyzer {
     skip_predicted_threshold: Option<f64>,
     /// Trained ML predictor for filtering mutants.
     predictor: Option<ml_predictor::SurvivabilityPredictor>,
+    /// Whether uncommitted target files may be mutated.
+    allow_dirty: bool,
 }
 
 impl Default for Analyzer {
@@ -126,6 +131,7 @@ impl Analyzer {
             output_survivors: None,
             skip_predicted_threshold: None,
             predictor: None,
+            allow_dirty: false,
         }
     }
 
@@ -150,6 +156,12 @@ impl Analyzer {
     /// Enable dry-run mode (generate only, no execution).
     pub fn dry_run(mut self, dry_run: bool) -> Self {
         self.dry_run = dry_run;
+        self
+    }
+
+    /// Allow mutation testing on files with uncommitted changes.
+    pub fn allow_dirty(mut self, allow: bool) -> Self {
+        self.allow_dirty = allow;
         self
     }
 
@@ -314,10 +326,31 @@ impl AnalyzerTrait for Analyzer {
     }
 
     fn analyze(&self, ctx: &AnalysisContext<'_>) -> Result<Self::Output> {
+        if !self.allow_dirty {
+            let dirty_files: Vec<_> = ctx
+                .files
+                .iter()
+                .map(|file| ctx.root.join(file))
+                .filter(|file| has_uncommitted_changes(file))
+                .collect();
+            if !dirty_files.is_empty() {
+                return Err(Error::InvalidArgument(format!(
+                    "mutation target files have uncommitted changes; commit or stash them, or allow dirty files explicitly: {}",
+                    dirty_files
+                        .iter()
+                        .map(|file| file.display().to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )));
+            }
+        }
+
         // If dry run, just generate mutants
         if self.dry_run {
             return self.generate_only(ctx);
         }
+
+        install_signal_handler()?;
 
         let start = Instant::now();
 
@@ -596,6 +629,7 @@ fn build_summary(files: &[FileResult], duration_ms: u64) -> Summary {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::FileSet;
 
     #[test]
     fn test_analyzer_new() {
@@ -733,6 +767,39 @@ mod tests {
             analyzer.output_survivors,
             Some(PathBuf::from("survivors.json"))
         );
+    }
+
+    #[test]
+    fn test_analyzer_refuses_dirty_files_unless_allowed() {
+        let temp = tempfile::tempdir().unwrap();
+        let file = temp.path().join("test.rs");
+        std::fs::write(&file, "fn value() -> i32 { 1 }\n").unwrap();
+        for args in [
+            vec!["init"],
+            vec!["config", "user.email", "test@example.com"],
+            vec!["config", "user.name", "Test User"],
+            vec!["add", "."],
+            vec!["commit", "-m", "initial"],
+        ] {
+            assert!(std::process::Command::new("git")
+                .args(args)
+                .current_dir(temp.path())
+                .output()
+                .unwrap()
+                .status
+                .success());
+        }
+        std::fs::write(&file, "fn value() -> i32 { 2 }\n").unwrap();
+        let files = FileSet::from_path_default(temp.path()).unwrap();
+        let config = crate::config::Config::default();
+        let ctx = AnalysisContext::new(&files, &config, Some(temp.path()));
+
+        assert!(Analyzer::new().dry_run(true).analyze(&ctx).is_err());
+        assert!(Analyzer::new()
+            .dry_run(true)
+            .allow_dirty(true)
+            .analyze(&ctx)
+            .is_ok());
     }
 
     #[test]

--- a/src/analyzers/mutation/safety.rs
+++ b/src/analyzers/mutation/safety.rs
@@ -3,15 +3,67 @@
 //! Provides RAII-based guards to ensure source files are always restored
 //! to their original state, even if a panic occurs during mutation testing.
 
+use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{LazyLock, OnceLock};
+use std::time::Duration;
 
 use crate::core::{Error, Result};
 
 /// Global counter for generating unique temp file names across threads.
 static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
+static ACTIVE_MUTATIONS: LazyLock<parking_lot::Mutex<HashMap<PathBuf, Vec<u8>>>> =
+    LazyLock::new(|| parking_lot::Mutex::new(HashMap::new()));
+static SIGNAL_HANDLER: OnceLock<std::result::Result<(), String>> = OnceLock::new();
+static INTERRUPTED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+#[cfg(unix)]
+extern "C" fn mark_interrupted(_: libc::c_int) {
+    INTERRUPTED.store(true, Ordering::SeqCst);
+}
+
+#[cfg(unix)]
+fn register_interrupt_handler() -> std::result::Result<(), String> {
+    let previous = unsafe {
+        libc::signal(
+            libc::SIGINT,
+            mark_interrupted as *const () as libc::sighandler_t,
+        )
+    };
+    if previous == libc::SIG_ERR {
+        Err(std::io::Error::last_os_error().to_string())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+extern "system" fn mark_interrupted_windows(signal: u32) -> i32 {
+    const CTRL_C_EVENT: u32 = 0;
+    if signal == CTRL_C_EVENT {
+        INTERRUPTED.store(true, Ordering::SeqCst);
+        1
+    } else {
+        0
+    }
+}
+
+#[cfg(windows)]
+fn register_interrupt_handler() -> std::result::Result<(), String> {
+    #[link(name = "Kernel32")]
+    unsafe extern "system" {
+        fn SetConsoleCtrlHandler(handler: extern "system" fn(u32) -> i32, add: i32) -> i32;
+    }
+
+    if unsafe { SetConsoleCtrlHandler(mark_interrupted_windows, 1) } == 0 {
+        Err(std::io::Error::last_os_error().to_string())
+    } else {
+        Ok(())
+    }
+}
 
 /// RAII guard that ensures a file is restored to its original content.
 ///
@@ -45,7 +97,13 @@ impl MutationGuard {
     ///
     /// This writes the mutated content to the file atomically.
     pub fn apply(&mut self, content: &[u8]) -> Result<()> {
-        atomic_write(&self.path, content)?;
+        let mut active = ACTIVE_MUTATIONS.lock();
+        active.insert(self.path.clone(), self.original.clone());
+        if let Err(error) = atomic_write(&self.path, content) {
+            active.remove(&self.path);
+            return Err(error);
+        }
+        drop(active);
         self.modified = true;
         Ok(())
     }
@@ -72,6 +130,7 @@ impl MutationGuard {
         if self.modified {
             atomic_write(&self.path, &self.original)?;
             self.modified = false;
+            ACTIVE_MUTATIONS.lock().remove(&self.path);
         }
         Ok(())
     }
@@ -105,7 +164,35 @@ impl Drop for MutationGuard {
                 let _ = fs::write(&self.path, &self.original);
             }
         }
+        ACTIVE_MUTATIONS.lock().remove(&self.path);
     }
+}
+
+pub fn restore_active_mutations() {
+    let active = ACTIVE_MUTATIONS.lock();
+    for (path, original) in active.iter() {
+        let _ = atomic_write(path, original);
+    }
+}
+
+pub fn install_signal_handler() -> Result<()> {
+    SIGNAL_HANDLER
+        .get_or_init(|| {
+            register_interrupt_handler()?;
+            std::thread::Builder::new()
+                .name("omen-mutation-signal".to_string())
+                .spawn(|| loop {
+                    if INTERRUPTED.load(Ordering::SeqCst) {
+                        restore_active_mutations();
+                        std::process::exit(130);
+                    }
+                    std::thread::park_timeout(Duration::from_millis(20));
+                })
+                .map(|_| ())
+                .map_err(|error| error.to_string())
+        })
+        .clone()
+        .map_err(Error::analysis)
 }
 
 /// Write content to a file atomically.
@@ -151,6 +238,7 @@ pub fn has_uncommitted_changes(path: impl AsRef<Path>) -> bool {
             // Found git root, check if file has uncommitted changes
             let output = std::process::Command::new("git")
                 .args(["status", "--porcelain"])
+                .arg("--")
                 .arg(path)
                 .current_dir(d)
                 .output();
@@ -325,6 +413,33 @@ mod tests {
 
         // Should return false when not in a git repo
         assert!(!has_uncommitted_changes(&file_path));
+    }
+
+    #[test]
+    fn test_has_uncommitted_changes_handles_option_like_filename() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("--output=stolen");
+        std::process::Command::new("git")
+            .arg("init")
+            .current_dir(temp_dir.path())
+            .output()
+            .unwrap();
+        fs::write(&file_path, b"content").unwrap();
+
+        assert!(has_uncommitted_changes(&file_path));
+    }
+
+    #[test]
+    fn test_restore_active_mutations_restores_modified_files() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("test.rs");
+        fs::write(&file_path, b"original").unwrap();
+        let mut guard = MutationGuard::new(&file_path).unwrap();
+        guard.apply(b"mutated").unwrap();
+
+        restore_active_mutations();
+
+        assert_eq!(fs::read(&file_path).unwrap(), b"original");
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -61,7 +61,7 @@ pub enum Command {
 
     /// Find dead/unreachable code
     #[command(alias = "dc")]
-    Deadcode(AnalyzerArgs),
+    Deadcode(DeadcodeArgs),
 
     /// Analyze code churn from git history
     Churn(ChurnArgs),
@@ -173,6 +173,16 @@ pub struct AnalyzerArgs {
     /// Skip the first N results (use with --top for pagination)
     #[arg(long)]
     pub offset: Option<usize>,
+}
+
+#[derive(Args)]
+pub struct DeadcodeArgs {
+    #[command(flatten)]
+    pub common: AnalyzerArgs,
+
+    /// Runs `cargo check`, which executes build scripts — only use on trusted code
+    #[arg(long)]
+    pub cargo_check: bool,
 }
 
 #[derive(Args)]
@@ -303,6 +313,10 @@ pub struct McpArgs {
     /// Host for SSE transport
     #[arg(long, default_value = "127.0.0.1")]
     pub host: String,
+
+    /// Allow tools to access paths outside the configured repository root
+    #[arg(long)]
+    pub allow_external_paths: bool,
 }
 
 /// Context generation for LLM consumption.
@@ -520,6 +534,10 @@ pub struct MutationArgs {
     /// Skip mutants predicted to be killed above this threshold (0.0-1.0)
     #[arg(long, value_name = "THRESHOLD")]
     pub skip_predicted: Option<f64>,
+
+    /// Allow mutation testing on files with uncommitted changes
+    #[arg(long)]
+    pub allow_dirty: bool,
 }
 
 /// Mutation testing mode.
@@ -1062,6 +1080,22 @@ mod tests {
     }
 
     #[test]
+    fn test_mcp_external_paths_default_to_denied() {
+        let cli = parse(&["omen", "mcp"]);
+        if let Command::Mcp(cmd) = cli.command {
+            assert!(!cmd.args.allow_external_paths);
+        }
+    }
+
+    #[test]
+    fn test_mcp_allow_external_paths() {
+        let cli = parse(&["omen", "mcp", "--allow-external-paths"]);
+        if let Command::Mcp(cmd) = cli.command {
+            assert!(cmd.args.allow_external_paths);
+        }
+    }
+
+    #[test]
     fn test_mcp_manifest() {
         let cli = parse(&["omen", "mcp", "manifest"]);
         if let Command::Mcp(cmd) = cli.command {
@@ -1492,6 +1526,22 @@ mod tests {
         assert!(!parse_complexity_args(&["omen", "complexity"]).check);
     }
 
+    #[test]
+    fn test_deadcode_cargo_check_default_false() {
+        let cli = parse(&["omen", "deadcode"]);
+        if let Command::Deadcode(args) = cli.command {
+            assert!(!args.cargo_check);
+        }
+    }
+
+    #[test]
+    fn test_deadcode_cargo_check_opt_in() {
+        let cli = parse(&["omen", "deadcode", "--cargo-check"]);
+        if let Command::Deadcode(args) = cli.command {
+            assert!(args.cargo_check);
+        }
+    }
+
     // Mutation command tests
 
     #[test]
@@ -1508,6 +1558,12 @@ mod tests {
         assert!(!args.skip_equivalent);
         assert!(matches!(args.mode, MutationMode::All));
         assert!(args.output_survivors.is_none());
+        assert!(!args.allow_dirty);
+    }
+
+    #[test]
+    fn test_mutation_allow_dirty() {
+        assert!(parse_mutation_args(&["omen", "mutation", "--allow-dirty"]).allow_dirty);
     }
 
     #[test]

--- a/src/core/source_file.rs
+++ b/src/core/source_file.rs
@@ -1,8 +1,11 @@
 //! Source file representation.
 
+use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use super::{Language, Result};
+
+pub const MAX_FILE_SIZE: usize = 5 * 1024 * 1024;
 
 /// A source file with its content loaded.
 #[derive(Debug, Clone)]
@@ -22,7 +25,25 @@ impl SourceFile {
         let language = Language::detect(path).ok_or_else(|| super::Error::UnsupportedLanguage {
             path: path.to_path_buf(),
         })?;
-        let content = std::fs::read(path)?;
+        let size = std::fs::metadata(path)?.len();
+        if size > MAX_FILE_SIZE as u64 {
+            tracing::debug!(path = %path.display(), size, "Skipping source file over size limit");
+            return Err(super::Error::InvalidArgument(format!(
+                "source file exceeds {MAX_FILE_SIZE} byte limit: {}",
+                path.display()
+            )));
+        }
+        let mut content = Vec::with_capacity((size as usize).min(MAX_FILE_SIZE));
+        std::fs::File::open(path)?
+            .take((MAX_FILE_SIZE + 1) as u64)
+            .read_to_end(&mut content)?;
+        if content.len() > MAX_FILE_SIZE {
+            tracing::debug!(path = %path.display(), "Skipping source file over size limit");
+            return Err(super::Error::InvalidArgument(format!(
+                "source file exceeds {MAX_FILE_SIZE} byte limit: {}",
+                path.display()
+            )));
+        }
 
         Ok(Self {
             path: path.to_path_buf(),
@@ -88,6 +109,7 @@ fn is_comment_line(line: &str, lang: Language) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
 
     #[test]
     fn test_source_file_from_content() {
@@ -106,5 +128,14 @@ mod tests {
 
         assert_eq!(file.total_lines(), 3);
         assert_eq!(file.lines_of_code(), 1);
+    }
+
+    #[test]
+    fn test_load_rejects_files_over_size_limit() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("large.rs");
+        std::fs::write(&path, vec![b'x'; MAX_FILE_SIZE + 1]).unwrap();
+
+        assert!(SourceFile::load(&path).is_err());
     }
 }

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -4,6 +4,61 @@ use std::path::{Path, PathBuf};
 
 use crate::core::{Error, Result};
 
+#[cfg(unix)]
+fn ensure_secure_clone_base(path: &Path) -> Result<()> {
+    use std::os::unix::fs::{DirBuilderExt, MetadataExt};
+
+    if !path.exists() {
+        let mut builder = std::fs::DirBuilder::new();
+        builder.recursive(true).mode(0o700);
+        if let Err(error) = builder.create(path) {
+            if error.kind() != std::io::ErrorKind::AlreadyExists {
+                return Err(Error::Remote(format!(
+                    "Failed to create clone directory '{}': {error}",
+                    path.display()
+                )));
+            }
+        }
+    }
+
+    let metadata = std::fs::symlink_metadata(path).map_err(|error| {
+        Error::Remote(format!(
+            "Failed to inspect clone directory '{}': {error}",
+            path.display()
+        ))
+    })?;
+    if !metadata.file_type().is_dir() {
+        return Err(Error::Remote(format!(
+            "Clone base '{}' is not a directory",
+            path.display()
+        )));
+    }
+    let current_uid = unsafe { libc::geteuid() };
+    if metadata.uid() != current_uid {
+        return Err(Error::Remote(format!(
+            "Clone base '{}' is not owned by the current user",
+            path.display()
+        )));
+    }
+    if metadata.mode() & 0o002 != 0 {
+        return Err(Error::Remote(format!(
+            "Clone base '{}' must not be world-writable",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn ensure_secure_clone_base(path: &Path) -> Result<()> {
+    std::fs::create_dir_all(path).map_err(|error| {
+        Error::Remote(format!(
+            "Failed to create clone directory '{}': {error}",
+            path.display()
+        ))
+    })
+}
+
 /// Clone options for remote repositories.
 #[derive(Debug, Clone, Default)]
 pub struct CloneOptions {
@@ -94,7 +149,7 @@ pub fn clone_remote(url: &str, options: CloneOptions) -> Result<PathBuf> {
         t
     } else {
         let temp_dir = std::env::temp_dir().join("omen-repos");
-        std::fs::create_dir_all(&temp_dir).ok();
+        ensure_secure_clone_base(&temp_dir)?;
         let sanitized = sanitize_repo_name(&repo_url);
         if sanitized.is_empty()
             || sanitized.contains("..")
@@ -210,6 +265,34 @@ fn sanitize_repo_name(url: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn test_secure_clone_base_has_private_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let base = temp.path().join("omen-repos");
+        ensure_secure_clone_base(&base).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(base).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_secure_clone_base_rejects_world_writable_directory() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let base = temp.path().join("omen-repos");
+        std::fs::create_dir(&base).unwrap();
+        std::fs::set_permissions(&base, std::fs::Permissions::from_mode(0o707)).unwrap();
+
+        assert!(ensure_secure_clone_base(&base).is_err());
+    }
 
     #[test]
     fn test_parse_github_shorthand() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,7 +131,11 @@ fn run_with_path(cli: &Cli, path: &PathBuf) -> omen::core::Result<()> {
                     println!("{}", serde_json::to_string_pretty(&manifest)?);
                 }
                 None => {
-                    let server = McpServer::new(path.clone(), config);
+                    let server = McpServer::new_with_external_paths(
+                        path.clone(),
+                        config,
+                        cmd.args.allow_external_paths,
+                    );
                     server.run_stdio()?;
                 }
             }
@@ -154,8 +158,16 @@ fn run_with_path(cli: &Cli, path: &PathBuf) -> omen::core::Result<()> {
         Command::Changes(args) => {
             run_changes_analyzer(path, &config, format, args)?;
         }
+        Command::Deadcode(args) => {
+            run_analyzer_instance(
+                path,
+                &config,
+                format,
+                Some(&args.common),
+                omen::analyzers::deadcode::Analyzer::new().with_cargo_check(args.cargo_check),
+            )?;
+        }
         Command::Satd(_)
-        | Command::Deadcode(_)
         | Command::Clones(_)
         | Command::Defect(_)
         | Command::Tdg(_)
@@ -436,9 +448,6 @@ fn dispatch_analyzer(
         Command::Satd(args) => {
             run_analyzer::<omen::analyzers::satd::Analyzer>(path, config, format, Some(args))
         }
-        Command::Deadcode(args) => {
-            run_analyzer::<omen::analyzers::deadcode::Analyzer>(path, config, format, Some(args))
-        }
         Command::Clones(args) => {
             run_analyzer::<omen::analyzers::duplicates::Analyzer>(path, config, format, Some(args))
         }
@@ -497,8 +506,21 @@ fn filtered_file_set(
 fn changed_files_since(path: &Path, base: &str) -> omen::core::Result<Vec<PathBuf>> {
     use std::process::Command;
 
+    if base.starts_with('-') {
+        return Err(omen::core::Error::git(
+            "changed-since reference must not start with '-'",
+        ));
+    }
+
     let output = Command::new("git")
-        .args(["diff", "--name-only", "--diff-filter=ACMR", base, "--"])
+        .args([
+            "diff",
+            "--name-only",
+            "--diff-filter=ACMR",
+            "--end-of-options",
+            base,
+            "--",
+        ])
         .current_dir(path)
         .output()
         .map_err(omen::core::Error::Io)?;
@@ -523,6 +545,16 @@ fn run_analyzer<A: Analyzer + Default>(
     format: Format,
     args: Option<&AnalyzerArgs>,
 ) -> omen::core::Result<()> {
+    run_analyzer_instance(path, config, format, args, A::default())
+}
+
+fn run_analyzer_instance<A: Analyzer>(
+    path: &PathBuf,
+    config: &Config,
+    format: Format,
+    args: Option<&AnalyzerArgs>,
+    analyzer: A,
+) -> omen::core::Result<()> {
     let file_set = filtered_file_set(path, config, args)?;
 
     // Show analysis progress
@@ -539,7 +571,6 @@ fn run_analyzer<A: Analyzer + Default>(
         None
     };
 
-    let analyzer = A::default();
     if let Some(ref s) = spinner {
         s.set_message(format!("Analyzing {} files...", file_set.len()));
     }
@@ -1284,7 +1315,8 @@ fn run_mutation(
         .operators(operators)
         .test_command(args.test_command.clone())
         .timeout(args.timeout)
-        .dry_run(args.dry_run);
+        .dry_run(args.dry_run)
+        .allow_dirty(args.allow_dirty);
 
     if args.check {
         analyzer = analyzer.min_score(Some(args.min_score));

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1,7 +1,7 @@
 //! MCP (Model Context Protocol) server implementation.
 
-use std::io::{BufRead, BufReader, Write};
-use std::path::PathBuf;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -9,6 +9,40 @@ use serde_json::{json, Value};
 use crate::config::Config;
 use crate::core::{AnalysisContext, Analyzer, FileSet, Result};
 use crate::git::GitRepo;
+
+const MAX_STDIO_LINE_SIZE: usize = 10 * 1024 * 1024;
+
+fn discard_until_newline(reader: &mut impl BufRead) -> std::io::Result<()> {
+    loop {
+        let buffer = reader.fill_buf()?;
+        if buffer.is_empty() {
+            return Ok(());
+        }
+        if let Some(position) = buffer.iter().position(|byte| *byte == b'\n') {
+            reader.consume(position + 1);
+            return Ok(());
+        }
+        let length = buffer.len();
+        reader.consume(length);
+    }
+}
+
+fn write_parse_error(writer: &mut impl Write, detail: &str) -> Result<()> {
+    let response = JsonRpcResponse {
+        jsonrpc: "2.0".to_string(),
+        id: None,
+        result: None,
+        error: Some(JsonRpcError {
+            code: -32700,
+            message: format!("Parse error: {detail}"),
+            data: None,
+        }),
+    };
+    serde_json::to_writer(&mut *writer, &response)?;
+    writeln!(writer)?;
+    writer.flush()?;
+    Ok(())
+}
 
 struct ToolDef {
     name: &'static str,
@@ -81,11 +115,24 @@ fn count_items(value: &serde_json::Value) -> Option<usize> {
 pub struct McpServer {
     config: Config,
     root_path: PathBuf,
+    allow_external_paths: bool,
 }
 
 impl McpServer {
     pub fn new(root_path: PathBuf, config: Config) -> Self {
-        Self { config, root_path }
+        Self::new_with_external_paths(root_path, config, false)
+    }
+
+    pub fn new_with_external_paths(
+        root_path: PathBuf,
+        config: Config,
+        allow_external_paths: bool,
+    ) -> Self {
+        Self {
+            config,
+            root_path,
+            allow_external_paths,
+        }
     }
 
     /// Run the MCP server with stdio transport.
@@ -95,13 +142,53 @@ impl McpServer {
         let reader = BufReader::new(stdin.lock());
         let mut writer = stdout.lock();
 
-        for line in reader.lines() {
-            let line = line?;
-            if line.is_empty() {
+        self.run_stream(reader, &mut writer)
+    }
+
+    fn run_stream<R: BufRead, W: Write>(&self, mut reader: R, mut writer: W) -> Result<()> {
+        loop {
+            let mut bytes = Vec::new();
+            let read = match (&mut reader)
+                .take((MAX_STDIO_LINE_SIZE + 2) as u64)
+                .read_until(b'\n', &mut bytes)
+            {
+                Ok(read) => read,
+                Err(error) => {
+                    write_parse_error(&mut writer, &format!("read error: {error}"))?;
+                    continue;
+                }
+            };
+            if read == 0 {
+                break;
+            }
+
+            let has_newline = bytes.last() == Some(&b'\n');
+            let content_len = bytes.len().saturating_sub(usize::from(has_newline));
+            if content_len > MAX_STDIO_LINE_SIZE {
+                if !has_newline {
+                    discard_until_newline(&mut reader)?;
+                }
+                write_parse_error(&mut writer, "request line exceeds size limit")?;
                 continue;
             }
 
-            match serde_json::from_str::<JsonRpcRequest>(&line) {
+            bytes.pop();
+            if bytes.last() == Some(&b'\r') {
+                bytes.pop();
+            }
+            if bytes.is_empty() {
+                continue;
+            }
+
+            let line = match std::str::from_utf8(&bytes) {
+                Ok(line) => line,
+                Err(error) => {
+                    write_parse_error(&mut writer, &format!("invalid UTF-8: {error}"))?;
+                    continue;
+                }
+            };
+
+            match serde_json::from_str::<JsonRpcRequest>(line) {
                 Ok(request) => {
                     // JSON-RPC notifications have no `id` field; no response expected.
                     if request.id.is_none() {
@@ -113,24 +200,45 @@ impl McpServer {
                     writer.flush()?;
                 }
                 Err(e) => {
-                    let error_response = JsonRpcResponse {
-                        jsonrpc: "2.0".to_string(),
-                        id: None,
-                        result: None,
-                        error: Some(JsonRpcError {
-                            code: -32700,
-                            message: format!("Parse error: {}", e),
-                            data: None,
-                        }),
-                    };
-                    serde_json::to_writer(&mut writer, &error_response)?;
-                    writeln!(writer)?;
-                    writer.flush()?;
+                    write_parse_error(&mut writer, &e.to_string())?;
                 }
             }
         }
 
         Ok(())
+    }
+
+    fn resolve_confined_path(
+        &self,
+        requested: &Path,
+        relative_to: Option<&Path>,
+    ) -> std::result::Result<PathBuf, String> {
+        let candidate = if requested.is_absolute() {
+            requested.to_path_buf()
+        } else {
+            relative_to.unwrap_or(&self.root_path).join(requested)
+        };
+        let canonical = candidate
+            .canonicalize()
+            .map_err(|e| format!("Failed to resolve path '{}': {e}", candidate.display()))?;
+        if self.allow_external_paths {
+            return Ok(canonical);
+        }
+        let root = self.root_path.canonicalize().map_err(|e| {
+            format!(
+                "Failed to resolve MCP root '{}': {e}",
+                self.root_path.display()
+            )
+        })?;
+        if canonical.starts_with(&root) {
+            Ok(canonical)
+        } else {
+            Err(format!(
+                "Path '{}' is outside the MCP root '{}'",
+                canonical.display(),
+                root.display()
+            ))
+        }
     }
 
     fn handle_request(&self, request: JsonRpcRequest) -> JsonRpcResponse {
@@ -489,11 +597,12 @@ impl McpServer {
             .ok_or("Missing tool name")?;
         let arguments = params.get("arguments").cloned().unwrap_or(json!({}));
 
-        let path = arguments
+        let requested_path = arguments
             .get("path")
             .and_then(|v| v.as_str())
             .map(PathBuf::from)
             .unwrap_or_else(|| self.root_path.clone());
+        let path = self.resolve_confined_path(&requested_path, Some(&self.root_path))?;
 
         let file_set = FileSet::from_path(&path, &self.config)
             .map_err(|e| format!("Failed to create file set: {}", e))?;
@@ -676,7 +785,14 @@ impl McpServer {
                     .filter(|p| !p.trim().is_empty())
                     .map(|p| std::path::PathBuf::from(p.trim()))
                     .collect()
-            });
+            })
+            .map(|paths: Vec<PathBuf>| {
+                paths
+                    .into_iter()
+                    .map(|path| self.resolve_confined_path(&path, Some(&self.root_path)))
+                    .collect::<std::result::Result<Vec<_>, _>>()
+            })
+            .transpose()?;
 
         let search_config = SearchConfig {
             min_score,
@@ -776,7 +892,14 @@ impl McpServer {
                     .filter(|p| !p.trim().is_empty())
                     .map(|p| std::path::PathBuf::from(p.trim()))
                     .collect()
-            });
+            })
+            .map(|paths: Vec<PathBuf>| {
+                paths
+                    .into_iter()
+                    .map(|path| self.resolve_confined_path(&path, Some(&self.root_path)))
+                    .collect::<std::result::Result<Vec<_>, _>>()
+            })
+            .transpose()?;
 
         let search_config = SearchConfig {
             min_score,
@@ -853,11 +976,7 @@ impl McpServer {
             // callers can pass repo-relative paths (e.g. "src/main.rs") without
             // needing to know the absolute path.
             let raw = std::path::PathBuf::from(file_str);
-            let file_path = if raw.is_relative() {
-                repo_path.join(&raw)
-            } else {
-                raw
-            };
+            let file_path = self.resolve_confined_path(&raw, Some(repo_path))?;
             let file_outline =
                 outline_file(&file_path).map_err(|e| format!("Outline failed: {}", e))?;
             OutlineResult {
@@ -1010,6 +1129,107 @@ mod tests {
     fn test_mcp_server_new() {
         let (server, _temp_dir) = create_test_server();
         assert!(server.root_path.exists());
+    }
+
+    #[test]
+    fn test_requested_path_outside_root_is_rejected_by_default() {
+        let (server, _root) = create_test_server();
+        let outside = TempDir::new().unwrap();
+
+        let result = server.resolve_confined_path(outside.path(), None);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_requested_path_outside_root_is_allowed_with_flag() {
+        let root = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let server =
+            McpServer::new_with_external_paths(root.path().to_path_buf(), Config::default(), true);
+
+        assert_eq!(
+            server.resolve_confined_path(outside.path(), None).unwrap(),
+            outside.path().canonicalize().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_outline_rejects_parent_traversal() {
+        let (server, root) = create_test_server();
+        let outside = root.path().parent().unwrap().join("outside.rs");
+        std::fs::write(&outside, "fn secret() {}\n").unwrap();
+        let args = json!({"file": "../outside.rs"});
+
+        let result = server.handle_outline(root.path(), &args);
+
+        assert!(result.is_err());
+        std::fs::remove_file(outside).unwrap();
+    }
+
+    #[test]
+    fn test_semantic_search_rejects_external_include_project() {
+        let (server, _root) = create_test_server();
+        let outside = TempDir::new().unwrap();
+        let args = json!({
+            "query": "test",
+            "include_projects": outside.path().to_str().unwrap()
+        });
+
+        assert!(server.handle_semantic_search(&args).is_err());
+    }
+
+    #[test]
+    fn test_semantic_search_hyde_rejects_external_include_project() {
+        let (server, _root) = create_test_server();
+        let outside = TempDir::new().unwrap();
+        let args = json!({
+            "hypothetical_document": "test",
+            "include_projects": outside.path().to_str().unwrap()
+        });
+
+        assert!(server.handle_semantic_search_hyde(&args).is_err());
+    }
+
+    #[test]
+    fn test_stdio_invalid_utf8_does_not_stop_following_request() {
+        let (server, _root) = create_test_server();
+        let mut input = vec![0xff, b'\n'];
+        input.extend_from_slice(br#"{"jsonrpc":"2.0","id":1,"method":"initialize"}"#);
+        input.push(b'\n');
+        let mut output = Vec::new();
+
+        server.run_stream(input.as_slice(), &mut output).unwrap();
+
+        let responses: Vec<Value> = String::from_utf8(output)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect();
+        assert_eq!(responses.len(), 2);
+        assert_eq!(responses[0]["error"]["code"], -32700);
+        assert_eq!(responses[1]["id"], 1);
+    }
+
+    #[test]
+    fn test_stdio_rejects_oversized_line_and_continues() {
+        let (server, _root) = create_test_server();
+        let mut input = vec![b'x'; MAX_STDIO_LINE_SIZE + 1];
+        input.push(b'\n');
+        input.extend_from_slice(br#"{"jsonrpc":"2.0","id":2,"method":"initialize"}"#);
+        input.push(b'\n');
+        let mut output = Vec::new();
+
+        server.run_stream(input.as_slice(), &mut output).unwrap();
+
+        let responses: Vec<Value> = String::from_utf8(output)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect();
+        assert_eq!(responses.len(), 2);
+        assert_eq!(responses[0]["error"]["code"], -32700);
+        assert_eq!(responses[1]["id"], 2);
     }
 
     /// B9: tool_names() must exactly match the names produced by handle_tools_list,
@@ -1173,17 +1393,14 @@ mod tests {
 
     #[test]
     fn test_handle_tool_call_uses_requested_path_as_analysis_root() {
-        let (server, _server_root) = create_test_server();
-        let target_dir = TempDir::new().unwrap();
-        std::fs::write(
-            target_dir.path().join("target.rs"),
-            "fn target_function() {}\n",
-        )
-        .unwrap();
+        let (server, server_root) = create_test_server();
+        let target_dir = server_root.path().join("nested");
+        std::fs::create_dir(&target_dir).unwrap();
+        std::fs::write(target_dir.join("target.rs"), "fn target_function() {}\n").unwrap();
 
         let params = json!({
             "name": "complexity",
-            "arguments": {"path": target_dir.path().to_str().unwrap()}
+            "arguments": {"path": target_dir.to_str().unwrap()}
         });
         let response = server.handle_tool_call(Some(params)).unwrap();
         let text = response["content"][0]["text"]
@@ -1293,42 +1510,39 @@ mod tests {
     }
 
     #[test]
-    fn test_handle_tool_call_does_not_use_server_root_when_path_given() {
-        // Server is initialized with server_root (which has a file with a unique symbol)
-        // but the tool call requests a *different* path.
-        // The analysis result should only reflect the requested path, not the server root.
-        let (server, server_root) = create_test_server();
-        std::fs::write(
-            server_root.path().join("server_root_only.rs"),
-            "fn server_root_symbol() {}\n",
-        )
-        .unwrap();
-
-        // target_dir has completely different content
+    fn test_handle_tool_call_rejects_path_outside_server_root() {
+        let (server, _server_root) = create_test_server();
         let target_dir = TempDir::new().unwrap();
-        std::fs::write(
-            target_dir.path().join("target_only.rs"),
-            "fn target_only_symbol() {}\n",
-        )
-        .unwrap();
-
         let params = json!({
             "name": "complexity",
             "arguments": {"path": target_dir.path().to_str().unwrap()}
         });
-        let response = server.handle_tool_call(Some(params)).unwrap();
-        let text = response["content"][0]["text"]
-            .as_str()
-            .expect("tool response text should be a string");
 
-        assert!(
-            text.contains("target_only_symbol"),
-            "analysis should include content from the requested path, got: {text}"
+        assert!(server.handle_tool_call(Some(params)).is_err());
+    }
+
+    #[test]
+    fn test_handle_tool_call_allows_outside_path_with_flag() {
+        let server_root = TempDir::new().unwrap();
+        let target_dir = TempDir::new().unwrap();
+        std::fs::write(
+            target_dir.path().join("target.rs"),
+            "fn target_function() {}\n",
+        )
+        .unwrap();
+        let server = McpServer::new_with_external_paths(
+            server_root.path().to_path_buf(),
+            Config::default(),
+            true,
         );
-        assert!(
-            !text.contains("server_root_symbol"),
-            "analysis must not include content from server root when different path is requested, got: {text}"
-        );
+        let params = json!({
+            "name": "complexity",
+            "arguments": {"path": target_dir.path().to_str().unwrap()}
+        });
+
+        let response = server.handle_tool_call(Some(params)).unwrap();
+        let text = response["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("target_function"));
     }
 
     #[test]
@@ -1341,16 +1555,17 @@ mod tests {
         )
         .unwrap();
 
-        let target_dir = TempDir::new().unwrap();
+        let target_dir = server_root.path().join("target");
+        std::fs::create_dir(&target_dir).unwrap();
         std::fs::write(
-            target_dir.path().join("target.py"),
+            target_dir.join("target.py"),
             "# TODO: unique_target_todo\ndef target_func(): pass\n",
         )
         .unwrap();
 
         let params = json!({
             "name": "satd",
-            "arguments": {"path": target_dir.path().to_str().unwrap()}
+            "arguments": {"path": target_dir.to_str().unwrap()}
         });
         let response = server.handle_tool_call(Some(params)).unwrap();
         let text = response["content"][0]["text"]
@@ -1968,9 +2183,9 @@ mod tests {
 
     #[test]
     fn test_handle_tool_call_outline_file() {
-        let (server, _temp_dir) = create_test_server();
-        let fixture =
-            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/sample.rs");
+        let (server, temp_dir) = create_test_server();
+        let fixture = temp_dir.path().join("sample.rs");
+        std::fs::write(&fixture, "fn sample() {}\n").unwrap();
         let params = json!({
             "name": "outline",
             "arguments": {"file": fixture.to_str().unwrap()}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,3 +1,4 @@
+use assert_cmd::cargo::CommandCargoExt;
 use assert_cmd::Command;
 use predicates::prelude::*;
 use tempfile::TempDir;
@@ -254,6 +255,153 @@ fn test_changed_since_filters_analyzer_files() {
     assert_eq!(files.len(), 1, "expected only changed file: {stdout}");
     assert!(files[0]["path"].as_str().unwrap().ends_with("src/b.rs"));
     assert!(!stdout.contains("src/a.rs"));
+}
+
+#[test]
+fn test_changed_since_rejects_option_like_ref() {
+    omen()
+        .args([
+            "-p",
+            fixtures_dir(),
+            "complexity",
+            "--changed-since=--output=stolen",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("must not start with '-'"));
+}
+
+#[test]
+fn test_mutation_refuses_dirty_targets_unless_allowed() {
+    let temp = TempDir::new().unwrap();
+    std::fs::write(temp.path().join("lib.rs"), "pub fn value() -> i32 { 1 }\n").unwrap();
+    for args in [
+        vec!["init"],
+        vec!["config", "user.email", "test@example.com"],
+        vec!["config", "user.name", "Test User"],
+        vec!["add", "."],
+        vec!["commit", "-m", "initial"],
+    ] {
+        assert!(std::process::Command::new("git")
+            .args(args)
+            .current_dir(temp.path())
+            .status()
+            .unwrap()
+            .success());
+    }
+    std::fs::write(temp.path().join("lib.rs"), "pub fn value() -> i32 { 2 }\n").unwrap();
+
+    omen()
+        .args(["-p", temp.path().to_str().unwrap(), "mutation", "--dry-run"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("uncommitted changes"));
+
+    omen()
+        .args([
+            "-p",
+            temp.path().to_str().unwrap(),
+            "mutation",
+            "--dry-run",
+            "--allow-dirty",
+        ])
+        .assert()
+        .success();
+}
+
+#[cfg(unix)]
+#[test]
+fn test_mutation_sigint_restores_active_source_file() {
+    let temp = TempDir::new().unwrap();
+    let source = temp.path().join("lib.rs");
+    let marker = temp.path().join("test-started");
+    let original = "pub fn value() -> i32 { 1 }\n";
+    std::fs::write(&source, original).unwrap();
+    for args in [
+        vec!["init"],
+        vec!["config", "user.email", "test@example.com"],
+        vec!["config", "user.name", "Test User"],
+        vec!["add", "."],
+        vec!["commit", "-m", "initial"],
+    ] {
+        assert!(std::process::Command::new("git")
+            .args(args)
+            .current_dir(temp.path())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .unwrap()
+            .success());
+    }
+    let test_command = format!("touch '{}' && sleep 2", marker.display());
+    #[allow(deprecated)]
+    let mut command = std::process::Command::cargo_bin("omen").unwrap();
+    command.args([
+        "-p",
+        temp.path().to_str().unwrap(),
+        "mutation",
+        "--test-command",
+        &test_command,
+    ]);
+    let mut child = command
+        .current_dir(temp.path())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .unwrap();
+
+    for _ in 0..250 {
+        if marker.exists() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    assert!(marker.exists(), "mutation test command did not start");
+    assert_ne!(std::fs::read_to_string(&source).unwrap(), original);
+
+    assert_eq!(unsafe { libc::kill(child.id() as i32, libc::SIGINT) }, 0);
+    let status = child.wait().unwrap();
+
+    assert_eq!(status.code(), Some(130));
+    assert_eq!(std::fs::read_to_string(source).unwrap(), original);
+}
+
+#[test]
+fn test_deadcode_only_runs_cargo_check_when_opted_in() {
+    let temp = TempDir::new().unwrap();
+    let marker = temp.path().join("build-script-ran");
+    std::fs::create_dir(temp.path().join("src")).unwrap();
+    std::fs::write(
+        temp.path().join("Cargo.toml"),
+        "[package]\nname = \"deadcode-opt-in\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .unwrap();
+    std::fs::write(temp.path().join("src/lib.rs"), "fn unused() {}\n").unwrap();
+    std::fs::write(
+        temp.path().join("build.rs"),
+        format!(
+            "fn main() {{ std::fs::write(r#\"{}\"#, b\"ran\").unwrap(); }}\n",
+            marker.display()
+        ),
+    )
+    .unwrap();
+
+    omen()
+        .args(["-p", temp.path().to_str().unwrap(), "deadcode"])
+        .assert()
+        .success();
+    assert!(!marker.exists());
+
+    omen()
+        .args([
+            "-p",
+            temp.path().to_str().unwrap(),
+            "deadcode",
+            "--cargo-check",
+        ])
+        .assert()
+        .success();
+    assert!(marker.exists());
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes a set of command-execution and filesystem-access risks found in a security audit.

- **deadcode no longer runs `cargo check` by default.** `cargo check` executes build scripts and proc-macros from the analyzed repo (RCE on untrusted code). It now runs only with the explicit `deadcode --cargo-check` flag, and is never enabled through the MCP server.
- **MCP path confinement.** `path`, outline `file`, and semantic-search `include_projects` arguments are canonicalized and must resolve beneath the MCP root; an `mcp --allow-external-paths` flag opts out. Replaces the previous unrestricted behavior.
- **Git argument injection.** Refs/paths reaching `git diff`/`git status` use `--end-of-options`, reject leading `-`, and place `--` before paths.
- **Clone directory.** The shared temp clone base is created `0700` on unix and, if pre-existing, must be owned by the current uid and not world-writable.
- **Mutation safety.** `omen mutation` refuses to run on files with uncommitted changes unless `--allow-dirty`, and a SIGINT/Ctrl-C handler restores mutated files before exit.
- **Resource caps.** 5 MiB per-source-file limit and 10 MiB MCP line limit; the MCP stdio loop now replies with a parse error and continues on invalid UTF-8 instead of dying.
- **CI.** New SHA-pinned `cargo-audit` job; pinned `actions/checkout` in `omen.yml`.

## Verification

`cargo fmt --check`, `cargo test` (1850 lib + 50 integration + property/doc) pass; clippy clean. New regression tests: malicious `build.rs` is not executed without `--cargo-check`; MCP rejects external paths and `../` traversal; mutation refuses dirty targets; oversized files are rejected.

Note: the SIGINT handler is registered via `libc` directly (only sets an atomic flag — async-signal-safe) because the sandbox had no crates.io access to add `ctrlc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added opt-in `--cargo-check` support for dead-code analysis.
  - Added `--allow-dirty` for mutation testing and `--allow-external-paths` for MCP.
  - Added a 5 MiB source-file size limit.

- **Bug Fixes & Security**
  - Improved protection against unsafe Git references, path traversal, insecure clone directories, and malformed MCP input.
  - Mutation testing now restores modified files after interruptions and blocks dirty files by default.
  - Added automated dependency vulnerability auditing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->