### PR TITLE
Overhaul agent-facing CLI and MCP DX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -58,9 +58,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -122,12 +122,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
-
-[[package]]
 name = "arc-swap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,9 +138,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "assert_cmd"
@@ -180,9 +174,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
@@ -270,15 +264,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -311,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -353,9 +347,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "byteorder"
@@ -365,9 +359,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cast"
@@ -386,21 +380,15 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -410,9 +398,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -500,21 +488,24 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clru"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59"
+checksum = "197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5"
+dependencies = [
+ "hashbrown 0.16.1",
+]
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -525,14 +516,14 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -546,9 +537,9 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -572,23 +563,9 @@ dependencies = [
 
 [[package]]
 name = "const-str"
-version = "0.3.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21077772762a1002bb421c3af42ac1725fa56066bfc53d9a55bb79905df2aaf3"
-dependencies = [
- "const-str-proc-macro",
-]
-
-[[package]]
-name = "const-str-proc-macro"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1e0fdd2e5d3041e530e1b21158aeeef8b5d0e306bc5c1e3d6cf0930d10e25a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
+checksum = "18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f"
 
 [[package]]
 name = "constant_time_eq"
@@ -700,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -719,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -741,34 +718,34 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.33.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be934d936a0fbed5bcdc01042b770de1398bf79d0e192f49fa7faea0e99281e"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
 dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf 0.11.3",
+ "phf 0.13.1",
  "smallvec",
 ]
 
 [[package]]
 name = "cssparser-color"
-version = "0.1.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556c099a61d85989d7af52b692e35a8d68a57e7df8c6d07563dc0778b3960c9f"
+checksum = "bbaa233e1dcd9c13a5d3e3a8a2c0f5a727bac380398345dbcb31db4597edc86b"
 dependencies = [
  "cssparser",
 ]
 
 [[package]]
 name = "cssparser-macros"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -800,9 +777,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "data-url"
@@ -832,7 +809,7 @@ dependencies = [
  "defmt-parser",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -841,7 +818,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -862,13 +839,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -900,9 +877,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "embedded-io"
@@ -944,7 +921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -985,6 +962,8 @@ dependencies = [
  "parking_lot",
  "pear",
  "serde",
+ "serde_json",
+ "serde_yaml",
  "tempfile",
  "toml",
  "uncased",
@@ -1003,9 +982,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "fixedbitset"
@@ -1073,9 +1052,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1083,33 +1062,33 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -1117,7 +1096,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1233,7 +1211,7 @@ dependencies = [
  "gix-zlib",
  "nonempty",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -1260,7 +1238,7 @@ dependencies = [
  "gix-quote",
  "gix-trace",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror",
  "unicode-bom",
 ]
 
@@ -1290,7 +1268,7 @@ dependencies = [
  "gix-traverse",
  "gix-worktree",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -1344,7 +1322,7 @@ dependencies = [
  "gix-sec",
  "gix-utils",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror",
  "unicode-bom",
 ]
 
@@ -1354,11 +1332,11 @@ version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f6af5321bfd3711a279d6b244d58532ba1cfabf9eb6374791f19929d8970082"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "bstr",
  "gix-path",
  "libc",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -1377,7 +1355,7 @@ dependencies = [
  "gix-sec",
  "gix-trace",
  "gix-url",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -1410,7 +1388,7 @@ dependencies = [
  "gix-trace",
  "gix-traverse",
  "gix-worktree",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -1425,7 +1403,7 @@ dependencies = [
  "gix-path",
  "gix-ref",
  "gix-sec",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -1474,7 +1452,7 @@ dependencies = [
  "gix-trace",
  "gix-utils",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -1487,7 +1465,7 @@ dependencies = [
  "gix-features",
  "gix-path",
  "gix-utils",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -1496,7 +1474,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "421e92a711554fa5827d1b0599d3389acdd0f6729e97a8c5a57d79af1e50bf36"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "bstr",
  "gix-features",
  "gix-path",
@@ -1511,7 +1489,7 @@ dependencies = [
  "faster-hex",
  "gix-features",
  "sha1-checked",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -1554,7 +1532,7 @@ version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5009c4e7e9f9b4cfaaab1153e49133eb04d79c015b5702d6c3d2ab94271a89c6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "bstr",
  "filetime",
  "fnv",
@@ -1573,7 +1551,7 @@ dependencies = [
  "memmap2",
  "rustix",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -1584,7 +1562,7 @@ checksum = "d4c69157820343bf1c6e4b88b9808e920900de02e18aaf5862b30ada43814848"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -1610,7 +1588,7 @@ dependencies = [
  "gix-trace",
  "gix-worktree",
  "nonempty",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -1619,7 +1597,7 @@ version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fa5aa789990f124e4f559b142cecfb60662cb4ae17006684ea9d668f4f07689"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "gix-commitgraph",
  "gix-date",
  "gix-hash",
@@ -1643,7 +1621,7 @@ dependencies = [
  "gix-validate",
  "itoa",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -1665,7 +1643,7 @@ dependencies = [
  "memmap2",
  "parking_lot",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -1687,7 +1665,7 @@ dependencies = [
  "memmap2",
  "parking_lot",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -1699,7 +1677,7 @@ dependencies = [
  "bstr",
  "faster-hex",
  "gix-trace",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -1711,7 +1689,7 @@ dependencies = [
  "bstr",
  "gix-trace",
  "gix-validate",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -1720,13 +1698,13 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f6fa5f8007f008187c3f60b4373209ca83d1cc947f35ede03e16cd15a4d137"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "bstr",
  "gix-attributes",
  "gix-config-value",
  "gix-glob",
  "gix-path",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -1739,7 +1717,7 @@ dependencies = [
  "gix-config-value",
  "parking_lot",
  "rustix",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -1765,7 +1743,7 @@ dependencies = [
  "gix-transport",
  "gix-utils",
  "nonempty",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -1796,7 +1774,7 @@ dependencies = [
  "gix-utils",
  "gix-validate",
  "memmap2",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -1812,7 +1790,7 @@ dependencies = [
  "gix-revision",
  "gix-validate",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -1821,7 +1799,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e55e09d4a1ecf2beecc8c09cafcad37979e805b31f588b0e957e191df5783681"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "bstr",
  "gix-commitgraph",
  "gix-date",
@@ -1847,7 +1825,7 @@ dependencies = [
  "gix-hashtable",
  "gix-object",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -1856,7 +1834,7 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af4fe6c152c1d50aea36f299825702cd37e303307832fec1d0fdd5844e47ce2f"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "gix-path",
  "libc",
  "windows-sys 0.61.2",
@@ -1872,7 +1850,7 @@ dependencies = [
  "gix-hash",
  "gix-lock",
  "nonempty",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -1887,7 +1865,7 @@ dependencies = [
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -1927,7 +1905,7 @@ dependencies = [
  "gix-url",
  "parking_lot",
  "reqwest",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -1936,7 +1914,7 @@ version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "008c5cd879e46e86b5c2469e633611978b18775d53d05668d691bc13088bd409"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "gix-commitgraph",
  "gix-date",
  "gix-hash",
@@ -1944,7 +1922,7 @@ dependencies = [
  "gix-object",
  "gix-revwalk",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -1957,7 +1935,7 @@ dependencies = [
  "gix-path",
  "gix-utils",
  "percent-encoding",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -2023,7 +2001,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e8813f5579b3075ff9c90f7c59cd2b62b4ebb639361f0911648b22d7446cc7c"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror",
  "zlib-rs",
 ]
 
@@ -2042,9 +2020,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2110,6 +2088,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -2151,9 +2130,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2161,9 +2140,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -2171,9 +2150,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2190,9 +2169,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2204,7 +2183,6 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -2212,15 +2190,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -2275,12 +2252,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -2288,9 +2266,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2301,9 +2279,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2315,15 +2293,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -2335,15 +2313,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2367,9 +2345,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2393,12 +2371,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2437,19 +2415,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-
-[[package]]
-name = "iri-string"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
-dependencies = [
- "memchr",
- "serde",
-]
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2486,9 +2454,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
@@ -2525,14 +2493,14 @@ dependencies = [
  "jiff-core",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68971ebff725b9e2ca27a601c5eb38a4c5d64422c4cbab0c535f248087eda5c2"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
 
 [[package]]
 name = "jiff-tzdb-platform"
@@ -2545,51 +2513,79 @@ dependencies = [
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
+ "jni-macros",
  "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "json-escape-simd"
-version = "3.0.1"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3c2a6c0b4b5637c41719973ef40c6a1cf564f9db6958350de6193fbee9c23f5"
+checksum = "c22a2041e3874a055a4eb03ea2395aaccdefa84ce75b31d542d72a741c3c6ad3"
 
 [[package]]
 name = "lazy_static"
@@ -2616,12 +2612,12 @@ dependencies = [
 
 [[package]]
 name = "lightningcss"
-version = "1.0.0-alpha.70"
+version = "1.0.0-alpha.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9efb6a77b2389e62735b0b8157be9cc10a159eb4d1c3b864e99db9f297ada1b0"
+checksum = "d31b760f96e8fdfe1d0c295e4bf76c503d6f15d2d470d53bd8cd1f7aa8c7d934"
 dependencies = [
  "ahash 0.8.12",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "const-str",
  "cssparser",
  "cssparser-color",
@@ -2662,9 +2658,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -2677,9 +2673,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -2704,9 +2700,9 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
@@ -2823,9 +2819,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -2853,7 +2849,6 @@ dependencies = [
 name = "omen-cli"
 version = "4.25.0"
 dependencies = [
- "anyhow",
  "assert_cmd",
  "blake3",
  "bstr",
@@ -2883,7 +2878,7 @@ dependencies = [
  "serde_json",
  "streaming-iterator",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2941,48 +2936,48 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "owo-colors"
-version = "4.2.3"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "oxc-browserslist"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b1853bc34cadaa90aa09f95713d8b77ec0c0d3e2d90ccf7a74216f40d20850"
+checksum = "abb7a1163a5501f935f8722d839b576491b749c695e7a066aa0b8df988b806df"
 dependencies = [
  "flate2",
  "postcard",
  "rustc-hash",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
 name = "oxc-miette"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a7ba54c704edefead1f44e9ef09c43e5cfae666bdc33516b066011f0e6ebf7"
+checksum = "4356a61f2ed4c9b3610245215fbf48970eb277126919f87db9d0efa93a74245c"
 dependencies = [
  "cfg-if",
  "owo-colors",
  "oxc-miette-derive",
  "textwrap",
- "thiserror 2.0.19",
+ "thiserror",
  "unicode-segmentation",
  "unicode-width",
 ]
 
 [[package]]
 name = "oxc-miette-derive"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4faecb54d0971f948fbc1918df69b26007e6f279a204793669542e1e8b75eb3"
+checksum = "b237422b014f8f8fff75bb9379e697d13f8d57551a22c88bebb39f073c1bf696"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3004,7 +2999,7 @@ version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e78ea25d23521092edcd509198635dd0bd96df7fb71349bcd8087bb8f6a615d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "oxc_allocator",
  "oxc_ast_macros",
  "oxc_data_structures",
@@ -3024,7 +3019,7 @@ dependencies = [
  "phf 0.13.1",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3045,7 +3040,7 @@ version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "480bab938439c921d34750708abf15aacf253ea11e2f348e4b085cbf697f4ea2"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cow-utils",
  "dragonbox_ecma",
  "itoa",
@@ -3169,7 +3164,7 @@ version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb730ab93ff23bbc471ef7109f847afa709bb284dd52a5d3366283d724858158"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cow-utils",
  "memchr",
  "num-bigint",
@@ -3192,7 +3187,7 @@ version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bafc3035e3b0fe555ae56f7bbc108a7ee520b0858250ba16d197e44ca83746"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "oxc_allocator",
  "oxc_ast_macros",
  "oxc_diagnostics",
@@ -3225,9 +3220,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_sourcemap"
-version = "6.0.2"
+version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f89482522f3cd820817d48ee4ade5b10822060d6e5e4d419f05f6d8bd29d70"
+checksum = "6d378eb8bad20e89d66276aebab51f6a5408571092cac94abdd3eabb773713d6"
 dependencies = [
  "base64-simd 0.8.0",
  "json-escape-simd",
@@ -3255,7 +3250,7 @@ version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93c99e555ed497111004a71fb2aa6f8fb90b0d3e2733aceeb035e24701d69634"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cow-utils",
  "dragonbox_ecma",
  "nonmax",
@@ -3299,11 +3294,11 @@ dependencies = [
 
 [[package]]
 name = "parcel_selectors"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54fd03f1ad26cb6b3ec1b7414fa78a3bd639e7dbb421b1a60513c96ce886a196"
+checksum = "d05f71e01edca03d245ab0a9f7ce13a974ceb79baaae8faf2ba0b11de6b90913"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cssparser",
  "log",
  "phf 0.11.3",
@@ -3382,7 +3377,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3409,7 +3404,6 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros 0.11.3",
  "phf_shared 0.11.3",
 ]
 
@@ -3419,7 +3413,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros 0.13.1",
+ "phf_macros",
  "phf_shared 0.13.1",
  "serde",
 ]
@@ -3441,7 +3435,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -3456,19 +3450,6 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "phf_macros"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
@@ -3477,7 +3458,7 @@ dependencies = [
  "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3500,21 +3481,15 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plotters"
@@ -3546,15 +3521,15 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -3573,9 +3548,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -3611,15 +3586,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -3627,9 +3602,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -3642,7 +3617,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "version_check",
  "yansi",
 ]
@@ -3664,9 +3639,9 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -3701,7 +3676,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "getopts",
  "memchr",
  "pulldown-cmark-escape",
@@ -3722,9 +3697,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -3734,7 +3709,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.19",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -3757,7 +3732,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.19",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3765,23 +3740,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -3806,18 +3781,18 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -3909,7 +3884,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -4037,12 +4012,12 @@ dependencies = [
 
 [[package]]
 name = "rsqlite-vfs"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -4051,7 +4026,7 @@ version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -4062,9 +4037,18 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -4072,18 +4056,18 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -4095,9 +4079,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -4107,9 +4091,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4117,9 +4101,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -4133,7 +4117,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4144,9 +4128,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4156,9 +4140,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-fork"
@@ -4189,9 +4173,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -4210,11 +4194,11 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
-version = "3.5.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -4223,9 +4207,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4233,9 +4217,15 @@ dependencies = [
 
 [[package]]
 name = "self_cell"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
+checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "seq-macro"
@@ -4306,6 +4296,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4343,9 +4346,9 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -4368,9 +4371,19 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
 
 [[package]]
 name = "simdutf8"
@@ -4386,9 +4399,9 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -4398,15 +4411,15 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smawk"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
 
 [[package]]
 name = "socket2"
@@ -4420,9 +4433,9 @@ dependencies = [
 
 [[package]]
 name = "sqlite-wasm-rs"
-version = "0.5.2"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4206ed3a67690b9c29b77d728f6acc3ce78f16bf846d83c94f76400320181b"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
 dependencies = [
  "cc",
  "js-sys",
@@ -4473,9 +4486,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4510,7 +4523,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4529,7 +4542,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4551,38 +4564,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
-dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4591,18 +4584,18 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -4620,9 +4613,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4672,13 +4665,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -4741,20 +4735,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -4788,7 +4782,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4832,9 +4826,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.11"
+version = "0.26.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1c71c1c4cc0920b20d6b0f6572e7682cd07a6a2faec71067a31fa394c586df"
+checksum = "83c567a8e18ae93f20982c90370b16fd24023aeaf52f6052b96957ab253a0fec"
 dependencies = [
  "cc",
  "regex",
@@ -5017,9 +5011,9 @@ checksum = "81b79ad29b5e19de4260020f8919b443b2ef0277d242ce532ec7b7a2cc8b6007"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-linebreak"
@@ -5038,9 +5032,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -5053,6 +5047,12 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -5086,9 +5086,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.20.0"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5160,18 +5160,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5182,23 +5182,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5206,31 +5202,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5248,9 +5244,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5277,7 +5273,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5307,7 +5303,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5318,7 +5314,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5347,20 +5343,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -5374,40 +5361,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -5417,21 +5383,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5447,21 +5401,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5471,21 +5413,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5495,24 +5425,24 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyz"
@@ -5537,9 +5467,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -5548,68 +5478,68 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -5618,9 +5548,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -5629,13 +5559,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5646,6 +5576,6 @@ checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ categories = ["command-line-utilities", "development-tools"]
 name = "omen"
 path = "src/lib.rs"
 
+[features]
+default = ["mutation"]
+mutation = ["dep:tokio", "dep:reqwest"]
+
 [[bin]]
 name = "omen"
 path = "src/main.rs"
@@ -24,12 +28,11 @@ clap = { version = "4.5", features = ["derive", "env", "cargo"] }
 
 # Error handling
 thiserror = "2.0"
-anyhow = "1.0"
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-figment = { version = "0.10", features = ["toml", "env"] }
+figment = { version = "0.10", features = ["toml", "env", "yaml", "json"] }
 
 # Tree-sitter for parsing
 tree-sitter = "0.26"
@@ -68,8 +71,8 @@ blake3 = "1.5"
 indicatif = "0.18"
 
 # HTTP for remote repos (MCP server)
-reqwest = { version = "0.13", default-features = false, features = ["rustls", "blocking", "json"] }
-tokio = { version = "1.42", features = ["rt-multi-thread", "macros", "io-std", "sync", "time", "process"] }
+reqwest = { version = "0.13", default-features = false, features = ["rustls", "blocking", "json"], optional = true }
+tokio = { version = "1.42", features = ["rt-multi-thread", "macros", "io-std", "sync", "time", "process"], optional = true }
 
 # Logging
 tracing = "0.1"

--- a/omen.example.toml
+++ b/omen.example.toml
@@ -3,7 +3,7 @@
 # Documentation: https://github.com/panbanda/omen
 
 # Exclude patterns (glob) - files/directories to skip during analysis
-exclude_patterns = [
+exclude = [
     # Test files
     "*_test.rs",
     "*_test.go",
@@ -49,21 +49,13 @@ exclude_patterns = [
 
 # Complexity analysis thresholds
 [complexity]
-# Cyclomatic complexity warning threshold (default: 10)
-cyclomatic_warn = 10
 # Cyclomatic complexity error threshold (default: 20)
 cyclomatic_error = 20
-# Cognitive complexity warning threshold (default: 15)
-cognitive_warn = 15
 # Cognitive complexity error threshold (default: 30)
 cognitive_error = 30
-# Maximum nesting depth (default: 4)
-max_nesting = 4
 
 # Self-Admitted Technical Debt (SATD) detection
 [satd]
-# Categories to detect: design, defect, requirement, test, performance, security
-categories = ["design", "defect", "requirement", "test", "performance", "security"]
 # Custom markers beyond the default (TODO, FIXME, HACK, BUG, etc.)
 custom_markers = []
 
@@ -91,16 +83,6 @@ top = 20
 # Fail CI if score is below this threshold (optional)
 # fail_under = 70.0
 
-# Individual component score thresholds
-[score.thresholds]
-complexity = 85.0
-duplication = 65.0
-satd = 80.0
-tdg = 90.0
-coupling = 70.0
-smells = 90.0
-cohesion = 80.0
-
 # Feature flag detection
 [feature_flags]
 # Days before a flag is considered stale
@@ -125,33 +107,3 @@ providers = []
 #     (simple_symbol) @flag_key))
 # '''
 custom_providers = []
-
-# Semantic search configuration
-[semantic_search]
-# Maximum number of search results to return
-max_results = 20
-# Minimum similarity score (0-1) for results
-min_score = 0.3
-
-# Embedding provider configuration
-# Default: candle (local inference with all-MiniLM-L6-v2)
-[semantic_search.provider]
-type = "candle"
-
-# Alternative: OpenAI embeddings
-# [semantic_search.provider]
-# type = "open_ai"
-# model = "text-embedding-3-small"  # or "text-embedding-3-large", "text-embedding-ada-002"
-# api_key = "sk-..."  # Optional: can also use OPENAI_API_KEY env var
-
-# Alternative: Cohere embeddings
-# [semantic_search.provider]
-# type = "cohere"
-# model = "embed-english-v3.0"  # or "embed-multilingual-v3.0", "embed-english-light-v3.0"
-# api_key = "..."  # Optional: can also use COHERE_API_KEY env var
-
-# Alternative: Voyage AI embeddings (optimized for code)
-# [semantic_search.provider]
-# type = "voyage"
-# model = "voyage-code-2"  # or "voyage-2", "voyage-large-2"
-# api_key = "..."  # Optional: can also use VOYAGE_API_KEY env var

--- a/omen.toml
+++ b/omen.toml
@@ -2,7 +2,7 @@
 # Documentation: https://github.com/panbanda/omen
 
 # Exclude patterns (glob)
-exclude_patterns = [
+exclude = [
     # Test and benchmark files
     "*_test.rs",
     "tests/**",
@@ -25,14 +25,10 @@ exclude_patterns = [
 ]
 
 [complexity]
-cyclomatic_warn = 10
 cyclomatic_error = 20
-cognitive_warn = 15
 cognitive_error = 30
-max_nesting = 4
 
 [satd]
-categories = ["design", "defect", "requirement", "test", "performance", "security"]
 custom_markers = []
 
 [churn]
@@ -48,15 +44,6 @@ top = 20
 
 [score]
 fail_under = 70.0
-
-[score.thresholds]
-complexity = 85.0
-duplication = 65.0
-satd = 80.0
-tdg = 90.0
-coupling = 70.0
-smells = 90.0
-cohesion = 80.0
 
 [feature_flags]
 stale_days = 90

--- a/plugins/development/skills/assess-impact/SKILL.md
+++ b/plugins/development/skills/assess-impact/SKILL.md
@@ -18,7 +18,7 @@ Omen CLI must be installed and available in PATH.
 Use the `impact` command to get transitive callers and callees in one call:
 
 ```bash
-omen -f json impact --symbol <symbol-name> --depth 2
+omen -f json impact <symbol-name> --depth 2
 ```
 
 This returns affected files, caller/callee BFS levels, and the total count — much faster than building the picture manually.
@@ -26,7 +26,7 @@ This returns affected files, caller/callee BFS levels, and the total count — m
 To inspect a specific symbol first:
 
 ```bash
-omen -f json symbol --name <symbol-name>
+omen -f json symbol <symbol-name>
 ```
 
 ### Step 2: Map File-Level Dependencies

--- a/plugins/development/skills/context/SKILL.md
+++ b/plugins/development/skills/context/SKILL.md
@@ -19,10 +19,10 @@ Get metrics before modifying: `{{.focus}}`
 omen -f json outline --compact --file "{{.focus}}"
 
 # Inspect a specific symbol's definition and callers
-omen -f json symbol --name "{{.focus}}"
+omen -f json symbol "{{.focus}}"
 
 # Get full deep context for LLM-assisted editing
-omen -f json context --symbol "{{.focus}}"
+omen -f json context
 ```
 
 ## What You Get

--- a/plugins/development/skills/find-bugs/SKILL.md
+++ b/plugins/development/skills/find-bugs/SKILL.md
@@ -17,10 +17,10 @@ Hunt for bugs in: `{{.paths}}`
 
 ```bash
 # Get high-risk files (threshold 0.8 = high risk)
-omen -f json defect --risk-threshold 0.8
+omen -f json defect
 
 # Find hotspots
-omen -f json hotspot --days 30
+omen -f json hotspot
 
 # Check for explicit markers
 omen -f json satd | jq '.items[] | select(.category == "defect")'

--- a/plugins/development/skills/focus-review/SKILL.md
+++ b/plugins/development/skills/focus-review/SKILL.md
@@ -19,7 +19,7 @@ Review focus for: `{{.changed_files}}`
 omen -f json outline --compact --top 30
 
 # Check blast radius of changed symbols
-omen -f json impact --symbol <changed-symbol> --depth 2
+omen -f json impact <changed-symbol> --depth 2
 
 # Check risk of changed files
 omen -p "{{.changed_files}}" -f json defect

--- a/plugins/development/skills/plan-refactoring/SKILL.md
+++ b/plugins/development/skills/plan-refactoring/SKILL.md
@@ -20,16 +20,16 @@ Find refactoring targets in: `{{.paths}}`
 omen -f json outline --compact --top 50
 
 # Find hotspots (high churn + complexity)
-omen -f json hotspot -n 10
+omen -f json hotspot --top 10
 
 # Find code clones
-omen -f json clones --min-tokens 50
+omen -f json clones
 
 # Find acknowledged debt
 omen -f json satd | jq '.items[] | select(.category == "design")'
 
 # Assess blast radius before refactoring a specific symbol
-omen -f json impact --symbol <symbol-name> --depth 2
+omen -f json impact <symbol-name> --depth 2
 ```
 
 ## Priority Matrix

--- a/plugins/development/skills/setup-config/SKILL.md
+++ b/plugins/development/skills/setup-config/SKILL.md
@@ -79,7 +79,7 @@ Key points for custom providers:
 - Custom providers run automatically and don't need to be listed in `providers`
 
 To write tree-sitter queries:
-1. Use `omen context <file>` to see the AST structure
+1. Use `omen outline --file <file>` to inspect the file structure
 2. Match the pattern that wraps your feature flag calls
 3. Capture the flag key string with `@flag_key` or `@key`
 

--- a/src/analyzers/complexity.rs
+++ b/src/analyzers/complexity.rs
@@ -131,7 +131,7 @@ impl AnalyzerTrait for Analyzer {
             .files()
             .par_iter()
             .filter_map(|path| {
-                let result = if ctx.content_source.is_some() {
+                let mut result = if ctx.content_source.is_some() {
                     // Read via content source (e.g., git tree)
                     ctx.read_file(path)
                         .ok()
@@ -146,6 +146,9 @@ impl AnalyzerTrait for Analyzer {
                 let current = counter.fetch_add(1, Ordering::Relaxed) + 1;
                 ctx.report_progress(current, total_files);
 
+                if let Some(result) = result.as_mut() {
+                    result.path = path.to_string_lossy().to_string();
+                }
                 result
             })
             .collect();
@@ -204,16 +207,20 @@ impl Analysis {
         let violations: Vec<Violation> = self
             .files
             .iter()
-            .flat_map(|file| &file.functions)
-            .filter(|func| {
-                func.metrics.cyclomatic > max_cyclomatic || func.metrics.cognitive > max_cognitive
-            })
-            .map(|func| Violation {
-                name: func.name.clone(),
-                file: func.file.clone(),
-                line: func.start_line,
-                cyclomatic: func.metrics.cyclomatic,
-                cognitive: func.metrics.cognitive,
+            .flat_map(|file| {
+                file.functions
+                    .iter()
+                    .filter(|func| {
+                        func.metrics.cyclomatic > max_cyclomatic
+                            || func.metrics.cognitive > max_cognitive
+                    })
+                    .map(|func| Violation {
+                        name: func.name.clone(),
+                        file: file.path.clone(),
+                        line: func.start_line,
+                        cyclomatic: func.metrics.cyclomatic,
+                        cognitive: func.metrics.cognitive,
+                    })
             })
             .collect();
 
@@ -249,8 +256,6 @@ pub struct FileResult {
 pub struct FunctionResult {
     /// Function name.
     pub name: String,
-    /// File path.
-    pub file: String,
     /// Start line (1-indexed).
     pub start_line: u32,
     /// End line (1-indexed).
@@ -321,7 +326,6 @@ fn analyze_parse_result(result: &ParseResult) -> FileResult {
 
         file_result.functions.push(FunctionResult {
             name: func.name,
-            file: result.path.to_string_lossy().to_string(),
             start_line: func.start_line,
             end_line: func.end_line,
             metrics,
@@ -691,7 +695,6 @@ mod tests {
                 language: "rust".to_string(),
                 functions: vec![FunctionResult {
                     name: "simple_fn".to_string(),
-                    file: "test.rs".to_string(),
                     start_line: 1,
                     end_line: 5,
                     metrics: Metrics {
@@ -721,7 +724,6 @@ mod tests {
                 language: "rust".to_string(),
                 functions: vec![FunctionResult {
                     name: "complex_fn".to_string(),
-                    file: "test.rs".to_string(),
                     start_line: 1,
                     end_line: 50,
                     metrics: Metrics {
@@ -755,7 +757,6 @@ mod tests {
                 language: "rust".to_string(),
                 functions: vec![FunctionResult {
                     name: "nested_fn".to_string(),
-                    file: "test.rs".to_string(),
                     start_line: 1,
                     end_line: 30,
                     metrics: Metrics {
@@ -789,7 +790,6 @@ mod tests {
                 functions: vec![
                     FunctionResult {
                         name: "ok_fn".to_string(),
-                        file: "test.rs".to_string(),
                         start_line: 1,
                         end_line: 5,
                         metrics: Metrics {
@@ -801,7 +801,6 @@ mod tests {
                     },
                     FunctionResult {
                         name: "bad_fn1".to_string(),
-                        file: "test.rs".to_string(),
                         start_line: 10,
                         end_line: 50,
                         metrics: Metrics {
@@ -813,7 +812,6 @@ mod tests {
                     },
                     FunctionResult {
                         name: "bad_fn2".to_string(),
-                        file: "test.rs".to_string(),
                         start_line: 60,
                         end_line: 100,
                         metrics: Metrics {

--- a/src/analyzers/deadcode.rs
+++ b/src/analyzers/deadcode.rs
@@ -10,6 +10,7 @@
 //! constants, and type aliases are not yet analyzed.
 
 use std::collections::{HashMap, HashSet};
+use std::path::Path;
 use std::time::Instant;
 
 use rayon::prelude::*;
@@ -267,6 +268,12 @@ impl AnalyzerTrait for Analyzer {
         }
 
         let total_items = items.len();
+        for item in &mut items {
+            let path = Path::new(&item.file);
+            if let Ok(relative) = path.strip_prefix(ctx.root) {
+                item.file = relative.to_string_lossy().to_string();
+            }
+        }
         let analysis = Analysis {
             items,
             summary: AnalysisSummary {

--- a/src/analyzers/mod.rs
+++ b/src/analyzers/mod.rs
@@ -11,6 +11,7 @@ pub mod flags;
 pub mod graph;
 pub mod hotspot;
 pub mod impact;
+#[cfg(feature = "mutation")]
 pub mod mutation;
 pub mod outline;
 pub mod ownership;

--- a/src/analyzers/satd.rs
+++ b/src/analyzers/satd.rs
@@ -38,6 +38,20 @@ impl Analyzer {
         Self { patterns }
     }
 
+    pub fn with_custom_markers(mut self, markers: &[String]) -> Self {
+        if !markers.is_empty() {
+            let pattern = markers
+                .iter()
+                .map(|marker| regex::escape(marker))
+                .collect::<Vec<_>>()
+                .join("|");
+            if let Ok(regex) = Regex::new(&format!(r"(?i)\b({pattern})\b")) {
+                self.patterns.push(("custom".to_string(), regex, 1.0));
+            }
+        }
+        self
+    }
+
     /// Analyze a single file for SATD.
     pub fn analyze_file(&self, file: &SourceFile) -> Vec<SatdItem> {
         let content = file.content_str();
@@ -347,6 +361,23 @@ mod tests {
         assert_eq!(items.len(), 2);
         assert_eq!(items[0].category, "design");
         assert_eq!(items[1].category, "security");
+    }
+
+    #[test]
+    fn test_custom_marker_changes_detection() {
+        let file = SourceFile::from_content(
+            std::path::Path::new("test.rs"),
+            crate::core::Language::Rust,
+            b"// REVISIT: simplify this\n".to_vec(),
+        );
+        assert!(Analyzer::new().analyze_file(&file).is_empty());
+        assert_eq!(
+            Analyzer::new()
+                .with_custom_markers(&["REVISIT".to_string()])
+                .analyze_file(&file)
+                .len(),
+            1
+        );
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -18,7 +18,7 @@ pub struct Cli {
     pub format: OutputFormat,
 
     /// Compact JSON output (single line, no indentation; ignored for non-JSON formats)
-    #[arg(long)]
+    #[arg(long, global = true)]
     pub compact: bool,
 
     /// Configuration file path
@@ -135,6 +135,7 @@ pub enum Command {
     #[command(alias = "s")]
     Search(SearchCommand),
 
+    #[cfg(feature = "mutation")]
     /// Mutation testing for test suite effectiveness
     #[command(alias = "mut")]
     Mutation(Box<MutationCommand>),
@@ -216,8 +217,8 @@ pub struct ChurnArgs {
     pub common: AnalyzerArgs,
 
     /// Number of days to analyze
-    #[arg(long, default_value = "30")]
-    pub days: u32,
+    #[arg(long)]
+    pub days: Option<u32>,
 }
 
 #[derive(Args)]
@@ -306,14 +307,6 @@ pub struct McpArgs {
     #[arg(long, value_enum, default_value = "stdio")]
     pub transport: McpTransport,
 
-    /// Port for SSE transport
-    #[arg(long, default_value = "3000")]
-    pub port: u16,
-
-    /// Host for SSE transport
-    #[arg(long, default_value = "127.0.0.1")]
-    pub host: String,
-
     /// Allow tools to access paths outside the configured repository root
     #[arg(long)]
     pub allow_external_paths: bool,
@@ -322,21 +315,9 @@ pub struct McpArgs {
 /// Context generation for LLM consumption.
 #[derive(Args)]
 pub struct ContextArgs {
-    /// Target file or directory for context
-    #[arg(long)]
-    pub target: Option<PathBuf>,
-
     /// Maximum context tokens to generate
     #[arg(long, default_value = "8000")]
     pub max_tokens: usize,
-
-    /// Focus on specific symbol/function
-    #[arg(long)]
-    pub symbol: Option<String>,
-
-    /// Depth for dependency traversal
-    #[arg(long, default_value = "2")]
-    pub depth: usize,
 }
 
 /// Report command with subcommands.
@@ -471,6 +452,7 @@ pub struct SearchQueryArgs {
 }
 
 #[derive(Args)]
+#[cfg(feature = "mutation")]
 pub struct MutationArgs {
     #[command(flatten)]
     pub common: AnalyzerArgs,
@@ -542,6 +524,7 @@ pub struct MutationArgs {
 
 /// Mutation testing mode.
 #[derive(Clone, Copy, Debug, ValueEnum)]
+#[cfg(feature = "mutation")]
 pub enum MutationMode {
     /// All operators, all mutants
     All,
@@ -553,6 +536,7 @@ pub enum MutationMode {
 
 /// Mutation testing command with subcommands.
 #[derive(Args)]
+#[cfg(feature = "mutation")]
 pub struct MutationCommand {
     #[command(subcommand)]
     pub subcommand: Option<MutationSubcommand>,
@@ -562,6 +546,7 @@ pub struct MutationCommand {
 }
 
 #[derive(Subcommand)]
+#[cfg(feature = "mutation")]
 pub enum MutationSubcommand {
     /// Train ML predictor from historical mutation results
     Train(MutationTrainArgs),
@@ -626,6 +611,7 @@ pub struct SymbolArgs {
 
 /// Arguments for mutation train command.
 #[derive(Args)]
+#[cfg(feature = "mutation")]
 pub struct MutationTrainArgs {
     /// Path to analyze (default: current directory)
     #[arg(short, long, default_value = ".")]
@@ -651,7 +637,6 @@ pub enum OutputFormat {
 #[derive(Clone, Copy, ValueEnum)]
 pub enum McpTransport {
     Stdio,
-    Sse,
 }
 
 impl Cli {
@@ -1019,7 +1004,7 @@ mod tests {
     fn test_churn_days_default() {
         let cli = parse(&["omen", "churn"]);
         if let Command::Churn(args) = cli.command {
-            assert_eq!(args.days, 30);
+            assert_eq!(args.days, None);
         }
     }
 
@@ -1027,7 +1012,7 @@ mod tests {
     fn test_churn_days_custom() {
         let cli = parse(&["omen", "churn", "--days", "30"]);
         if let Command::Churn(args) = cli.command {
-            assert_eq!(args.days, 30);
+            assert_eq!(args.days, Some(30));
         }
     }
 
@@ -1052,30 +1037,6 @@ mod tests {
         let cli = parse(&["omen", "mcp", "--transport", "stdio"]);
         if let Command::Mcp(cmd) = cli.command {
             assert!(matches!(cmd.args.transport, McpTransport::Stdio));
-        }
-    }
-
-    #[test]
-    fn test_mcp_transport_sse() {
-        let cli = parse(&["omen", "mcp", "--transport", "sse"]);
-        if let Command::Mcp(cmd) = cli.command {
-            assert!(matches!(cmd.args.transport, McpTransport::Sse));
-        }
-    }
-
-    #[test]
-    fn test_mcp_port() {
-        let cli = parse(&["omen", "mcp", "--port", "8080"]);
-        if let Command::Mcp(cmd) = cli.command {
-            assert_eq!(cmd.args.port, 8080);
-        }
-    }
-
-    #[test]
-    fn test_mcp_host() {
-        let cli = parse(&["omen", "mcp", "--host", "0.0.0.0"]);
-        if let Command::Mcp(cmd) = cli.command {
-            assert_eq!(cmd.args.host, "0.0.0.0");
         }
     }
 
@@ -1135,37 +1096,11 @@ mod tests {
         ));
     }
 
-    // Context option tests
-
-    #[test]
-    fn test_context_target() {
-        let cli = parse(&["omen", "context", "--target", "src/main.rs"]);
-        if let Command::Context(args) = cli.command {
-            assert_eq!(args.target, Some(PathBuf::from("src/main.rs")));
-        }
-    }
-
     #[test]
     fn test_context_max_tokens() {
         let cli = parse(&["omen", "context", "--max-tokens", "4000"]);
         if let Command::Context(args) = cli.command {
             assert_eq!(args.max_tokens, 4000);
-        }
-    }
-
-    #[test]
-    fn test_context_symbol() {
-        let cli = parse(&["omen", "context", "--symbol", "main"]);
-        if let Command::Context(args) = cli.command {
-            assert_eq!(args.symbol, Some("main".to_string()));
-        }
-    }
-
-    #[test]
-    fn test_context_depth() {
-        let cli = parse(&["omen", "context", "--depth", "3"]);
-        if let Command::Context(args) = cli.command {
-            assert_eq!(args.depth, 3);
         }
     }
 
@@ -1712,6 +1647,65 @@ mod tests {
     #[test]
     fn test_cli_compact_flag() {
         assert!(parse(&["omen", "--compact", "complexity"]).compact);
+    }
+
+    #[test]
+    fn test_cli_compact_flag_after_subcommand() {
+        assert!(parse(&["omen", "complexity", "--compact"]).compact);
+    }
+
+    #[test]
+    fn test_mcp_rejects_non_stdio_transport() {
+        assert!(Cli::try_parse_from(["omen", "mcp", "--transport", "sse"]).is_err());
+    }
+
+    #[test]
+    fn test_context_rejects_unused_flags() {
+        for flag in ["--target", "--symbol", "--depth"] {
+            assert!(Cli::try_parse_from(["omen", "context", flag, "value"]).is_err());
+        }
+    }
+
+    #[test]
+    fn test_plugin_fenced_omen_commands_parse() {
+        let plugins = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("plugins");
+        let mut markdown_files = Vec::new();
+        collect_markdown_files(&plugins, &mut markdown_files);
+
+        let placeholder = regex::Regex::new(r#"\{\{[^}]+\}\}|<[^>]+>"#).unwrap();
+        let mut failures = Vec::new();
+        for path in markdown_files {
+            let content = std::fs::read_to_string(&path).unwrap();
+            let mut fenced = false;
+            for line in content.lines() {
+                if line.trim_start().starts_with("```") {
+                    fenced = !fenced;
+                    continue;
+                }
+                let line = line.trim();
+                if !fenced || !line.starts_with("omen ") {
+                    continue;
+                }
+                let command = line.split(['|', '>']).next().unwrap().trim();
+                let command = placeholder.replace_all(command, "placeholder");
+                let args: Vec<&str> = command.split_whitespace().collect();
+                if let Err(error) = Cli::try_parse_from(args) {
+                    failures.push(format!("{}: `{line}`: {error}", path.display()));
+                }
+            }
+        }
+        assert!(failures.is_empty(), "{}", failures.join("\n"));
+    }
+
+    fn collect_markdown_files(dir: &std::path::Path, files: &mut Vec<PathBuf>) {
+        for entry in std::fs::read_dir(dir).unwrap() {
+            let path = entry.unwrap().path();
+            if path.is_dir() {
+                collect_markdown_files(&path, files);
+            } else if path.extension().is_some_and(|extension| extension == "md") {
+                files.push(path);
+            }
+        }
     }
 
     #[test]

--- a/src/config/default_config.toml
+++ b/src/config/default_config.toml
@@ -16,14 +16,10 @@ exclude = [
 ]
 
 [complexity]
-cyclomatic_warn = 10
 cyclomatic_error = 20
-cognitive_warn = 15
 cognitive_error = 30
-max_nesting = 5
 
 [satd]
-categories = ["design", "defect", "requirement", "test", "performance", "security"]
 custom_markers = []
 
 [churn]
@@ -40,21 +36,8 @@ top = 20
 [score]
 # fail_under = 80
 
-[score.thresholds]
-# complexity = 85
-# duplication = 65
-# satd = 75
-# tdg = 70
-# coupling = 70
-# smells = 90
-# cohesion = 70
-
 [feature_flags]
 stale_days = 90
 # Built-in providers to enable. If empty, no built-in detection runs.
 # Available: launchdarkly, flipper, split, unleash, generic, env
 providers = []
-
-[output]
-format = "text"
-color = true

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 
 use figment::{
-    providers::{Env, Format, Serialized, Toml},
+    providers::{Env, Format, Json, Serialized, Toml, Yaml},
     Figment,
 };
 use serde::{Deserialize, Serialize};
@@ -12,7 +12,7 @@ use crate::core::Result;
 
 /// Main configuration structure.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct Config {
     /// Exclude patterns (glob).
     #[serde(rename = "exclude")]
@@ -33,8 +33,6 @@ pub struct Config {
     pub feature_flags: FeatureFlagsConfig,
     /// Temporal coupling configuration.
     pub temporal: TemporalConfig,
-    /// Output configuration.
-    pub output: OutputConfig,
     /// Exclude built/minified assets (e.g. *.min.js) from analysis.
     pub exclude_built_assets: bool,
     /// Changes/JIT analyzer configuration.
@@ -53,7 +51,6 @@ impl Default for Config {
             score: ScoreConfig::default(),
             feature_flags: FeatureFlagsConfig::default(),
             temporal: TemporalConfig::default(),
-            output: OutputConfig::default(),
             exclude_built_assets: true,
             changes: ChangesConfig::default(),
         }
@@ -73,8 +70,14 @@ impl Config {
                 path.display()
             )));
         }
-        let config: Self = Figment::from(Serialized::defaults(Self::default()))
-            .merge(Toml::file_exact(path))
+        let figment = Figment::from(Serialized::defaults(Self::default()));
+        let extension = path.extension().and_then(|value| value.to_str());
+        let figment = match extension {
+            Some("yaml" | "yml") => figment.merge(Yaml::file_exact(path)),
+            Some("json") => figment.merge(Json::file_exact(path)),
+            _ => figment.merge(Toml::file_exact(path)),
+        };
+        let config: Self = figment
             .merge(Env::prefixed("OMEN_").split("__"))
             .extract()
             .map_err(|e| crate::core::Error::Config(e.to_string()))?;
@@ -114,61 +117,34 @@ impl Config {
 
 /// Complexity analyzer configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct ComplexityConfig {
-    /// Maximum cyclomatic complexity before warning.
-    pub cyclomatic_warn: u32,
     /// Maximum cyclomatic complexity before error.
     pub cyclomatic_error: u32,
-    /// Maximum cognitive complexity before warning.
-    pub cognitive_warn: u32,
     /// Maximum cognitive complexity before error.
     pub cognitive_error: u32,
-    /// Maximum nesting depth.
-    pub max_nesting: u32,
 }
 
 impl Default for ComplexityConfig {
     fn default() -> Self {
         Self {
-            cyclomatic_warn: 10,
             cyclomatic_error: 20,
-            cognitive_warn: 15,
             cognitive_error: 30,
-            max_nesting: 5,
         }
     }
 }
 
 /// SATD analyzer configuration.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
 pub struct SatdConfig {
-    /// Categories to detect.
-    pub categories: Vec<String>,
     /// Custom markers to detect.
     pub custom_markers: Vec<String>,
 }
 
-impl Default for SatdConfig {
-    fn default() -> Self {
-        Self {
-            categories: vec![
-                "design".to_string(),
-                "defect".to_string(),
-                "requirement".to_string(),
-                "test".to_string(),
-                "performance".to_string(),
-                "security".to_string(),
-            ],
-            custom_markers: Vec::new(),
-        }
-    }
-}
-
 /// Churn analyzer configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct ChurnConfig {
     /// Time period to analyze (e.g., "6m", "1y").
     pub since: String,
@@ -187,7 +163,7 @@ impl Default for ChurnConfig {
 
 /// Clone detection configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct DuplicatesConfig {
     /// Minimum token count for clone detection.
     pub min_tokens: usize,
@@ -206,7 +182,7 @@ impl Default for DuplicatesConfig {
 
 /// Hotspot analyzer configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct HotspotConfig {
     /// Number of top hotspots to report.
     pub top: usize,
@@ -220,32 +196,16 @@ impl Default for HotspotConfig {
 
 /// Score configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 #[derive(Default)]
 pub struct ScoreConfig {
     /// Minimum overall score to pass.
     pub fail_under: Option<f64>,
-    /// Component thresholds.
-    pub thresholds: ScoreThresholds,
-}
-
-/// Score component thresholds.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
-#[derive(Default)]
-pub struct ScoreThresholds {
-    pub complexity: Option<f64>,
-    pub duplication: Option<f64>,
-    pub satd: Option<f64>,
-    pub tdg: Option<f64>,
-    pub coupling: Option<f64>,
-    pub smells: Option<f64>,
-    pub cohesion: Option<f64>,
 }
 
 /// Feature flag detection configuration.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct FeatureFlagsConfig {
     /// Days before a flag is considered stale.
     pub stale_days: u32,
@@ -258,6 +218,7 @@ pub struct FeatureFlagsConfig {
 
 /// Custom feature flag provider.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CustomProvider {
     /// Provider name.
     pub name: String,
@@ -270,7 +231,7 @@ pub struct CustomProvider {
 /// Output configuration.
 /// Temporal coupling configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct TemporalConfig {
     /// Exclude test files from coupling analysis.
     pub exclude_tests: bool,
@@ -284,27 +245,9 @@ impl Default for TemporalConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
-pub struct OutputConfig {
-    /// Default output format.
-    pub format: OutputFormat,
-    /// Color output.
-    pub color: bool,
-}
-
-impl Default for OutputConfig {
-    fn default() -> Self {
-        Self {
-            format: OutputFormat::Text,
-            color: true,
-        }
-    }
-}
-
 /// Changes/JIT analyzer configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct ChangesConfig {
     /// Number of days of history to analyze.
     pub days: u32,
@@ -350,7 +293,7 @@ mod tests {
     #[test]
     fn test_default_config() {
         let config = Config::default();
-        assert_eq!(config.complexity.cyclomatic_warn, 10);
+        assert_eq!(config.complexity.cyclomatic_error, 20);
         assert_eq!(config.churn.top, 20);
         assert!(config.exclude_built_assets);
     }
@@ -399,12 +342,8 @@ mod tests {
     #[test]
     fn test_config_from_file() {
         Jail::expect_with(|jail| {
-            jail.create_file(
-                "omen.toml",
-                "[complexity]\ncyclomatic_warn = 15\ncyclomatic_error = 25",
-            )?;
+            jail.create_file("omen.toml", "[complexity]\ncyclomatic_error = 25")?;
             let config = Config::from_file("omen.toml").unwrap();
-            assert_eq!(config.complexity.cyclomatic_warn, 15);
             assert_eq!(config.complexity.cyclomatic_error, 25);
             Ok(())
         });
@@ -445,7 +384,7 @@ mod tests {
     fn test_config_load_default_no_file() {
         Jail::expect_with(|_jail| {
             let config = Config::load_default(".").unwrap();
-            assert_eq!(config.complexity.cyclomatic_warn, 10);
+            assert_eq!(config.complexity.cyclomatic_error, 20);
             Ok(())
         });
     }
@@ -470,10 +409,10 @@ mod tests {
     #[test]
     fn test_env_var_overrides_file_value() {
         Jail::expect_with(|jail| {
-            jail.create_file("omen.toml", "[complexity]\ncyclomatic_warn = 15")?;
-            jail.set_env("OMEN_COMPLEXITY__CYCLOMATIC_WARN", "5");
+            jail.create_file("omen.toml", "[complexity]\ncyclomatic_error = 15")?;
+            jail.set_env("OMEN_COMPLEXITY__CYCLOMATIC_ERROR", "5");
             let config = Config::from_file("omen.toml").unwrap();
-            assert_eq!(config.complexity.cyclomatic_warn, 5);
+            assert_eq!(config.complexity.cyclomatic_error, 5);
             Ok(())
         });
     }
@@ -481,9 +420,9 @@ mod tests {
     #[test]
     fn test_env_var_overrides_default_no_file() {
         Jail::expect_with(|jail| {
-            jail.set_env("OMEN_COMPLEXITY__CYCLOMATIC_WARN", "42");
+            jail.set_env("OMEN_COMPLEXITY__CYCLOMATIC_ERROR", "42");
             let config = Config::load_default(".").unwrap();
-            assert_eq!(config.complexity.cyclomatic_warn, 42);
+            assert_eq!(config.complexity.cyclomatic_error, 42);
             Ok(())
         });
     }
@@ -497,18 +436,13 @@ mod tests {
     #[test]
     fn test_complexity_config_default() {
         let config = ComplexityConfig::default();
-        assert_eq!(config.cyclomatic_warn, 10);
         assert_eq!(config.cyclomatic_error, 20);
-        assert_eq!(config.cognitive_warn, 15);
         assert_eq!(config.cognitive_error, 30);
-        assert_eq!(config.max_nesting, 5);
     }
 
     #[test]
     fn test_satd_config_default() {
         let config = SatdConfig::default();
-        assert!(config.categories.contains(&"design".to_string()));
-        assert!(config.categories.contains(&"defect".to_string()));
         assert!(config.custom_markers.is_empty());
     }
 
@@ -539,13 +473,6 @@ mod tests {
     }
 
     #[test]
-    fn test_output_config_default() {
-        let config = OutputConfig::default();
-        assert_eq!(config.format, OutputFormat::Text);
-        assert!(config.color);
-    }
-
-    #[test]
     fn test_output_format_default() {
         assert_eq!(OutputFormat::default(), OutputFormat::Text);
     }
@@ -555,7 +482,7 @@ mod tests {
         let config = Config::default();
         let json = serde_json::to_string(&config).unwrap();
         assert!(json.contains("complexity"));
-        assert!(json.contains("cyclomatic_warn"));
+        assert!(json.contains("cyclomatic_error"));
     }
 
     #[test]
@@ -568,6 +495,26 @@ mod tests {
             let config = Config::from_file("omen.toml").unwrap();
             assert_eq!(config.exclude_patterns.len(), 2);
             assert!(config.exclude_patterns.contains(&"target/**".to_string()));
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_unknown_config_key_is_rejected_with_key_name() {
+        Jail::expect_with(|jail| {
+            jail.create_file("omen.toml", "[churn]\nunknown_window = 3")?;
+            let error = Config::from_file("omen.toml").unwrap_err().to_string();
+            assert!(error.contains("unknown_window"), "{error}");
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_yaml_config_loads() {
+        Jail::expect_with(|jail| {
+            jail.create_file("omen.yaml", "churn:\n  top: 37\n")?;
+            let config = Config::from_file("omen.yaml").unwrap();
+            assert_eq!(config.churn.top, 37);
             Ok(())
         });
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -7,6 +7,10 @@ use crate::analyzers::{complexity, repomap, satd};
 use crate::config::Config;
 use crate::core::{AnalysisContext, Analyzer, FileSet, Language, Result};
 
+pub fn max_symbols_for_token_budget(max_tokens: usize) -> usize {
+    max_tokens.saturating_div(250).clamp(5, 100)
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Context {
     pub repository: String,
@@ -373,29 +377,40 @@ fn summarize_risks(ctx: &AnalysisContext<'_>, limit: usize) -> Vec<RiskSummary> 
         let mut functions: Vec<_> = complexity
             .files
             .into_iter()
-            .flat_map(|file| file.functions)
-            .collect();
-        functions.sort_by_key(|func| std::cmp::Reverse(func.metrics.cognitive));
-        risks.extend(functions.into_iter().take(limit).filter_map(|func| {
-            if func.metrics.cognitive < 15 && func.metrics.cyclomatic < 10 {
-                return None;
-            }
-            Some(RiskSummary {
-                kind: "complexity".to_string(),
-                file: func.file,
-                line: func.start_line,
-                message: format!(
-                    "{} has cyclomatic {} and cognitive {} complexity",
-                    func.name, func.metrics.cyclomatic, func.metrics.cognitive
-                ),
-                severity: if func.metrics.cognitive >= 30 || func.metrics.cyclomatic >= 20 {
-                    "high"
-                } else {
-                    "medium"
-                }
-                .to_string(),
+            .flat_map(|file| {
+                let path = file.path;
+                file.functions
+                    .into_iter()
+                    .map(move |function| (path.clone(), function))
             })
-        }));
+            .collect();
+        functions.sort_by_key(|(_, func)| std::cmp::Reverse(func.metrics.cognitive));
+        risks.extend(
+            functions
+                .into_iter()
+                .take(limit)
+                .filter_map(|(file, func)| {
+                    if func.metrics.cognitive < 15 && func.metrics.cyclomatic < 10 {
+                        return None;
+                    }
+                    Some(RiskSummary {
+                        kind: "complexity".to_string(),
+                        file,
+                        line: func.start_line,
+                        message: format!(
+                            "{} has cyclomatic {} and cognitive {} complexity",
+                            func.name, func.metrics.cyclomatic, func.metrics.cognitive
+                        ),
+                        severity:
+                            if func.metrics.cognitive >= 30 || func.metrics.cyclomatic >= 20 {
+                                "high"
+                            } else {
+                                "medium"
+                            }
+                            .to_string(),
+                    })
+                }),
+        );
     }
 
     risks.truncate(limit);
@@ -432,6 +447,13 @@ fn build_hints(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_max_symbols_for_token_budget_is_clamped() {
+        assert_eq!(max_symbols_for_token_budget(0), 5);
+        assert_eq!(max_symbols_for_token_budget(8_000), 32);
+        assert_eq!(max_symbols_for_token_budget(100_000), 100);
+    }
 
     #[test]
     fn test_build_context_includes_repo_map_and_risks() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,10 +12,11 @@ use rayon::ThreadPoolBuilder;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 use omen::cli::{
-    AnalyzerArgs, Cli, Command, ComplexityArgs, ImpactArgs, McpSubcommand, MutationArgs,
-    MutationSubcommand, MutationTrainArgs, OutlineArgs, OutputFormat, ReportSubcommand, ScoreArgs,
-    ScoreSubcommand, SearchSubcommand, SymbolArgs,
+    AnalyzerArgs, Cli, Command, ComplexityArgs, ImpactArgs, McpSubcommand, OutlineArgs,
+    OutputFormat, ReportSubcommand, ScoreArgs, ScoreSubcommand, SearchSubcommand, SymbolArgs,
 };
+#[cfg(feature = "mutation")]
+use omen::cli::{MutationArgs, MutationSubcommand, MutationTrainArgs};
 use omen::config::Config;
 use omen::core::progress::is_tty;
 use omen::core::{AnalysisContext, Analyzer, FileSet};
@@ -23,20 +24,30 @@ use omen::git::{clone_remote, is_remote_repo, CloneOptions};
 use omen::mcp::McpServer;
 use omen::output::{format_with_limits, Format};
 
+fn logging_filter(verbose: bool, rust_log: Option<&str>) -> EnvFilter {
+    let directive = rust_log.unwrap_or(if verbose { "debug" } else { "off" });
+    EnvFilter::new(directive)
+}
+
 fn main() -> ExitCode {
-    // Initialize tracing
+    let cli = Cli::parse();
     tracing_subscriber::registry()
         .with(fmt::layer())
-        .with(EnvFilter::from_default_env())
+        .with(logging_filter(
+            cli.verbose,
+            std::env::var("RUST_LOG").ok().as_deref(),
+        ))
         .init();
-
-    let cli = Cli::parse();
 
     match run(cli) {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
             eprintln!("Error: {e:#}");
-            ExitCode::FAILURE
+            if matches!(e, omen::core::Error::ThresholdViolation { .. }) {
+                ExitCode::from(2)
+            } else {
+                ExitCode::FAILURE
+            }
         }
     }
 }
@@ -142,7 +153,7 @@ fn run_with_path(cli: &Cli, path: &PathBuf) -> omen::core::Result<()> {
         }
         Command::Complexity(args) => {
             if args.check {
-                run_complexity_check(path, &config, args)?;
+                run_complexity_check(path, &config, args, format)?;
             } else {
                 run_analyzer::<omen::analyzers::complexity::Analyzer>(
                     path,
@@ -181,7 +192,10 @@ fn run_with_path(cli: &Cli, path: &PathBuf) -> omen::core::Result<()> {
             dispatch_analyzer(&cli.command, path, &config, format)?;
         }
         Command::Churn(args) => {
-            run_churn_analyzer(path, &config, format, args.days, &args.common)?;
+            let days = args.days.unwrap_or_else(|| {
+                omen::git::parse_since_to_days(&config.churn.since).unwrap_or(u32::MAX)
+            });
+            run_churn_analyzer(path, &config, format, days, &args.common)?;
         }
         Command::Flags(args) => {
             // Merge CLI --provider option into config
@@ -201,7 +215,7 @@ fn run_with_path(cli: &Cli, path: &PathBuf) -> omen::core::Result<()> {
         }
         Command::Score(cmd) => {
             if cmd.args.check {
-                run_score_check(path, &config, &cmd.args)?;
+                run_score_check(path, &config, &cmd.args, format)?;
             } else {
                 match &cmd.subcommand {
                     Some(ScoreSubcommand::Trend(args)) => {
@@ -398,6 +412,7 @@ fn run_with_path(cli: &Cli, path: &PathBuf) -> omen::core::Result<()> {
         Command::Search(ref cmd) => {
             run_search(path, &config, cmd.subcommand.clone(), format)?;
         }
+        #[cfg(feature = "mutation")]
         Command::Mutation(ref cmd) => match &cmd.subcommand {
             Some(MutationSubcommand::Train(args)) => {
                 run_mutation_train(&args.path, args)?;
@@ -445,12 +460,22 @@ fn dispatch_analyzer(
     format: Format,
 ) -> omen::core::Result<()> {
     match command {
-        Command::Satd(args) => {
-            run_analyzer::<omen::analyzers::satd::Analyzer>(path, config, format, Some(args))
-        }
-        Command::Clones(args) => {
-            run_analyzer::<omen::analyzers::duplicates::Analyzer>(path, config, format, Some(args))
-        }
+        Command::Satd(args) => run_analyzer_instance(
+            path,
+            config,
+            format,
+            Some(args),
+            omen::analyzers::satd::Analyzer::new().with_custom_markers(&config.satd.custom_markers),
+        ),
+        Command::Clones(args) => run_analyzer_instance(
+            path,
+            config,
+            format,
+            Some(args),
+            omen::analyzers::duplicates::Analyzer::new()
+                .with_min_tokens(config.duplicates.min_tokens)
+                .with_similarity_threshold(config.duplicates.min_similarity),
+        ),
         Command::Defect(args) => {
             run_analyzer::<omen::analyzers::defect::Analyzer>(path, config, format, Some(args))
         }
@@ -460,9 +485,13 @@ fn dispatch_analyzer(
         Command::Graph(args) => {
             run_analyzer::<omen::analyzers::graph::Analyzer>(path, config, format, Some(args))
         }
-        Command::Hotspot(args) => {
-            run_analyzer::<omen::analyzers::hotspot::Analyzer>(path, config, format, Some(args))
-        }
+        Command::Hotspot(args) => run_analyzer_instance(
+            path,
+            config,
+            format,
+            Some(args),
+            omen::analyzers::hotspot::Analyzer::new(),
+        ),
         Command::Temporal(args) => {
             run_analyzer::<omen::analyzers::temporal::Analyzer>(path, config, format, Some(args))
         }
@@ -589,13 +618,16 @@ fn run_analyzer_instance<A: Analyzer>(
         }
     });
 
+    let analyzer_name = analyzer.name();
     let result = analyzer.analyze(&ctx)?;
 
     if let Some(s) = spinner {
         s.finish_and_clear();
     }
 
-    let top = args.and_then(|a| a.top);
+    let top = args
+        .and_then(|a| a.top)
+        .or_else(|| (analyzer_name == "hotspot").then_some(config.hotspot.top));
     let offset = args.and_then(|a| a.offset);
     let value = serde_json::to_value(&result)?;
     format_with_limits(value, format, top, offset, &mut stdout())?;
@@ -629,6 +661,7 @@ fn run_complexity_check(
     path: &PathBuf,
     config: &Config,
     args: &ComplexityArgs,
+    format: Format,
 ) -> omen::core::Result<()> {
     let file_set = filtered_file_set(path, config, Some(&args.common))?;
     let ctx = build_context(path, &file_set, config);
@@ -652,6 +685,18 @@ fn run_complexity_check(
             Ok(())
         }
         Err(violations) => {
+            if matches!(format, Format::Json | Format::JsonCompact) {
+                format.format(
+                    &serde_json::json!({
+                        "violations": violations,
+                        "thresholds": {
+                            "max_cyclomatic": max_cyclomatic,
+                            "max_cognitive": max_cognitive
+                        }
+                    }),
+                    &mut stdout(),
+                )?;
+            }
             eprintln!(
                 "Complexity threshold exceeded in {} function(s):\n",
                 violations.len()
@@ -677,7 +722,12 @@ fn run_complexity_check(
     }
 }
 
-fn run_score_check(path: &PathBuf, config: &Config, args: &ScoreArgs) -> omen::core::Result<()> {
+fn run_score_check(
+    path: &PathBuf,
+    config: &Config,
+    args: &ScoreArgs,
+    format: Format,
+) -> omen::core::Result<()> {
     let file_set = FileSet::from_path(path, config)?;
     let ctx = build_context(path, &file_set, config);
 
@@ -696,7 +746,21 @@ fn run_score_check(path: &PathBuf, config: &Config, args: &ScoreArgs) -> omen::c
             );
             Ok(())
         }
-        Err(e) => Err(e),
+        Err(e) => {
+            if matches!(format, Format::Json | Format::JsonCompact) {
+                format.format(
+                    &serde_json::json!({
+                        "violations": [{
+                            "kind": "score_below_threshold",
+                            "score": result.overall_score,
+                            "minimum": min_score
+                        }]
+                    }),
+                    &mut stdout(),
+                )?;
+            }
+            Err(e)
+        }
     }
 }
 
@@ -712,7 +776,13 @@ fn run_churn_analyzer(
     let analyzer = omen::analyzers::churn::Analyzer::new().with_days(days);
     let result = analyzer.analyze(&ctx)?;
     let value = serde_json::to_value(&result)?;
-    format_with_limits(value, format, args.top, args.offset, &mut stdout())?;
+    format_with_limits(
+        value,
+        format,
+        args.top.or(Some(config.churn.top)),
+        args.offset,
+        &mut stdout(),
+    )?;
     Ok(())
 }
 
@@ -727,7 +797,7 @@ fn run_context(
         path,
         &file_set,
         config,
-        Some(args.max_tokens.saturating_div(250).clamp(5, 100)),
+        Some(omen::context::max_symbols_for_token_budget(args.max_tokens)),
         Some(25),
     )?;
 
@@ -1245,6 +1315,7 @@ fn run_search(
     Ok(())
 }
 
+#[cfg(feature = "mutation")]
 fn run_mutation(
     path: &PathBuf,
     config: &Config,
@@ -1616,6 +1687,7 @@ fn run_symbol(
     Ok(())
 }
 
+#[cfg(feature = "mutation")]
 fn run_mutation_train(path: &std::path::Path, args: &MutationTrainArgs) -> omen::core::Result<()> {
     use omen::analyzers::mutation::ml_predictor::{SurvivabilityPredictor, TrainingData};
     use std::io::BufRead;
@@ -1695,4 +1767,16 @@ fn run_mutation_train(path: &std::path::Path, args: &MutationTrainArgs) -> omen:
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verbose_enables_debug_logging_without_rust_log() {
+        assert_eq!(logging_filter(true, None).to_string(), "debug");
+        assert_eq!(logging_filter(false, None).to_string(), "off");
+        assert_eq!(logging_filter(true, Some("warn")).to_string(), "warn");
+    }
 }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -51,6 +51,36 @@ struct ToolDef {
     required: &'static [&'static str],
 }
 
+fn u32_arg(arguments: &Value, name: &str, default: u32) -> u32 {
+    arguments
+        .get(name)
+        .and_then(Value::as_u64)
+        .and_then(|value| u32::try_from(value).ok())
+        .unwrap_or(default)
+}
+
+fn usize_arg(arguments: &Value, name: &str, default: usize) -> usize {
+    arguments
+        .get(name)
+        .and_then(Value::as_u64)
+        .and_then(|value| usize::try_from(value).ok())
+        .unwrap_or(default)
+}
+
+fn f64_arg(arguments: &Value, name: &str, default: f64) -> f64 {
+    arguments
+        .get(name)
+        .and_then(Value::as_f64)
+        .unwrap_or(default)
+}
+
+fn tool_error_response(error: &str) -> Value {
+    json!({
+        "content": [{"type": "text", "text": error}],
+        "isError": true
+    })
+}
+
 impl ToolDef {
     fn to_json(&self) -> serde_json::Value {
         let mut props = serde_json::Map::new();
@@ -108,6 +138,153 @@ fn count_items(value: &serde_json::Value) -> Option<usize> {
             }
         }
         _ => None,
+    }
+}
+
+fn primary_count(tool_name: &str, value: &Value) -> Option<usize> {
+    match tool_name {
+        "complexity" => value.get("files")?.as_array().map(|files| {
+            files
+                .iter()
+                .filter_map(|file| file.get("functions")?.as_array())
+                .map(Vec::len)
+                .sum()
+        }),
+        "impact" => Some(
+            ["callers", "callees"]
+                .iter()
+                .filter_map(|name| value.get(*name)?.as_array())
+                .flatten()
+                .filter_map(|level| level.get("symbols")?.as_array())
+                .map(Vec::len)
+                .sum(),
+        ),
+        "graph" => value.get("cycles")?.as_array().map(|cycles| {
+            cycles
+                .iter()
+                .filter_map(Value::as_array)
+                .map(Vec::len)
+                .sum()
+        }),
+        tool => primary_field(tool)
+            .and_then(|field| value.get(field))
+            .and_then(Value::as_array)
+            .map(Vec::len)
+            .or_else(|| count_items(value)),
+    }
+}
+
+fn primary_field(tool_name: &str) -> Option<&'static str> {
+    match tool_name {
+        "context" => Some("top_symbols"),
+        "outline" => Some("files"),
+        "satd" | "deadcode" => Some("items"),
+        "churn" | "defect" | "tdg" | "ownership" => Some("files"),
+        "clones" => Some("clones"),
+        "changes" => Some("commits"),
+        "diff" => Some("recommendations"),
+        "hotspot" => Some("hotspots"),
+        "temporal" => Some("couplings"),
+        "cohesion" => Some("classes"),
+        "repomap" => Some("symbols"),
+        "smells" => Some("smells"),
+        "flags" => Some("flags"),
+        "semantic_search" | "semantic_search_hyde" => Some("results"),
+        "get_symbol" => Some("callers"),
+        _ => None,
+    }
+}
+
+fn truncate_primary(tool_name: &str, value: &mut Value, limit: usize, offset: usize) {
+    match tool_name {
+        "complexity" => truncate_nested(value, &["files", "functions"], limit, offset),
+        "impact" => {
+            let mut remaining_offset = offset;
+            let mut remaining_limit = if limit == 0 { usize::MAX } else { limit };
+            for name in ["callers", "callees"] {
+                truncate_nested_budget(
+                    value,
+                    &[name, "symbols"],
+                    &mut remaining_limit,
+                    &mut remaining_offset,
+                );
+            }
+        }
+        "graph" => truncate_array_children(value, "cycles", limit, offset),
+        tool if primary_field(tool).is_some() => {
+            if let Some(field) = primary_field(tool) {
+                truncate_field(value, field, limit, offset);
+            }
+        }
+        _ => {
+            crate::output::truncate_lists(value, limit, offset);
+        }
+    }
+}
+
+fn truncate_field(value: &mut Value, field: &str, limit: usize, offset: usize) {
+    let Some(items) = value.get_mut(field).and_then(Value::as_array_mut) else {
+        return;
+    };
+    let skip = offset.min(items.len());
+    items.drain(0..skip);
+    if limit > 0 {
+        items.truncate(limit);
+    }
+}
+
+fn truncate_nested(value: &mut Value, path: &[&str], limit: usize, offset: usize) {
+    let mut remaining_limit = if limit == 0 { usize::MAX } else { limit };
+    let mut remaining_offset = offset;
+    truncate_nested_budget(value, path, &mut remaining_limit, &mut remaining_offset);
+}
+
+fn truncate_nested_budget(
+    value: &mut Value,
+    path: &[&str],
+    remaining_limit: &mut usize,
+    remaining_offset: &mut usize,
+) {
+    let Some(parents) = value.get_mut(path[0]).and_then(Value::as_array_mut) else {
+        return;
+    };
+    for parent in parents {
+        let Some(items) = parent.get_mut(path[1]).and_then(Value::as_array_mut) else {
+            continue;
+        };
+        let skip = (*remaining_offset).min(items.len());
+        items.drain(0..skip);
+        *remaining_offset -= skip;
+        if *remaining_offset > 0 {
+            items.clear();
+            continue;
+        }
+        if items.len() > *remaining_limit {
+            items.truncate(*remaining_limit);
+        }
+        *remaining_limit -= items.len();
+    }
+}
+
+fn truncate_array_children(value: &mut Value, field: &str, limit: usize, offset: usize) {
+    let Some(children) = value.get_mut(field).and_then(Value::as_array_mut) else {
+        return;
+    };
+    let mut remaining_limit = if limit == 0 { usize::MAX } else { limit };
+    let mut remaining_offset = offset;
+    for child in children {
+        let Some(items) = child.as_array_mut() else {
+            continue;
+        };
+        let skip = remaining_offset.min(items.len());
+        items.drain(0..skip);
+        remaining_offset -= skip;
+        if remaining_offset > 0 {
+            items.clear();
+        } else {
+            items.truncate(remaining_limit);
+            remaining_limit -= items.len();
+        }
     }
 }
 
@@ -242,12 +419,12 @@ impl McpServer {
     }
 
     fn handle_request(&self, request: JsonRpcRequest) -> JsonRpcResponse {
-        let result = match request.method.as_str() {
-            "initialize" => self.handle_initialize(),
-            "tools/list" => self.handle_tools_list(),
-            "tools/call" => self.handle_tool_call(request.params),
-            "shutdown" => Ok(json!({})),
-            _ => Err(format!("Unknown method: {}", request.method)),
+        let (result, error_code) = match request.method.as_str() {
+            "initialize" => (self.handle_initialize(), -32603),
+            "tools/list" => (self.handle_tools_list(), -32603),
+            "tools/call" => (self.handle_tool_call(request.params), -32602),
+            "shutdown" => (Ok(json!({})), -32603),
+            _ => (Err(format!("Unknown method: {}", request.method)), -32601),
         };
 
         match result {
@@ -262,7 +439,7 @@ impl McpServer {
                 id: request.id,
                 result: None,
                 error: Some(JsonRpcError {
-                    code: -32603,
+                    code: error_code,
                     message: msg,
                     data: None,
                 }),
@@ -272,7 +449,7 @@ impl McpServer {
 
     fn handle_initialize(&self) -> std::result::Result<Value, String> {
         Ok(json!({
-            "protocolVersion": "2024-11-05",
+            "protocolVersion": "2025-11-25",
             "capabilities": {
                 "tools": {}
             },
@@ -293,10 +470,9 @@ impl McpServer {
         let limit = args["limit"].as_u64().unwrap_or(50) as usize;
         let offset = args["offset"].as_u64().unwrap_or(0) as usize;
 
-        let total_items = count_items(&value);
-        crate::output::truncate_lists(&mut value, limit, offset);
-        // Count returned items by summing array lengths AFTER truncation.
-        let returned = count_items(&value);
+        let total_items = primary_count(tool_name, &value);
+        truncate_primary(tool_name, &mut value, limit, offset);
+        let returned = primary_count(tool_name, &value);
 
         let mut envelope = json!({
             "tool": tool_name,
@@ -321,7 +497,7 @@ impl McpServer {
         let tools: Vec<serde_json::Value> = vec![
             ToolDef {
                 name: "context",
-                description: "Use first. Returns top-N PageRank-ranked symbols, risks, language breakdown, directory tree, entry points, and navigation hints. Cheap.",
+                description: "Use first. Returns top-N PageRank-ranked symbols, risks, language breakdown, directory tree, entry points, and navigation hints. Expensive on large repos; run once and cache.",
                 properties: vec![
                     ("path", json!({"type": "string", "description": "File or directory path"})),
                     ("max_symbols", json!({"type": "integer", "description": "Maximum symbols to include"})),
@@ -345,7 +521,6 @@ impl McpServer {
                 description: "Returns cyclomatic and cognitive complexity per function. Fast.",
                 properties: vec![
                     ("path", json!({"type": "string", "description": "File or directory path"})),
-                    ("threshold", json!({"type": "number", "description": "Minimum complexity to report"})),
                 ],
                 required: &[],
             },
@@ -397,8 +572,6 @@ impl McpServer {
                 name: "changes",
                 description: "Use to assess recent commit risk. Analyzes recent changes with JIT risk analysis.",
                 properties: vec![
-                    ("commit", json!({"type": "string", "description": "Commit or range to analyze"})),
-                    ("count", json!({"type": "integer", "description": "Number of commits"})),
                 ],
                 required: &[],
             },
@@ -442,7 +615,6 @@ impl McpServer {
                 properties: vec![
                     ("path", json!({"type": "string", "description": "File or directory path"})),
                     ("days", json!({"type": "integer", "description": "Number of days to analyze"})),
-                    ("min_coupling", json!({"type": "number", "description": "Minimum coupling strength"})),
                 ],
                 required: &[],
             },
@@ -494,7 +666,6 @@ impl McpServer {
                 description: "Use for an overall health summary. Calculates composite repository health score.",
                 properties: vec![
                     ("path", json!({"type": "string", "description": "File or directory path"})),
-                    ("analyzers", json!({"type": "string", "description": "Analyzers to include (comma-separated)"})),
                 ],
                 required: &[],
             },
@@ -597,15 +768,57 @@ impl McpServer {
             .ok_or("Missing tool name")?;
         let arguments = params.get("arguments").cloned().unwrap_or(json!({}));
 
+        if !Self::tool_names().contains(&tool_name) {
+            return Err(format!("Unknown tool: {tool_name}"));
+        }
+        let required = match tool_name {
+            "semantic_search" => Some(("query", "Missing query parameter")),
+            "semantic_search_hyde" => Some((
+                "hypothetical_document",
+                "Missing hypothetical_document parameter",
+            )),
+            "impact" => Some(("symbol", "Missing symbol parameter")),
+            "get_symbol" => Some(("name", "Missing name parameter")),
+            _ => None,
+        };
+        if let Some((field, message)) = required {
+            if arguments.get(field).and_then(Value::as_str).is_none() {
+                return Err(message.to_string());
+            }
+        }
+
+        match tool_name {
+            "semantic_search" => {
+                return Ok(self
+                    .handle_semantic_search(&arguments)
+                    .unwrap_or_else(|error| tool_error_response(&error)))
+            }
+            "semantic_search_hyde" => {
+                return Ok(self
+                    .handle_semantic_search_hyde(&arguments)
+                    .unwrap_or_else(|error| tool_error_response(&error)))
+            }
+            _ => {}
+        }
+
         let requested_path = arguments
             .get("path")
             .and_then(|v| v.as_str())
             .map(PathBuf::from)
             .unwrap_or_else(|| self.root_path.clone());
-        let path = self.resolve_confined_path(&requested_path, Some(&self.root_path))?;
+        let path = match self.resolve_confined_path(&requested_path, Some(&self.root_path)) {
+            Ok(path) => path,
+            Err(error) => return Ok(tool_error_response(&error)),
+        };
 
-        let file_set = FileSet::from_path(&path, &self.config)
-            .map_err(|e| format!("Failed to create file set: {}", e))?;
+        let file_set = match FileSet::from_path(&path, &self.config) {
+            Ok(file_set) => file_set,
+            Err(error) => {
+                return Ok(tool_error_response(&format!(
+                    "Failed to create file set: {error}"
+                )))
+            }
+        };
 
         // Try to open a git repository at the path
         let (git_root, git_skipped_reason) = match GitRepo::open(&path) {
@@ -613,7 +826,16 @@ impl McpServer {
             Err(error) => (None, Some(error.to_string())),
         };
 
-        let mut ctx = AnalysisContext::new(&file_set, &self.config, Some(&path));
+        let mut effective_config = self.config.clone();
+        if tool_name == "flags" {
+            if let Some(provider) = arguments.get("provider").and_then(Value::as_str) {
+                effective_config.feature_flags.providers = vec![provider.to_string()];
+            }
+            if let Some(days) = arguments.get("stale_days").and_then(Value::as_u64) {
+                effective_config.feature_flags.stale_days = u32::try_from(days).unwrap_or(u32::MAX);
+            }
+        }
+        let mut ctx = AnalysisContext::new(&file_set, &effective_config, Some(&path));
         if let Some(ref git_path) = git_root {
             ctx = ctx.with_git_path(git_path);
         }
@@ -622,43 +844,91 @@ impl McpServer {
             "complexity" => self.run_analyzer::<crate::analyzers::complexity::Analyzer>(&ctx),
             "satd" => self.run_analyzer::<crate::analyzers::satd::Analyzer>(&ctx),
             "deadcode" => self.run_analyzer::<crate::analyzers::deadcode::Analyzer>(&ctx),
-            "churn" => self.run_analyzer::<crate::analyzers::churn::Analyzer>(&ctx),
-            "clones" => self.run_analyzer::<crate::analyzers::duplicates::Analyzer>(&ctx),
-            "defect" => self.run_analyzer::<crate::analyzers::defect::Analyzer>(&ctx),
+            "churn" => self.run_analyzer_instance(
+                &ctx,
+                crate::analyzers::churn::Analyzer::new().with_days(u32_arg(&arguments, "days", 30)),
+            ),
+            "clones" => self.run_analyzer_instance(
+                &ctx,
+                crate::analyzers::duplicates::Analyzer::new()
+                    .with_min_tokens(usize_arg(&arguments, "min_tokens", 50))
+                    .with_similarity_threshold(f64_arg(&arguments, "similarity", 0.70)),
+            ),
+            "defect" => self.run_analyzer_instance(
+                &ctx,
+                crate::analyzers::defect::Analyzer::new()
+                    .with_churn_days(u32_arg(&arguments, "days", 30)),
+            ),
             "changes" => self.run_analyzer::<crate::analyzers::changes::Analyzer>(&ctx),
             "tdg" => self.run_analyzer::<crate::analyzers::tdg::Analyzer>(&ctx),
             "graph" => self.run_analyzer::<crate::analyzers::graph::Analyzer>(&ctx),
-            "hotspot" => self.run_analyzer::<crate::analyzers::hotspot::Analyzer>(&ctx),
-            "temporal" => self.run_analyzer::<crate::analyzers::temporal::Analyzer>(&ctx),
+            "hotspot" => self.run_analyzer_instance(
+                &ctx,
+                crate::analyzers::hotspot::Analyzer::new()
+                    .with_days(u32_arg(&arguments, "days", 90)),
+            ),
+            "temporal" => self.run_analyzer_instance(
+                &ctx,
+                crate::analyzers::temporal::Analyzer::new()
+                    .with_days(u32_arg(&arguments, "days", 30)),
+            ),
             "ownership" => self.run_analyzer::<crate::analyzers::ownership::Analyzer>(&ctx),
             "cohesion" => self.run_analyzer::<crate::analyzers::cohesion::Analyzer>(&ctx),
-            "repomap" => self.run_analyzer::<crate::analyzers::repomap::Analyzer>(&ctx),
+            "repomap" => self.run_analyzer_instance(
+                &ctx,
+                crate::analyzers::repomap::Analyzer::new().with_max_symbols(usize_arg(
+                    &arguments,
+                    "max_symbols",
+                    0,
+                )),
+            ),
             "smells" => self.run_analyzer::<crate::analyzers::smells::Analyzer>(&ctx),
-            "flags" => self.run_analyzer::<crate::analyzers::flags::Analyzer>(&ctx),
+            "flags" => {
+                let providers = arguments
+                    .get("provider")
+                    .and_then(Value::as_str)
+                    .map(|value| vec![value.to_string()])
+                    .unwrap_or_default();
+                self.run_analyzer_instance(
+                    &ctx,
+                    crate::analyzers::flags::Analyzer::new()
+                        .with_expected_ttl(u32_arg(&arguments, "stale_days", 14))
+                        .with_providers(providers),
+                )
+            }
             "score" => self.run_analyzer::<crate::score::Analyzer>(&ctx),
             "context" => {
-                return self.handle_context(&path, &file_set, &arguments);
+                return Ok(self
+                    .handle_context(&path, &file_set, &arguments)
+                    .unwrap_or_else(|error| tool_error_response(&error)));
             }
             "diff" => {
-                return self.handle_diff(&path, &arguments);
-            }
-            "semantic_search" => {
-                return self.handle_semantic_search(&arguments);
-            }
-            "semantic_search_hyde" => {
-                return self.handle_semantic_search_hyde(&arguments);
+                return Ok(self
+                    .handle_diff(&path, &arguments)
+                    .unwrap_or_else(|error| tool_error_response(&error)));
             }
             "outline" => {
-                return self.handle_outline(&path, &arguments);
+                return Ok(self
+                    .handle_outline(&path, &arguments)
+                    .unwrap_or_else(|error| tool_error_response(&error)));
             }
             "impact" => {
-                return self.handle_impact(&path, &file_set, &arguments);
+                return Ok(self
+                    .handle_impact(&path, &file_set, &arguments)
+                    .unwrap_or_else(|error| tool_error_response(&error)));
             }
             "get_symbol" => {
-                return self.handle_get_symbol(&path, &file_set, &arguments);
+                return Ok(self
+                    .handle_get_symbol(&path, &file_set, &arguments)
+                    .unwrap_or_else(|error| tool_error_response(&error)));
             }
-            _ => Err(format!("Unknown tool: {}", tool_name)),
-        }?;
+            _ => unreachable!(),
+        };
+
+        let result = match result {
+            Ok(result) => result,
+            Err(error) => return Ok(tool_error_response(&error)),
+        };
 
         self.tool_response(tool_name, result, &arguments, git_skipped_reason.as_deref())
     }
@@ -667,7 +937,14 @@ impl McpServer {
         &self,
         ctx: &AnalysisContext<'_>,
     ) -> std::result::Result<Value, String> {
-        let analyzer = A::default();
+        self.run_analyzer_instance(ctx, A::default())
+    }
+
+    fn run_analyzer_instance<A: Analyzer>(
+        &self,
+        ctx: &AnalysisContext<'_>,
+        analyzer: A,
+    ) -> std::result::Result<Value, String> {
         let result = analyzer
             .analyze(ctx)
             .map_err(|e| format!("Analysis failed: {}", e))?;
@@ -680,7 +957,7 @@ impl McpServer {
         file_set: &FileSet,
         arguments: &Value,
     ) -> std::result::Result<Value, String> {
-        let max_symbols = arguments
+        let explicit_max_symbols = arguments
             .get("max_symbols")
             .and_then(|v| v.as_u64())
             .map(|v| v as usize);
@@ -693,14 +970,21 @@ impl McpServer {
             .and_then(|v| v.as_u64())
             .map(|v| v as usize)
             .unwrap_or(8000);
+        let max_symbols = explicit_max_symbols
+            .unwrap_or_else(|| crate::context::max_symbols_for_token_budget(max_tokens));
         let format = arguments
             .get("format")
             .and_then(|v| v.as_str())
             .unwrap_or("json");
 
-        let mut context =
-            crate::context::build_context(path, file_set, &self.config, max_symbols, max_risks)
-                .map_err(|e| format!("Context failed: {}", e))?;
+        let mut context = crate::context::build_context(
+            path,
+            file_set,
+            &self.config,
+            Some(max_symbols),
+            max_risks,
+        )
+        .map_err(|e| format!("Context failed: {}", e))?;
 
         // Apply token budget
         crate::context::apply_token_budget(&mut context, max_tokens);
@@ -1051,7 +1335,7 @@ impl McpServer {
         file_set: &FileSet,
         arguments: &Value,
     ) -> std::result::Result<Value, String> {
-        use crate::symbol::{get_symbol, SymbolOptions};
+        use crate::symbol::{get_symbol, suggest_symbols, SymbolOptions};
 
         let name = arguments
             .get("name")
@@ -1076,11 +1360,17 @@ impl McpServer {
             max_source_lines,
         };
 
-        let report = get_symbol(repo_path, &files, name, &opts)
-            .map_err(|e| format!("Symbol lookup failed: {}", e))?;
-
-        let value =
-            serde_json::to_value(&report).map_err(|e| format!("Serialization failed: {}", e))?;
+        let value = match get_symbol(repo_path, &files, name, &opts) {
+            Ok(report) => {
+                serde_json::to_value(&report).map_err(|e| format!("Serialization failed: {e}"))?
+            }
+            Err(_) => json!({
+                "name": name,
+                "found": false,
+                "suggestions": suggest_symbols(repo_path, &files, name)
+                    .map_err(|e| format!("Symbol suggestions failed: {e}"))?
+            }),
+        };
 
         self.tool_response("get_symbol", value, arguments, None)
     }
@@ -1274,7 +1564,7 @@ mod tests {
     fn test_handle_initialize() {
         let (server, _temp_dir) = create_test_server();
         let result = server.handle_initialize().unwrap();
-        assert!(result.get("protocolVersion").is_some());
+        assert_eq!(result["protocolVersion"], "2025-11-25");
         assert!(result.get("capabilities").is_some());
         assert!(result.get("serverInfo").is_some());
     }
@@ -1518,7 +1808,10 @@ mod tests {
             "arguments": {"path": target_dir.path().to_str().unwrap()}
         });
 
-        assert!(server.handle_tool_call(Some(params)).is_err());
+        // A path outside the server root is rejected as a tool-level error result
+        // (isError) rather than analyzed, so the agent can see and recover.
+        let response = server.handle_tool_call(Some(params)).unwrap();
+        assert_eq!(response["isError"], true);
     }
 
     #[test]
@@ -1631,8 +1924,37 @@ mod tests {
         };
         let response = server.handle_request(request);
         assert!(response.result.is_none());
-        assert!(response.error.is_some());
-        assert!(response.error.unwrap().message.contains("Unknown method"));
+        let error = response.error.unwrap();
+        assert_eq!(error.code, -32601);
+        assert!(error.message.contains("Unknown method"));
+    }
+
+    #[test]
+    fn test_handle_request_invalid_tool_params_uses_invalid_params_code() {
+        let (server, _temp_dir) = create_test_server();
+        let response = server.handle_request(JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(json!(1)),
+            method: "tools/call".to_string(),
+            params: Some(json!({"name": "impact", "arguments": {}})),
+        });
+        assert_eq!(response.error.unwrap().code, -32602);
+    }
+
+    #[test]
+    fn test_handle_request_tool_execution_failure_is_tool_error_result() {
+        let (server, _temp_dir) = create_test_server();
+        let response = server.handle_request(JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(json!(1)),
+            method: "tools/call".to_string(),
+            params: Some(json!({
+                "name": "complexity",
+                "arguments": {"path": "/definitely/not/a/repository"}
+            })),
+        });
+        assert!(response.error.is_none());
+        assert_eq!(response.result.unwrap()["isError"], true);
     }
 
     #[test]
@@ -1784,6 +2106,92 @@ mod tests {
             "churn tool should succeed with git history: {:?}",
             result.err()
         );
+    }
+
+    #[test]
+    fn test_handle_tool_call_churn_honors_days() {
+        let (server, temp_dir) = create_git_test_server();
+        let response = server
+            .handle_tool_call(Some(json!({
+                "name": "churn",
+                "arguments": {"path": temp_dir.path(), "days": 3650}
+            })))
+            .unwrap();
+        let envelope: Value =
+            serde_json::from_str(response["content"][0]["text"].as_str().unwrap()).unwrap();
+        assert_eq!(envelope["result"]["period_days"], 3650);
+    }
+
+    #[test]
+    fn test_handle_tool_call_repomap_honors_max_symbols() {
+        let (server, temp_dir) = create_test_server();
+        std::fs::write(
+            temp_dir.path().join("symbols.rs"),
+            "fn one() {}\nfn two() {}\nfn three() {}\n",
+        )
+        .unwrap();
+        let response = server
+            .handle_tool_call(Some(json!({
+                "name": "repomap",
+                "arguments": {"path": temp_dir.path(), "max_symbols": 1, "limit": 0}
+            })))
+            .unwrap();
+        let envelope: Value =
+            serde_json::from_str(response["content"][0]["text"].as_str().unwrap()).unwrap();
+        assert!(envelope["result"]["symbols"].as_array().unwrap().len() <= 1);
+    }
+
+    #[test]
+    fn test_handle_tool_call_clones_honors_thresholds() {
+        let (server, temp_dir) = create_test_server();
+        std::fs::write(
+            temp_dir.path().join("clones.rs"),
+            "fn a() { let x = 1; let y = 2; }\nfn b() { let x = 1; let y = 2; }\n",
+        )
+        .unwrap();
+        let response = server
+            .handle_tool_call(Some(json!({
+                "name": "clones",
+                "arguments": {"path": temp_dir.path(), "min_tokens": 8, "similarity": 0.42, "limit": 0}
+            })))
+            .unwrap();
+        let envelope: Value =
+            serde_json::from_str(response["content"][0]["text"].as_str().unwrap()).unwrap();
+        assert_eq!(envelope["result"]["min_lines"], 1);
+        assert_eq!(envelope["result"]["threshold"], 0.42);
+    }
+
+    #[test]
+    fn test_handle_tool_call_temporal_honors_days() {
+        let (server, temp_dir) = create_git_test_server();
+        let response = server
+            .handle_tool_call(Some(json!({
+                "name": "temporal",
+                "arguments": {"path": temp_dir.path(), "days": 321}
+            })))
+            .unwrap();
+        let envelope: Value =
+            serde_json::from_str(response["content"][0]["text"].as_str().unwrap()).unwrap();
+        assert_eq!(envelope["result"]["period_days"], 321);
+    }
+
+    #[test]
+    fn test_handle_tool_call_flags_honors_provider() {
+        let (server, temp_dir) = create_test_server();
+        std::fs::write(
+            temp_dir.path().join("flags.rs"),
+            "fn f() { if std::env::var(\"FEATURE_ALPHA\").is_ok() {} }\n",
+        )
+        .unwrap();
+        let response = server
+            .handle_tool_call(Some(json!({
+                "name": "flags",
+                "arguments": {"path": temp_dir.path(), "provider": "nonexistent", "limit": 0}
+            })))
+            .unwrap();
+        let envelope: Value =
+            serde_json::from_str(response["content"][0]["text"].as_str().unwrap()).unwrap();
+        assert_eq!(envelope["result"]["summary"]["total_flags"], 0);
     }
 
     #[test]
@@ -2146,6 +2554,33 @@ mod tests {
     }
 
     #[test]
+    fn test_complexity_pagination_bounds_nested_functions_globally() {
+        let (server, _temp_dir) = create_test_server();
+        let files: Vec<Value> = (0..3)
+            .map(|file| json!({"path": format!("{file}.rs"), "functions": vec![json!({"name": "f"}); 100]}))
+            .collect();
+        let response = server
+            .tool_response(
+                "complexity",
+                json!({"files": files}),
+                &json!({"limit": 50}),
+                None,
+            )
+            .unwrap();
+        let envelope: Value =
+            serde_json::from_str(response["content"][0]["text"].as_str().unwrap()).unwrap();
+        let returned: usize = envelope["result"]["files"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|file| file["functions"].as_array().unwrap().len())
+            .sum();
+        assert_eq!(envelope["total_items"], 300);
+        assert_eq!(envelope["returned"], 50);
+        assert_eq!(returned, 50);
+    }
+
+    #[test]
     fn test_all_tools_have_limit_and_offset_params() {
         let (server, _temp_dir) = create_test_server();
         let request = JsonRpcRequest {
@@ -2313,5 +2748,25 @@ mod tests {
         });
         let result = server.handle_tool_call(Some(params));
         assert!(result.is_err(), "get_symbol without name should fail");
+    }
+
+    #[test]
+    fn test_handle_tool_call_get_symbol_unknown_returns_structured_suggestions() {
+        let (server, temp_dir) = create_test_server();
+        std::fs::write(temp_dir.path().join("known.rs"), "fn known_symbol() {}\n").unwrap();
+        let response = server
+            .handle_tool_call(Some(json!({
+                "name": "get_symbol",
+                "arguments": {"name": "known", "path": temp_dir.path()}
+            })))
+            .unwrap();
+        let envelope: Value =
+            serde_json::from_str(response["content"][0]["text"].as_str().unwrap()).unwrap();
+        assert_eq!(envelope["result"]["found"], false);
+        assert!(envelope["result"]["suggestions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|suggestion| suggestion == "known_symbol"));
     }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -55,6 +55,9 @@ pub fn truncate_lists(value: &mut Value, top: usize, offset: usize) -> usize {
     if top == 0 && offset == 0 {
         return 0;
     }
+    if let Some(omitted) = truncate_nested_primary(value, top, offset) {
+        return omitted;
+    }
     let mut total_omitted = 0usize;
     match value {
         Value::Object(map) => {
@@ -115,6 +118,117 @@ pub fn truncate_lists(value: &mut Value, top: usize, offset: usize) -> usize {
         _ => {}
     }
     total_omitted
+}
+
+fn truncate_nested_primary(value: &mut Value, top: usize, offset: usize) -> Option<usize> {
+    let map = value.as_object_mut()?;
+    if map
+        .get("files")
+        .and_then(Value::as_array)
+        .is_some_and(|files| files.iter().any(|file| file.get("functions").is_some()))
+    {
+        return truncate_object_arrays(map.get_mut("files")?, "functions", top, offset);
+    }
+    if map.contains_key("callers") && map.contains_key("callees") {
+        let total: usize = ["callers", "callees"]
+            .iter()
+            .filter_map(|field| map.get(*field)?.as_array())
+            .flatten()
+            .filter_map(|level| level.get("symbols")?.as_array())
+            .map(Vec::len)
+            .sum();
+        let mut remaining_top = if top == 0 { usize::MAX } else { top };
+        let mut remaining_offset = offset;
+        for field in ["callers", "callees"] {
+            if let Some(levels) = map.get_mut(field) {
+                truncate_object_arrays_budget(
+                    levels,
+                    "symbols",
+                    &mut remaining_top,
+                    &mut remaining_offset,
+                );
+            }
+        }
+        let returned = total
+            .saturating_sub(offset)
+            .min(if top == 0 { usize::MAX } else { top });
+        return Some(total.saturating_sub(offset).saturating_sub(returned));
+    }
+    if let Some(cycles) = map.get_mut("cycles").and_then(Value::as_array_mut) {
+        if cycles.iter().all(Value::is_array) {
+            let total: usize = cycles
+                .iter()
+                .filter_map(Value::as_array)
+                .map(Vec::len)
+                .sum();
+            let mut remaining_top = if top == 0 { usize::MAX } else { top };
+            let mut remaining_offset = offset;
+            for cycle in cycles {
+                let items = cycle.as_array_mut()?;
+                let skip = remaining_offset.min(items.len());
+                items.drain(0..skip);
+                remaining_offset -= skip;
+                if remaining_offset > 0 {
+                    items.clear();
+                } else {
+                    items.truncate(remaining_top);
+                    remaining_top -= items.len();
+                }
+            }
+            let returned =
+                total
+                    .saturating_sub(offset)
+                    .min(if top == 0 { usize::MAX } else { top });
+            return Some(total.saturating_sub(offset).saturating_sub(returned));
+        }
+    }
+    None
+}
+
+fn truncate_object_arrays(
+    parents: &mut Value,
+    field: &str,
+    top: usize,
+    offset: usize,
+) -> Option<usize> {
+    let total: usize = parents
+        .as_array()?
+        .iter()
+        .filter_map(|parent| parent.get(field)?.as_array())
+        .map(Vec::len)
+        .sum();
+    let mut remaining_top = if top == 0 { usize::MAX } else { top };
+    let mut remaining_offset = offset;
+    truncate_object_arrays_budget(parents, field, &mut remaining_top, &mut remaining_offset);
+    let returned = total
+        .saturating_sub(offset)
+        .min(if top == 0 { usize::MAX } else { top });
+    Some(total.saturating_sub(offset).saturating_sub(returned))
+}
+
+fn truncate_object_arrays_budget(
+    parents: &mut Value,
+    field: &str,
+    remaining_top: &mut usize,
+    remaining_offset: &mut usize,
+) {
+    let Some(parents) = parents.as_array_mut() else {
+        return;
+    };
+    for parent in parents {
+        let Some(items) = parent.get_mut(field).and_then(Value::as_array_mut) else {
+            continue;
+        };
+        let skip = (*remaining_offset).min(items.len());
+        items.drain(0..skip);
+        *remaining_offset -= skip;
+        if *remaining_offset > 0 {
+            items.clear();
+            continue;
+        }
+        items.truncate(*remaining_top);
+        *remaining_top -= items.len();
+    }
 }
 
 /// Format a JSON value with optional truncation applied for JSON formats.
@@ -201,28 +315,44 @@ struct SarifFinding {
 }
 
 fn collect_sarif_findings(value: &Value, findings: &mut Vec<SarifFinding>) {
+    collect_sarif_findings_with_path(value, findings, None);
+}
+
+fn collect_sarif_findings_with_path(
+    value: &Value,
+    findings: &mut Vec<SarifFinding>,
+    parent_path: Option<&str>,
+) {
     match value {
         Value::Object(map) => {
-            if let Some(finding) = sarif_finding_from_object(map) {
+            let path = ["file", "path", "file_path"]
+                .iter()
+                .find_map(|key| map.get(*key).and_then(Value::as_str))
+                .or(parent_path);
+            if let Some(finding) = sarif_finding_from_object(map, parent_path) {
                 findings.push(finding);
             }
             for child in map.values() {
-                collect_sarif_findings(child, findings);
+                collect_sarif_findings_with_path(child, findings, path);
             }
         }
         Value::Array(items) => {
             for item in items {
-                collect_sarif_findings(item, findings);
+                collect_sarif_findings_with_path(item, findings, parent_path);
             }
         }
         _ => {}
     }
 }
 
-fn sarif_finding_from_object(map: &serde_json::Map<String, Value>) -> Option<SarifFinding> {
+fn sarif_finding_from_object(
+    map: &serde_json::Map<String, Value>,
+    parent_path: Option<&str>,
+) -> Option<SarifFinding> {
     let file = ["file", "path", "file_path"]
         .iter()
-        .find_map(|key| map.get(*key).and_then(Value::as_str))?;
+        .find_map(|key| map.get(*key).and_then(Value::as_str))
+        .or(parent_path)?;
     let line = ["line", "start_line", "line_start"]
         .iter()
         .find_map(|key| map.get(*key).and_then(Value::as_u64))

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -67,19 +67,7 @@ pub fn get_symbol(
     let candidates_idxs = index.resolve(name);
 
     if candidates_idxs.is_empty() {
-        // Build suggestions
-        let q = name.to_lowercase();
-        let mut suggestions: Vec<String> = index
-            .by_name
-            .keys()
-            .filter(|k| {
-                let kl = k.to_lowercase();
-                kl.contains(&q) || q.contains(kl.as_str())
-            })
-            .cloned()
-            .collect();
-        suggestions.sort();
-        suggestions.truncate(10);
+        let suggestions = suggestions_from_index(&index, name);
         let hint = if suggestions.is_empty() {
             String::new()
         } else {
@@ -174,6 +162,30 @@ pub fn get_symbol(
         cognitive,
         candidates,
     })
+}
+
+pub fn suggest_symbols(root: &Path, files: &[PathBuf], name: &str) -> Result<Vec<String>> {
+    let index = build_index(root, files)?;
+    Ok(suggestions_from_index(&index, name))
+}
+
+fn suggestions_from_index(
+    index: &crate::analyzers::repomap::CallGraphIndex,
+    name: &str,
+) -> Vec<String> {
+    let query = name.to_lowercase();
+    let mut suggestions: Vec<String> = index
+        .by_name
+        .keys()
+        .filter(|candidate| {
+            let candidate = candidate.to_lowercase();
+            candidate.contains(&query) || query.contains(candidate.as_str())
+        })
+        .cloned()
+        .collect();
+    suggestions.sort();
+    suggestions.truncate(10);
+    suggestions
 }
 
 /// Read lines start_line..=end_line from a file (1-indexed).

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -80,6 +80,28 @@ fn test_deadcode_runs_successfully() {
 }
 
 #[test]
+fn test_analyzer_json_paths_are_repo_relative() {
+    for analyzer in ["complexity", "satd", "deadcode"] {
+        let output = omen()
+            .args(["-p", fixtures_dir(), "-f", "json", analyzer])
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "{analyzer}");
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        assert!(!stdout.contains(fixtures_dir()), "{analyzer}: {stdout}");
+        if analyzer == "complexity" {
+            let value: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+            assert!(value["files"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .flat_map(|file| file["functions"].as_array().unwrap())
+                .all(|function| function.get("file").is_none()));
+        }
+    }
+}
+
+#[test]
 fn test_cohesion_runs_successfully() {
     omen()
         .args(["-p", fixtures_dir(), "-f", "json", "cohesion"])
@@ -153,6 +175,32 @@ fn test_score_runs_successfully() {
         .assert()
         .success()
         .stdout(predicate::str::contains("overall_score"));
+}
+
+#[test]
+fn test_threshold_violation_exits_two_and_emits_json() {
+    omen()
+        .args([
+            "-p",
+            fixtures_dir(),
+            "-f",
+            "json",
+            "score",
+            "--check",
+            "--fail-under",
+            "99",
+        ])
+        .assert()
+        .code(2)
+        .stdout(predicate::str::contains("\"violations\""));
+}
+
+#[test]
+fn test_operational_failure_exits_one() {
+    omen()
+        .args(["-p", "/definitely/not/a/repository", "complexity"])
+        .assert()
+        .code(1);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Makes the CLI and MCP surface actually usable by LLM agents, and fixes a batch of DX papercuts found in the audit.

- **Skills**: fixed the invalid `omen` invocations in the shipped plugin skills (post-subcommand `--compact`, positional-vs-flag mismatches, nonexistent flags); made `--compact` a global flag; added a test that parses every `omen` command in `plugins/**/*.md`.
- **MCP parameters honored**: the 13 tools that advertised parameters they ignored now honor them (or the unsupported ones were removed from the schema). Structured `isError` tool results and symbol suggestions replace opaque `-32603`s; protocol bumped to `2025-11-25`.
- **Pagination** now bounds the dominant nested collection (complexity functions, impact levels, graph cycles); envelope totals reflect it.
- **Repo-relative paths** in complexity/satd/deadcode, and the redundant per-function absolute path is gone — a large token saving. SARIF/context consumers updated.
- **Exit codes**: threshold violations exit `2`, operational failures `1`; `--check` with `-f json` writes machine-readable violations to stdout.
- **Dead flags** removed or implemented (`--verbose` now works; `mcp` restricted to stdio; dead `context`/`mcp` flags dropped).
- **Config honesty**: `deny_unknown_fields`, YAML/JSON loading enabled, previously-ignored sections wired up, never-honored fields removed.
- **Deps**: `anyhow` removed; `tokio`/`reqwest` gated behind a default-on `mutation` feature (`--no-default-features` compiles).

## Verification

`cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (1903 passed), and `cargo check --no-default-features` all pass, plus new regression tests for each area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added YAML and JSON configuration file support.
  - Added suggestions when requested symbols cannot be found.
  - Improved MCP tool pagination, validation, error reporting, and configurable analysis options.
  - Added custom SATD marker support.
  - Mutation analysis is now enabled by default but can be excluded from builds.

- **Improvements**
  - CLI commands now use simpler positional arguments and global compact output.
  - Reports use repository-relative paths and improved nested-result truncation.
  - Threshold violations now exit with status code 2.

- **Documentation**
  - Updated built-in workflow and configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->