### PR TITLE
perf: optimize analyzer hot loops, algorithms, and memory

### DIFF
--- a/src/analyzers/cohesion.rs
+++ b/src/analyzers/cohesion.rs
@@ -613,17 +613,19 @@ fn has_child_of_kind(node: &tree_sitter::Node, kind: &str) -> bool {
 /// Extracts field names from a Go struct's field_declaration_list.
 fn extract_go_struct_fields(type_decl: &tree_sitter::Node, source: &[u8]) -> Vec<String> {
     let mut fields = Vec::new();
+    let mut seen = HashSet::new();
     // type_declaration -> type_spec -> struct_type -> field_declaration_list -> field_declaration
     let mut cursor = type_decl.walk();
-    extract_go_fields_recursive(&mut cursor, source, &mut fields);
+    extract_go_fields_recursive(&mut cursor, source, &mut fields, &mut seen);
     fields
 }
 
 /// Recursively finds Go field_declaration nodes and extracts their names.
-fn extract_go_fields_recursive(
+fn extract_go_fields_recursive<'source>(
     cursor: &mut tree_sitter::TreeCursor,
-    source: &[u8],
+    source: &'source [u8],
     fields: &mut Vec<String>,
+    seen: &mut HashSet<&'source str>,
 ) {
     loop {
         let node = cursor.node();
@@ -632,7 +634,7 @@ fn extract_go_fields_recursive(
             // field_declaration has a "name" field (field_identifier)
             if let Some(name_node) = node.child_by_field_name("name") {
                 if let Ok(name) = std::str::from_utf8(&source[name_node.byte_range()]) {
-                    if !name.is_empty() && !fields.contains(&name.to_string()) {
+                    if !name.is_empty() && seen.insert(name) {
                         fields.push(name.to_string());
                     }
                 }
@@ -640,7 +642,7 @@ fn extract_go_fields_recursive(
         }
 
         if cursor.goto_first_child() {
-            extract_go_fields_recursive(cursor, source, fields);
+            extract_go_fields_recursive(cursor, source, fields, seen);
             cursor.goto_parent();
         }
 
@@ -1150,10 +1152,18 @@ fn find_field_accesses(
 /// Extracts field names from a class.
 fn extract_fields(node: &tree_sitter::Node, source: &[u8], lang: Language) -> Vec<String> {
     let mut fields = Vec::new();
+    let mut seen = HashSet::new();
     let field_types = get_field_node_types(lang);
 
     let mut cursor = node.walk();
-    extract_fields_recursive(&mut cursor, source, lang, &field_types, &mut fields);
+    extract_fields_recursive(
+        &mut cursor,
+        source,
+        lang,
+        &field_types,
+        &mut fields,
+        &mut seen,
+    );
 
     fields
 }
@@ -1165,20 +1175,21 @@ fn extract_fields_recursive(
     lang: Language,
     field_types: &[&str],
     fields: &mut Vec<String>,
+    seen: &mut HashSet<String>,
 ) {
     loop {
         let node = cursor.node();
 
         if field_types.contains(&node.kind()) {
             if let Some(name) = extract_field_name(&node, source, lang) {
-                if !fields.contains(&name) {
+                if seen.insert(name.clone()) {
                     fields.push(name);
                 }
             }
         }
 
         if cursor.goto_first_child() {
-            extract_fields_recursive(cursor, source, lang, field_types, fields);
+            extract_fields_recursive(cursor, source, lang, field_types, fields, seen);
             cursor.goto_parent();
         }
 

--- a/src/analyzers/duplicates.rs
+++ b/src/analyzers/duplicates.rs
@@ -275,7 +275,6 @@ impl Analyzer {
             file: path.to_string(),
             start_line: (start_line + 1) as u32,
             end_line: (end_line + 1) as u32,
-            content: normalized_tokens.join(" "),
             tokens: normalized_tokens,
             normalized_hash: 0, // Set later
             signature: None,    // Set later
@@ -415,25 +414,32 @@ impl Analyzer {
 
         // Initialize Union-Find
         let mut parent: Vec<usize> = (0..fragments.len()).collect();
+        let mut sizes = vec![1usize; fragments.len()];
 
-        fn find(parent: &mut [usize], x: usize) -> usize {
-            if parent[x] != x {
-                parent[x] = find(parent, parent[x]);
+        fn find(parent: &mut [usize], mut x: usize) -> usize {
+            while parent[x] != x {
+                parent[x] = parent[parent[x]];
+                x = parent[x];
             }
-            parent[x]
+            x
         }
 
-        fn union(parent: &mut [usize], x: usize, y: usize) {
-            let px = find(parent, x);
-            let py = find(parent, y);
-            if px != py {
-                parent[px] = py;
+        fn union(parent: &mut [usize], sizes: &mut [usize], x: usize, y: usize) {
+            let mut px = find(parent, x);
+            let mut py = find(parent, y);
+            if px == py {
+                return;
             }
+            if sizes[px] < sizes[py] {
+                std::mem::swap(&mut px, &mut py);
+            }
+            parent[py] = px;
+            sizes[px] += sizes[py];
         }
 
         // Union all clone pairs
         for pair in pairs {
-            union(&mut parent, pair.idx_a, pair.idx_b);
+            union(&mut parent, &mut sizes, pair.idx_a, pair.idx_b);
         }
 
         // Group fragments by their root
@@ -701,8 +707,6 @@ struct CodeFragment {
     file: String,
     start_line: u32,
     end_line: u32,
-    #[allow(dead_code)]
-    content: String,
     tokens: Vec<String>,
     normalized_hash: u64,
     signature: Option<MinHashSignature>,
@@ -1115,184 +1119,117 @@ fn is_operator_or_delimiter(token: &str) -> bool {
 /// Tokenize code into tokens.
 fn tokenize(content: &str) -> Vec<String> {
     let mut tokens = Vec::new();
-    let chars: Vec<char> = content.chars().collect();
-    let mut i = 0;
+    let mut chars = content.char_indices().peekable();
 
-    while i < chars.len() {
-        let c = chars[i];
-
+    while let Some((start, c)) = chars.next() {
         // Skip whitespace
         if c.is_whitespace() {
-            i += 1;
             continue;
         }
 
         // String literals
         if c == '"' || c == '\'' || c == '`' {
-            tokens.push(collect_string_literal(&chars, &mut i, c));
+            let mut escaped = false;
+            for (_, current) in chars.by_ref() {
+                if escaped {
+                    escaped = false;
+                } else if current == '\\' {
+                    escaped = true;
+                } else if current == c {
+                    break;
+                }
+            }
+            let end = chars.peek().map_or(content.len(), |(index, _)| *index);
+            tokens.push(content[start..end].to_string());
             continue;
         }
 
         // Numbers
-        if c.is_ascii_digit() || (c == '-' && i + 1 < chars.len() && chars[i + 1].is_ascii_digit())
+        if c.is_ascii_digit()
+            || (c == '-' && chars.peek().is_some_and(|(_, next)| next.is_ascii_digit()))
         {
-            tokens.push(collect_number(&chars, &mut i));
+            while chars.peek().is_some_and(|(_, next)| {
+                next.is_ascii_digit()
+                    || matches!(
+                        next,
+                        '.' | '_'
+                            | 'x'
+                            | 'X'
+                            | 'b'
+                            | 'B'
+                            | 'o'
+                            | 'O'
+                            | 'a'..='f'
+                            | 'A'..='F'
+                    )
+            }) {
+                chars.next();
+            }
+            let end = chars.peek().map_or(content.len(), |(index, _)| *index);
+            tokens.push(content[start..end].to_string());
             continue;
         }
 
         // Identifiers and keywords
         if c.is_alphabetic() || c == '_' {
-            tokens.push(collect_identifier(&chars, &mut i));
+            while chars
+                .peek()
+                .is_some_and(|(_, next)| next.is_alphanumeric() || *next == '_')
+            {
+                chars.next();
+            }
+            let end = chars.peek().map_or(content.len(), |(index, _)| *index);
+            tokens.push(content[start..end].to_string());
             continue;
         }
 
-        // Multi-character operators
-        if let Some(op) = collect_operator(&chars, &mut i) {
-            tokens.push(op);
+        // Guard operator matching by the first byte, then allocate only the
+        // operator that is actually emitted.
+        let rest = &content[start..];
+        let operator_len = if matches!(c, '<' | '>' | '.' | '=' | '!')
+            && ["<<=", ">>=", "...", "===", "!=="]
+                .iter()
+                .any(|operator| rest.starts_with(operator))
+        {
+            3
+        } else if matches!(
+            c,
+            '=' | '!' | '<' | '>' | '&' | '|' | '+' | '-' | '*' | '/' | '%' | '^' | ':' | '.' | '?'
+        ) && [
+            "==", "!=", "<=", ">=", "&&", "||", "<<", ">>", "+=", "-=", "*=", "/=", "%=", "&=",
+            "|=", "^=", "++", "--", "->", "=>", "::", "..", "??",
+        ]
+        .iter()
+        .any(|operator| rest.starts_with(operator))
+        {
+            2
+        } else {
+            0
+        };
+        if operator_len > 0 {
+            for _ in 1..operator_len {
+                chars.next();
+            }
+            tokens.push(content[start..start + operator_len].to_string());
             continue;
         }
 
         // Single character
         tokens.push(c.to_string());
-        i += 1;
     }
 
     tokens
 }
 
-fn collect_string_literal(chars: &[char], i: &mut usize, quote: char) -> String {
-    let mut s = String::new();
-    s.push(chars[*i]);
-    *i += 1;
-
-    while *i < chars.len() {
-        let c = chars[*i];
-        s.push(c);
-        *i += 1;
-
-        if c == quote {
-            break;
-        }
-        // Handle escape sequences
-        if c == '\\' && *i < chars.len() {
-            s.push(chars[*i]);
-            *i += 1;
-        }
-    }
-
-    s
-}
-
-fn collect_number(chars: &[char], i: &mut usize) -> String {
-    let mut s = String::new();
-
-    // Handle negative sign
-    if chars[*i] == '-' {
-        s.push('-');
-        *i += 1;
-    }
-
-    while *i < chars.len() {
-        let c = chars[*i];
-        if c.is_ascii_digit()
-            || c == '.'
-            || c == '_'
-            || c == 'x'
-            || c == 'X'
-            || c == 'b'
-            || c == 'B'
-            || c == 'o'
-            || c == 'O'
-            || ('a'..='f').contains(&c)
-            || ('A'..='F').contains(&c)
-            || c == 'e'
-            || c == 'E'
-        {
-            s.push(c);
-            *i += 1;
-        } else {
-            break;
-        }
-    }
-
-    s
-}
-
-fn collect_identifier(chars: &[char], i: &mut usize) -> String {
-    let mut s = String::new();
-
-    while *i < chars.len() {
-        let c = chars[*i];
-        if c.is_alphanumeric() || c == '_' {
-            s.push(c);
-            *i += 1;
-        } else {
-            break;
-        }
-    }
-
-    s
-}
-
-fn collect_operator(chars: &[char], i: &mut usize) -> Option<String> {
-    if *i >= chars.len() {
-        return None;
-    }
-
-    // Try 3-character operators
-    if *i + 2 < chars.len() {
-        let op3: String = chars[*i..*i + 3].iter().collect();
-        if matches!(op3.as_str(), "<<=" | ">>=" | "..." | "===" | "!==") {
-            *i += 3;
-            return Some(op3);
-        }
-    }
-
-    // Try 2-character operators
-    if *i + 1 < chars.len() {
-        let op2: String = chars[*i..*i + 2].iter().collect();
-        if matches!(
-            op2.as_str(),
-            "==" | "!="
-                | "<="
-                | ">="
-                | "&&"
-                | "||"
-                | "<<"
-                | ">>"
-                | "+="
-                | "-="
-                | "*="
-                | "/="
-                | "%="
-                | "&="
-                | "|="
-                | "^="
-                | "++"
-                | "--"
-                | "->"
-                | "=>"
-                | "::"
-                | ".."
-                | "??"
-        ) {
-            *i += 2;
-            return Some(op2);
-        }
-    }
-
-    None
-}
-
-/// Generate k-shingles from tokens using blake3 hashing.
+/// Generate k-shingles from tokens using BLAKE3 hashing.
 fn generate_k_shingles(tokens: &[String], k: usize) -> Vec<u64> {
     if tokens.len() < k {
         if !tokens.is_empty() {
-            let mut hasher = blake3::Hasher::new();
+            let mut bytes = Vec::new();
             for t in tokens {
-                hasher.update(t.as_bytes());
+                bytes.extend_from_slice(t.as_bytes());
             }
-            let hash = hasher.finalize();
+            let hash = blake3::hash(&bytes);
             return vec![u64::from_le_bytes(
                 hash.as_bytes()[..8]
                     .try_into()
@@ -1303,19 +1240,19 @@ fn generate_k_shingles(tokens: &[String], k: usize) -> Vec<u64> {
     }
 
     let mut shingle_set: HashSet<u64> = HashSet::new();
+    let mut bytes = Vec::new();
 
     for window in tokens.windows(k) {
-        let mut hasher = blake3::Hasher::new();
+        bytes.clear();
         for token in window {
-            hasher.update(token.as_bytes());
+            bytes.extend_from_slice(token.as_bytes());
         }
-        let hash = hasher.finalize();
-        let h = u64::from_le_bytes(
+        let hash = blake3::hash(&bytes);
+        shingle_set.insert(u64::from_le_bytes(
             hash.as_bytes()[..8]
                 .try_into()
                 .expect("blake3 hash is always 32 bytes"),
-        );
-        shingle_set.insert(h);
+        ));
     }
 
     shingle_set.into_iter().collect()

--- a/src/analyzers/flags.rs
+++ b/src/analyzers/flags.rs
@@ -355,14 +355,15 @@ impl Analyzer {
         providers: &[String],
         custom_providers: &[CustomProvider],
     ) -> Result<Analysis> {
-        let builtin_providers = get_builtin_providers();
+        let builtin_providers: Vec<_> = get_builtin_providers()
+            .into_iter()
+            .filter(|builtin| providers.iter().any(|provider| provider == builtin.name))
+            .collect();
 
         // Pre-compile queries for each (language, provider) combination
-        let mut compiled_queries: HashMap<(Language, String), (Query, usize)> = HashMap::new();
+        let mut compiled_queries: HashMap<Language, HashMap<String, (Query, usize)>> =
+            HashMap::new();
         for builtin in &builtin_providers {
-            if !providers.contains(&builtin.name.to_string()) {
-                continue;
-            }
             for &lang in builtin.languages {
                 if let Ok(ts_lang) = get_tree_sitter_language(lang) {
                     if let Ok(query) = Query::new(&ts_lang, builtin.query) {
@@ -371,7 +372,10 @@ impl Analyzer {
                             .iter()
                             .position(|n| *n == "key")
                             .unwrap_or(0);
-                        compiled_queries.insert((lang, builtin.name.to_string()), (query, key_idx));
+                        compiled_queries
+                            .entry(lang)
+                            .or_default()
+                            .insert(builtin.name.to_string(), (query, key_idx));
                     }
                 }
             }
@@ -389,7 +393,10 @@ impl Analyzer {
                                 .iter()
                                 .position(|n| *n == "key" || *n == "flag_key")
                                 .unwrap_or(0);
-                            compiled_queries.insert((lang, custom.name.clone()), (query, key_idx));
+                            compiled_queries
+                                .entry(lang)
+                                .or_default()
+                                .insert(custom.name.clone(), (query, key_idx));
                         }
                     }
                 }
@@ -400,7 +407,6 @@ impl Analyzer {
         let compiled_queries = Arc::new(compiled_queries);
         let builtin_providers = Arc::new(builtin_providers);
         let custom_providers: Arc<[CustomProvider]> = custom_providers.to_vec().into();
-        let providers: Arc<[String]> = providers.to_vec().into();
 
         // Get files from context
         let files: Vec<_> = ctx.files.iter().collect();
@@ -440,16 +446,15 @@ impl Analyzer {
 
                 // Apply built-in providers using pre-compiled queries
                 for builtin in builtin_providers.iter() {
-                    if !providers.contains(&builtin.name.to_string()) {
-                        continue;
-                    }
                     if !builtin.languages.contains(&language) {
                         continue;
                     }
 
                     // Look up pre-compiled query
-                    let key = (language, builtin.name.to_string());
-                    if let Some((query, key_capture_idx)) = compiled_queries.get(&key) {
+                    if let Some((query, key_capture_idx)) = compiled_queries
+                        .get(&language)
+                        .and_then(|queries| queries.get(builtin.name))
+                    {
                         let mut cursor = QueryCursor::new();
                         let mut matches = cursor.matches(
                             query,
@@ -496,8 +501,10 @@ impl Analyzer {
                     }
 
                     // Look up pre-compiled query
-                    let key = (language, custom.name.clone());
-                    if let Some((query, key_capture_idx)) = compiled_queries.get(&key) {
+                    if let Some((query, key_capture_idx)) = compiled_queries
+                        .get(&language)
+                        .and_then(|queries| queries.get(custom.name.as_str()))
+                    {
                         let mut cursor = QueryCursor::new();
                         let mut matches = cursor.matches(
                             query,

--- a/src/analyzers/graph.rs
+++ b/src/analyzers/graph.rs
@@ -563,13 +563,15 @@ impl Analyzer {
         }
 
         let d = self.config.damping;
-        let mut rank: HashMap<NodeIndex, f64> = graph
+        let initial_rank = 1.0 / n as f64;
+        let mut rank = vec![initial_rank; n];
+        let mut new_rank = vec![0.0; n];
+        let out_degrees: Vec<usize> = graph
             .node_indices()
-            .map(|idx| (idx, 1.0 / n as f64))
+            .map(|node| graph.edges_directed(node, Direction::Outgoing).count())
             .collect();
 
         for _ in 0..self.config.max_iterations {
-            let mut new_rank: HashMap<NodeIndex, f64> = HashMap::with_capacity(n);
             let mut diff = 0.0;
 
             for node in graph.node_indices() {
@@ -577,9 +579,9 @@ impl Analyzer {
                     .edges_directed(node, Direction::Incoming)
                     .map(|e| {
                         let source = e.source();
-                        let out_deg = graph.edges_directed(source, Direction::Outgoing).count();
+                        let out_deg = out_degrees[source.index()];
                         if out_deg > 0 {
-                            rank[&source] / out_deg as f64
+                            rank[source.index()] / out_deg as f64
                         } else {
                             0.0
                         }
@@ -587,18 +589,21 @@ impl Analyzer {
                     .sum();
 
                 let new_score = (1.0 - d) / n as f64 + d * incoming;
-                diff += (new_score - rank[&node]).abs();
-                new_rank.insert(node, new_score);
+                diff += (new_score - rank[node.index()]).abs();
+                new_rank[node.index()] = new_score;
             }
 
-            rank = new_rank;
+            std::mem::swap(&mut rank, &mut new_rank);
 
             if diff < self.config.tolerance {
                 break;
             }
         }
 
-        rank
+        graph
+            .node_indices()
+            .map(|node| (node, rank[node.index()]))
+            .collect()
     }
 
     /// Calculate betweenness centrality using Brandes' algorithm with parallel BFS.
@@ -611,73 +616,100 @@ impl Analyzer {
         // Use all nodes as sources (no sampling - per project requirements)
         let sources: Vec<NodeIndex> = graph.node_indices().collect();
 
-        // Parallel betweenness calculation
-        let partial_betweenness: Vec<HashMap<NodeIndex, f64>> = sources
-            .par_iter()
-            .map(|&source| {
-                let mut local_betweenness: HashMap<NodeIndex, f64> = HashMap::new();
-                let mut dist: HashMap<NodeIndex, i32> = HashMap::with_capacity(n);
-                let mut paths: HashMap<NodeIndex, f64> = HashMap::with_capacity(n);
-                let mut predecessors: HashMap<NodeIndex, Vec<NodeIndex>> =
-                    HashMap::with_capacity(n);
-                let mut stack: Vec<NodeIndex> = Vec::with_capacity(n);
-                let mut queue: VecDeque<NodeIndex> = VecDeque::with_capacity(n);
+        struct BetweennessState {
+            totals: Vec<f64>,
+            dist: Vec<i32>,
+            sigma: Vec<f64>,
+            delta: Vec<f64>,
+            predecessors: Vec<Vec<u32>>,
+            stack: Vec<usize>,
+            queue: VecDeque<usize>,
+        }
 
-                dist.insert(source, 0);
-                paths.insert(source, 1.0);
-                queue.push_back(source);
-
-                // BFS
-                while let Some(v) = queue.pop_front() {
-                    stack.push(v);
-                    let v_dist = dist[&v];
-
-                    for edge in graph.edges_directed(v, Direction::Outgoing) {
-                        let w = edge.target();
-
-                        // First visit
-                        if let std::collections::hash_map::Entry::Vacant(e) = dist.entry(w) {
-                            e.insert(v_dist + 1);
-                            queue.push_back(w);
-                        }
-
-                        // Shortest path via v
-                        if dist[&w] == v_dist + 1 {
-                            *paths.entry(w).or_insert(0.0) += *paths.get(&v).unwrap_or(&0.0);
-                            predecessors.entry(w).or_default().push(v);
-                        }
-                    }
+        impl BetweennessState {
+            fn new(n: usize) -> Self {
+                Self {
+                    totals: vec![0.0; n],
+                    dist: vec![-1; n],
+                    sigma: vec![0.0; n],
+                    delta: vec![0.0; n],
+                    predecessors: (0..n).map(|_| Vec::new()).collect(),
+                    stack: Vec::with_capacity(n),
+                    queue: VecDeque::with_capacity(n),
                 }
+            }
 
-                // Accumulate dependencies
-                let mut delta: HashMap<NodeIndex, f64> = HashMap::with_capacity(n);
-                while let Some(w) = stack.pop() {
-                    if let Some(preds) = predecessors.get(&w) {
-                        for &v in preds {
-                            let coeff = (paths.get(&v).unwrap_or(&0.0)
-                                / paths.get(&w).unwrap_or(&1.0))
-                                * (1.0 + delta.get(&w).unwrap_or(&0.0));
-                            *delta.entry(v).or_insert(0.0) += coeff;
-                        }
-                    }
-                    if w != source {
-                        *local_betweenness.entry(w).or_insert(0.0) += delta.get(&w).unwrap_or(&0.0);
-                    }
+            fn reset_scratch(&mut self) {
+                self.dist.fill(-1);
+                self.sigma.fill(0.0);
+                self.delta.fill(0.0);
+                for predecessors in &mut self.predecessors {
+                    predecessors.clear();
                 }
-
-                local_betweenness
-            })
-            .collect();
-
-        // Merge partial results
-        let mut betweenness: HashMap<NodeIndex, f64> =
-            graph.node_indices().map(|idx| (idx, 0.0)).collect();
-
-        for partial in partial_betweenness {
-            for (idx, value) in partial {
-                *betweenness.entry(idx).or_insert(0.0) += value;
+                self.stack.clear();
+                self.queue.clear();
             }
         }
+
+        // Fold source contributions into per-worker totals, then merge worker
+        // totals incrementally to keep peak memory proportional to worker count.
+        let state = sources
+            .par_iter()
+            .fold(
+                || BetweennessState::new(n),
+                |mut state, &source| {
+                    state.reset_scratch();
+                    let source_idx = source.index();
+                    state.dist[source_idx] = 0;
+                    state.sigma[source_idx] = 1.0;
+                    state.queue.push_back(source_idx);
+
+                    // BFS
+                    while let Some(v) = state.queue.pop_front() {
+                        state.stack.push(v);
+                        let v_dist = state.dist[v];
+
+                        for edge in graph.edges_directed(NodeIndex::new(v), Direction::Outgoing) {
+                            let w = edge.target().index();
+
+                            // First visit
+                            if state.dist[w] < 0 {
+                                state.dist[w] = v_dist + 1;
+                                state.queue.push_back(w);
+                            }
+
+                            // Shortest path via v
+                            if state.dist[w] == v_dist + 1 {
+                                state.sigma[w] += state.sigma[v];
+                                state.predecessors[w].push(v as u32);
+                            }
+                        }
+                    }
+
+                    // Accumulate dependencies
+                    while let Some(w) = state.stack.pop() {
+                        for predecessor_index in 0..state.predecessors[w].len() {
+                            let v = state.predecessors[w][predecessor_index] as usize;
+                            let coeff = (state.sigma[v] / state.sigma[w]) * (1.0 + state.delta[w]);
+                            state.delta[v] += coeff;
+                        }
+                        if w != source_idx {
+                            state.totals[w] += state.delta[w];
+                        }
+                    }
+
+                    state
+                },
+            )
+            .reduce(
+                || BetweennessState::new(n),
+                |mut left, right| {
+                    for (left_value, right_value) in left.totals.iter_mut().zip(right.totals) {
+                        *left_value += right_value;
+                    }
+                    left
+                },
+            );
 
         // Normalize betweenness scores
         let norm = if n > 2 {
@@ -686,6 +718,10 @@ impl Analyzer {
             1.0
         };
 
+        let mut betweenness: HashMap<NodeIndex, f64> = graph
+            .node_indices()
+            .map(|node| (node, state.totals[node.index()]))
+            .collect();
         for value in betweenness.values_mut() {
             *value *= norm;
         }
@@ -904,6 +940,24 @@ mod tests {
         let rank_a = ranks[&a];
         let rank_b = ranks[&b];
         assert!(rank_b > rank_a, "Node b should have higher PageRank");
+    }
+
+    #[test]
+    fn test_pagerank_pins_asymmetric_fixture_scores() {
+        let analyzer = Analyzer::new();
+        let mut graph: DiGraph<String, ()> = DiGraph::new();
+        let a = graph.add_node("a.rs".to_string());
+        let b = graph.add_node("b.rs".to_string());
+        let c = graph.add_node("c.rs".to_string());
+        graph.add_edge(a, b, ());
+        graph.add_edge(a, c, ());
+        graph.add_edge(b, c, ());
+
+        let ranks = analyzer.calculate_pagerank(&graph);
+
+        assert!((ranks[&a] - 0.05).abs() < 1e-12);
+        assert!((ranks[&b] - 0.07125).abs() < 1e-12);
+        assert!((ranks[&c] - 0.1318125).abs() < 1e-12);
     }
 
     #[test]

--- a/src/analyzers/mutation/executor.rs
+++ b/src/analyzers/mutation/executor.rs
@@ -23,6 +23,40 @@ use super::safety::MutationGuard;
 use super::worker::{FileLockManager, ProgressUpdate, WorkItem, WorkQueue};
 use super::Mutant;
 
+fn build_work_items(mutants: &[Mutant], sources: &HashMap<PathBuf, Vec<u8>>) -> Vec<WorkItem> {
+    let shared_sources: HashMap<&PathBuf, Arc<Vec<u8>>> = sources
+        .iter()
+        .map(|(path, source)| (path, Arc::new(source.clone())))
+        .collect();
+    let mut file_positions = HashMap::new();
+    let mut mutants_by_file: Vec<Vec<&Mutant>> = Vec::new();
+    for mutant in mutants {
+        let position = if let Some(&position) = file_positions.get(&mutant.file_path) {
+            position
+        } else {
+            let position = mutants_by_file.len();
+            file_positions.insert(&mutant.file_path, position);
+            mutants_by_file.push(Vec::new());
+            position
+        };
+        mutants_by_file[position].push(mutant);
+    }
+
+    let mut work_items = Vec::with_capacity(mutants.len());
+    let max_mutants = mutants_by_file.iter().map(Vec::len).max().unwrap_or(0);
+    for index in 0..max_mutants {
+        for file_mutants in &mutants_by_file {
+            let Some(mutant) = file_mutants.get(index) else {
+                continue;
+            };
+            if let Some(source) = shared_sources.get(&mutant.file_path) {
+                work_items.push(WorkItem::new((*mutant).clone(), Arc::clone(source)));
+            }
+        }
+    }
+    work_items
+}
+
 /// Progress callback type for async execution.
 pub type ProgressCallback = Box<dyn Fn(ProgressUpdate) + Send + Sync>;
 
@@ -254,14 +288,7 @@ impl AsyncMutantExecutor {
         let results = Arc::new(parking_lot::Mutex::new(Vec::with_capacity(total)));
 
         // Create work items
-        let work_items: Vec<WorkItem> = mutants
-            .iter()
-            .filter_map(|mutant| {
-                sources
-                    .get(&mutant.file_path)
-                    .map(|source| WorkItem::new(mutant.clone(), Arc::new(source.clone())))
-            })
-            .collect();
+        let work_items = build_work_items(mutants, sources);
 
         let queue = Arc::new(WorkQueue::new(work_items));
 
@@ -827,6 +854,45 @@ mod tests {
         let results = executor.execute_mutants(&mutants, &sources).await.unwrap();
 
         assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn test_work_items_share_one_source_allocation_per_file() {
+        let path = PathBuf::from("test.rs");
+        let mutants = vec![
+            Mutant::new("mut-1", &path, "CRR", 1, 1, "1", "0", "desc", (0, 1)),
+            Mutant::new("mut-2", &path, "CRR", 1, 1, "2", "0", "desc", (2, 3)),
+        ];
+        let mut sources = HashMap::new();
+        sources.insert(path, b"1 2".to_vec());
+
+        let items = build_work_items(&mutants, &sources);
+
+        assert_eq!(items.len(), 2);
+        assert!(Arc::ptr_eq(&items[0].source, &items[1].source));
+    }
+
+    #[test]
+    fn test_work_items_interleave_files_for_parallel_workers() {
+        let path_a = PathBuf::from("a.rs");
+        let path_b = PathBuf::from("b.rs");
+        let mutants = vec![
+            Mutant::new("a-1", &path_a, "CRR", 1, 1, "1", "0", "desc", (0, 1)),
+            Mutant::new("a-2", &path_a, "CRR", 2, 1, "2", "0", "desc", (2, 3)),
+            Mutant::new("b-1", &path_b, "CRR", 1, 1, "1", "0", "desc", (0, 1)),
+            Mutant::new("b-2", &path_b, "CRR", 2, 1, "2", "0", "desc", (2, 3)),
+        ];
+        let sources = HashMap::from([(path_a, b"1 2".to_vec()), (path_b, b"1 2".to_vec())]);
+
+        let items = build_work_items(&mutants, &sources);
+        let popped_paths: Vec<_> = items
+            .iter()
+            .rev()
+            .take(2)
+            .map(|item| &item.mutant.file_path)
+            .collect();
+
+        assert_ne!(popped_paths[0], popped_paths[1]);
     }
 
     #[tokio::test]

--- a/src/analyzers/mutation/mod.rs
+++ b/src/analyzers/mutation/mod.rs
@@ -231,7 +231,6 @@ impl Analyzer {
     }
 
     /// Get effective number of workers.
-    #[allow(dead_code)]
     fn effective_jobs(&self) -> usize {
         if self.jobs == 0 {
             std::thread::available_parallelism()
@@ -385,14 +384,16 @@ impl AnalyzerTrait for Analyzer {
 
         let executor_config = ExecutorConfig::with_command(&test_cmd)
             .timeout(self.timeout_secs)
-            .working_dir(project_root);
-        let executor = MutantExecutor::new(executor_config);
+            .working_dir(project_root)
+            .jobs(self.effective_jobs());
+        let executor = AsyncMutantExecutor::new(executor_config);
 
         let total_files = ctx.files.len();
         let counter = Arc::new(AtomicUsize::new(0));
 
-        // Process files sequentially (mutations need to be applied one at a time per file)
-        let mut file_results = Vec::new();
+        let mut file_results: HashMap<PathBuf, FileResult> = HashMap::new();
+        let mut sources = HashMap::new();
+        let mut mutants_to_execute = Vec::new();
 
         for path in ctx.files.files() {
             let mutants = match generator.generate_for_file(path) {
@@ -423,15 +424,14 @@ impl AnalyzerTrait for Analyzer {
 
             // Get source as string for predictor context
             let source_str = String::from_utf8_lossy(&source);
+            let lines: Vec<&str> = source_str.lines().collect();
 
-            // Execute each mutant
             for mutant in mutants {
                 // Check if we should skip this mutant based on ML prediction
                 if let (Some(threshold), Some(predictor)) =
                     (self.skip_predicted_threshold, &self.predictor)
                 {
                     // Extract context around the mutation (5 lines before and after)
-                    let lines: Vec<&str> = source_str.lines().collect();
                     let line_idx = mutant.line.saturating_sub(1) as usize;
                     let start = line_idx.saturating_sub(5);
                     let end = (line_idx + 6).min(lines.len());
@@ -450,11 +450,35 @@ impl AnalyzerTrait for Analyzer {
                     }
                 }
 
-                let result = match executor.execute_mutant(&mutant, &source) {
-                    Ok(r) => r,
-                    Err(_) => MutationResult::new(mutant, MutantStatus::BuildError, 0),
-                };
+                mutants_to_execute.push(mutant);
+            }
 
+            sources.insert(path.clone(), source);
+            file_results.insert(path.clone(), file_result);
+
+            let current = counter.fetch_add(1, Ordering::Relaxed) + 1;
+            ctx.report_progress(current, total_files);
+        }
+
+        let jobs = self.effective_jobs();
+        let executed_results = std::thread::scope(|scope| {
+            scope
+                .spawn(move || {
+                    let runtime = tokio::runtime::Builder::new_multi_thread()
+                        .worker_threads(jobs)
+                        .enable_all()
+                        .build()
+                        .map_err(|error| {
+                            Error::analysis(format!("Failed to create mutation runtime: {error}"))
+                        })?;
+                    runtime.block_on(executor.execute_mutants(&mutants_to_execute, &sources))
+                })
+                .join()
+        })
+        .map_err(|_| Error::analysis("Mutation executor thread panicked"))??;
+
+        for result in executed_results {
+            if let Some(file_result) = file_results.get_mut(&result.mutant.file_path) {
                 match result.status {
                     MutantStatus::Killed => file_result.killed += 1,
                     MutantStatus::Survived => file_result.survived += 1,
@@ -462,21 +486,26 @@ impl AnalyzerTrait for Analyzer {
                     MutantStatus::BuildError | MutantStatus::Equivalent => file_result.error += 1,
                     MutantStatus::Pending | MutantStatus::Skipped => {}
                 }
-
                 file_result.mutants.push(result);
             }
+        }
 
-            // Calculate score for this file
+        let mut file_results: Vec<FileResult> = file_results.into_values().collect();
+        for file_result in &mut file_results {
+            file_result.mutants.sort_by(|left, right| {
+                left.mutant
+                    .line
+                    .cmp(&right.mutant.line)
+                    .then_with(|| left.mutant.operator.cmp(&right.mutant.operator))
+                    .then_with(|| left.mutant.column.cmp(&right.mutant.column))
+                    .then_with(|| left.mutant.id.cmp(&right.mutant.id))
+            });
             let total_scored = file_result.killed + file_result.survived;
             if total_scored > 0 {
                 file_result.score = file_result.killed as f64 / total_scored as f64;
             }
-
-            file_results.push(file_result);
-
-            let current = counter.fetch_add(1, Ordering::Relaxed) + 1;
-            ctx.report_progress(current, total_files);
         }
+        file_results.sort_by(|left, right| left.path.cmp(&right.path));
 
         let duration = start.elapsed();
         let summary = build_summary(&file_results, duration.as_millis() as u64);

--- a/src/analyzers/ownership.rs
+++ b/src/analyzers/ownership.rs
@@ -138,10 +138,7 @@ impl Analyzer {
             Err(_) => return Ok(None),
         };
 
-        // Filter trivial lines if configured
-        let lines: Vec<_> = blame_info.lines.iter().collect();
-
-        let total_lines = lines.len();
+        let total_lines = blame_info.total_lines as usize;
         if total_lines < self.config.min_lines {
             return Ok(None);
         }

--- a/src/analyzers/repomap.rs
+++ b/src/analyzers/repomap.rs
@@ -431,13 +431,15 @@ impl Analyzer {
         }
 
         let d = self.config.damping;
-        let mut rank: HashMap<NodeIndex, f64> = graph
+        let initial_rank = 1.0 / n as f64;
+        let mut rank = vec![initial_rank; n];
+        let mut new_rank = vec![0.0; n];
+        let out_degrees: Vec<usize> = graph
             .node_indices()
-            .map(|idx| (idx, 1.0 / n as f64))
+            .map(|node| graph.edges_directed(node, Direction::Outgoing).count())
             .collect();
 
         for _ in 0..self.config.max_iterations {
-            let mut new_rank: HashMap<NodeIndex, f64> = HashMap::new();
             let mut diff = 0.0;
 
             for node in graph.node_indices() {
@@ -445,9 +447,9 @@ impl Analyzer {
                     .edges_directed(node, Direction::Incoming)
                     .map(|e| {
                         let source = e.source();
-                        let out_deg = graph.edges_directed(source, Direction::Outgoing).count();
+                        let out_deg = out_degrees[source.index()];
                         if out_deg > 0 {
-                            rank[&source] / out_deg as f64
+                            rank[source.index()] / out_deg as f64
                         } else {
                             0.0
                         }
@@ -455,18 +457,21 @@ impl Analyzer {
                     .sum();
 
                 let new_score = (1.0 - d) / n as f64 + d * incoming;
-                diff += (new_score - rank[&node]).abs();
-                new_rank.insert(node, new_score);
+                diff += (new_score - rank[node.index()]).abs();
+                new_rank[node.index()] = new_score;
             }
 
-            rank = new_rank;
+            std::mem::swap(&mut rank, &mut new_rank);
 
             if diff < self.config.tolerance {
                 break;
             }
         }
 
-        rank
+        graph
+            .node_indices()
+            .map(|node| (node, rank[node.index()]))
+            .collect()
     }
 }
 
@@ -954,6 +959,24 @@ fn bar() {}
         assert!(pagerank[&hub] > pagerank[&a]);
         assert!(pagerank[&hub] > pagerank[&b]);
         assert!(pagerank[&hub] > pagerank[&c]);
+    }
+
+    #[test]
+    fn test_pagerank_pins_asymmetric_fixture_scores() {
+        let analyzer = Analyzer::new();
+        let mut graph: DiGraph<usize, ()> = DiGraph::new();
+        let a = graph.add_node(0);
+        let b = graph.add_node(1);
+        let c = graph.add_node(2);
+        graph.add_edge(a, b, ());
+        graph.add_edge(a, c, ());
+        graph.add_edge(b, c, ());
+
+        let ranks = analyzer.calculate_pagerank(&graph);
+
+        assert!((ranks[&a] - 0.05).abs() < 1e-12);
+        assert!((ranks[&b] - 0.07125).abs() < 1e-12);
+        assert!((ranks[&c] - 0.1318125).abs() < 1e-12);
     }
 
     #[test]

--- a/src/analyzers/tdg.rs
+++ b/src/analyzers/tdg.rs
@@ -14,10 +14,12 @@ use std::collections::HashMap;
 use std::ops::Range;
 use std::path::Path;
 
+use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::analyzers::{hotspot, temporal};
 use crate::core::{AnalysisContext, Analyzer as AnalyzerTrait, Result};
+use crate::parser::Parser;
 
 /// TDG weight configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -404,32 +406,29 @@ impl Analyzer {
     }
 
     fn detect_critical_defects(&self, source: &str, language: Language) -> (i32, bool) {
-        let ts_lang: tree_sitter::Language = match language {
-            Language::Rust => tree_sitter_rust::LANGUAGE.into(),
-            Language::Go => tree_sitter_go::LANGUAGE.into(),
-            Language::Python => tree_sitter_python::LANGUAGE.into(),
-            Language::JavaScript => tree_sitter_javascript::LANGUAGE.into(),
-            Language::TypeScript => tree_sitter_typescript::LANGUAGE_TSX.into(),
-            Language::Java => tree_sitter_java::LANGUAGE.into(),
-            Language::C => tree_sitter_c::LANGUAGE.into(),
-            Language::Cpp => tree_sitter_cpp::LANGUAGE.into(),
-            Language::CSharp => tree_sitter_c_sharp::LANGUAGE.into(),
-            Language::Ruby => tree_sitter_ruby::LANGUAGE.into(),
-            Language::PHP => tree_sitter_php::LANGUAGE_PHP.into(),
+        let parser_language = match language {
+            Language::Rust => crate::core::Language::Rust,
+            Language::Go => crate::core::Language::Go,
+            Language::Python => crate::core::Language::Python,
+            Language::JavaScript => crate::core::Language::JavaScript,
+            Language::TypeScript => crate::core::Language::TypeScript,
+            Language::Java => crate::core::Language::Java,
+            Language::C => crate::core::Language::C,
+            Language::Cpp => crate::core::Language::Cpp,
+            Language::CSharp => crate::core::Language::CSharp,
+            Language::Ruby => crate::core::Language::Ruby,
+            Language::PHP => crate::core::Language::Php,
             Language::Unknown | Language::Swift | Language::Kotlin => return (0, false),
         };
 
-        let mut parser = tree_sitter::Parser::new();
-        if parser.set_language(&ts_lang).is_err() {
-            return (0, false);
-        }
-        let tree = match parser.parse(source.as_bytes(), None) {
-            Some(t) => t,
-            None => return (0, false),
+        let parser = Parser::new();
+        let parsed = match parser.parse(source.as_bytes(), parser_language, Path::new("<tdg>")) {
+            Ok(parsed) => parsed,
+            Err(_) => return (0, false),
         };
 
         let test_ranges = if language == Language::Rust {
-            cfg_test_module_ranges(source)
+            cfg_test_module_ranges(&parsed.tree.root_node(), source)
         } else {
             Vec::new()
         };
@@ -438,7 +437,7 @@ impl Analyzer {
 
         let mut count = 0;
         count_defect_nodes(
-            &tree.root_node(),
+            &parsed.tree.root_node(),
             source.as_bytes(),
             language,
             &test_ranges,
@@ -522,55 +521,55 @@ impl AnalyzerTrait for Analyzer {
         // Run temporal coupling analysis to get per-file coupling counts
         let temporal_scores = self.compute_temporal_scores(ctx);
 
-        let mut scores = Vec::new();
+        let scores: Vec<Score> = ctx
+            .files
+            .files()
+            .par_iter()
+            .filter_map(|path| {
+                let content = String::from_utf8(ctx.read_file(path).ok()?).ok()?;
 
-        for path in ctx.files.iter() {
-            let content = match ctx.read_file(path) {
-                Ok(bytes) => match String::from_utf8(bytes) {
-                    Ok(s) => s,
-                    Err(_) => continue,
-                },
-                Err(_) => continue,
-            };
-
-            if let Some(max_size) = self.max_file_size {
-                if content.len() as u64 > max_size {
-                    continue;
+                if self
+                    .max_file_size
+                    .is_some_and(|max_size| content.len() as u64 > max_size)
+                {
+                    return None;
                 }
-            }
 
-            let file_path = path
-                .strip_prefix(ctx.root)
-                .unwrap_or(path)
-                .to_string_lossy()
-                .to_string();
+                let file_path = path
+                    .strip_prefix(ctx.root)
+                    .unwrap_or(path)
+                    .to_string_lossy()
+                    .to_string();
 
-            let language = Language::from_extension(path);
-            if let Ok(mut score) = self.analyze_source(&content, language, &file_path) {
-                // Apply hotspot score (higher hotspot = more risk = lower score)
-                // Hotspot score ranges 0-1, where 1 is worst (critical hotspot)
-                if let Some(&hs) = hotspot_scores.get(&file_path) {
-                    // Invert: hotspot 0 = full points, hotspot 1 = 0 points
-                    score.hotspot_score = self.weights.hotspot * (1.0 - hs);
+                let language = Language::from_extension(path);
+                if let Ok(mut score) = self.analyze_source(&content, language, &file_path) {
+                    // Apply hotspot score (higher hotspot = more risk = lower score)
+                    // Hotspot score ranges 0-1, where 1 is worst (critical hotspot)
+                    if let Some(&hs) = hotspot_scores.get(&file_path) {
+                        // Invert: hotspot 0 = full points, hotspot 1 = 0 points
+                        score.hotspot_score = self.weights.hotspot * (1.0 - hs);
+                    } else {
+                        // No hotspot data means no penalty (file may be new or not in git)
+                        score.hotspot_score = self.weights.hotspot;
+                    }
+
+                    // Apply temporal coupling score (more couplings = more risk = lower score)
+                    if let Some(&tc) = temporal_scores.get(&file_path) {
+                        // tc is a 0-1 normalized score where 1 = many couplings
+                        score.temporal_coupling_score = self.weights.temporal_coupling * (1.0 - tc);
+                    } else {
+                        // No coupling data means full points
+                        score.temporal_coupling_score = self.weights.temporal_coupling;
+                    }
+
+                    // Recalculate total with updated scores
+                    score.calculate_total();
+                    Some(score)
                 } else {
-                    // No hotspot data means no penalty (file may be new or not in git)
-                    score.hotspot_score = self.weights.hotspot;
+                    None
                 }
-
-                // Apply temporal coupling score (more couplings = more risk = lower score)
-                if let Some(&tc) = temporal_scores.get(&file_path) {
-                    // tc is a 0-1 normalized score where 1 = many couplings
-                    score.temporal_coupling_score = self.weights.temporal_coupling * (1.0 - tc);
-                } else {
-                    // No coupling data means full points
-                    score.temporal_coupling_score = self.weights.temporal_coupling;
-                }
-
-                // Recalculate total with updated scores
-                score.calculate_total();
-                scores.push(score);
-            }
-        }
+            })
+            .collect();
 
         Ok(aggregate_project_score(scores))
     }
@@ -771,26 +770,9 @@ fn match_php_defect(node: &tree_sitter::Node, source: &[u8]) -> bool {
 ///
 /// Performs a full depth-first walk so nested test modules are detected.
 /// Uses a thread-local parser cache to avoid allocating a new parser per file.
-fn cfg_test_module_ranges(source: &str) -> Vec<Range<usize>> {
-    use std::cell::RefCell;
-
-    thread_local! {
-        static RUST_PARSER: RefCell<tree_sitter::Parser> = RefCell::new({
-            let ts_lang: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
-            let mut p = tree_sitter::Parser::new();
-            p.set_language(&ts_lang).expect("built-in Rust grammar");
-            p
-        });
-    }
-
-    let tree = RUST_PARSER.with(|parser| parser.borrow_mut().parse(source.as_bytes(), None));
-    let tree = match tree {
-        Some(t) => t,
-        None => return Vec::new(),
-    };
-
+fn cfg_test_module_ranges(root: &tree_sitter::Node<'_>, source: &str) -> Vec<Range<usize>> {
     let mut ranges = Vec::new();
-    collect_cfg_test_modules(&tree.root_node(), source.as_bytes(), &mut ranges);
+    collect_cfg_test_modules(root, source.as_bytes(), &mut ranges);
     ranges
 }
 

--- a/src/analyzers/temporal.rs
+++ b/src/analyzers/temporal.rs
@@ -134,7 +134,7 @@ impl Analyzer {
             let mut changed_files = Vec::with_capacity(commit.files.len());
             for file in &commit.files {
                 let path = file.path.to_string_lossy();
-                if exclude_tests && is_test_file(&path) {
+                if exclude_tests && is_test_file(&file.path) {
                     continue;
                 }
                 if exclude_globs

--- a/src/analyzers/temporal.rs
+++ b/src/analyzers/temporal.rs
@@ -126,30 +126,40 @@ impl Analyzer {
 
         // Track co-changes: normalized pair -> count
         let mut cochanges: HashMap<FilePair, u32> = HashMap::new();
-        // Track individual file commits: file -> count
-        let mut file_commits: HashMap<String, u32> = HashMap::new();
+        let mut file_paths = Vec::new();
+        let mut file_ids: HashMap<String, u32> = HashMap::new();
+        let mut file_commits = Vec::new();
 
         for commit in &commits {
-            let changed_files: Vec<String> = commit
-                .files
-                .iter()
-                .map(|f| f.path.to_string_lossy().to_string())
-                .filter(|f| {
-                    if exclude_tests && is_test_file(f) {
-                        return false;
-                    }
-                    if let Some(ref gs) = exclude_globs {
-                        if gs.is_match(f) {
-                            return false;
-                        }
-                    }
-                    true
-                })
-                .collect();
+            let mut changed_files = Vec::with_capacity(commit.files.len());
+            for file in &commit.files {
+                let path = file.path.to_string_lossy();
+                if exclude_tests && is_test_file(&path) {
+                    continue;
+                }
+                if exclude_globs
+                    .as_ref()
+                    .is_some_and(|globs| globs.is_match(path.as_ref()))
+                {
+                    continue;
+                }
+
+                let id = if let Some(&id) = file_ids.get(path.as_ref()) {
+                    id
+                } else {
+                    let id = file_paths.len() as u32;
+                    let path = path.into_owned();
+                    file_ids.insert(path.clone(), id);
+                    file_paths.push(path);
+                    file_commits.push(0);
+                    id
+                };
+                changed_files.push(id);
+            }
 
             // Update individual file commit counts
-            for file in &changed_files {
-                *file_commits.entry(file.clone()).or_insert(0) += 1;
+            for &file in &changed_files {
+                file_commits[file as usize] += 1;
             }
 
             // Skip mega-commits (e.g. bulk renames, formatter runs).
@@ -162,7 +172,8 @@ impl Analyzer {
             // Record co-changes for all pairs
             for i in 0..changed_files.len() {
                 for j in (i + 1)..changed_files.len() {
-                    let pair = FilePair::new(&changed_files[i], &changed_files[j]);
+                    let pair =
+                        FilePair::from_paths(changed_files[i], changed_files[j], &file_paths);
                     *cochanges.entry(pair).or_insert(0) += 1;
                 }
             }
@@ -173,14 +184,14 @@ impl Analyzer {
             .into_iter()
             .filter(|(_, count)| *count >= self.config.min_cochanges)
             .map(|(pair, cochange_count)| {
-                let commits_a = file_commits.get(&pair.a).copied().unwrap_or(0);
-                let commits_b = file_commits.get(&pair.b).copied().unwrap_or(0);
+                let commits_a = file_commits[pair.a as usize];
+                let commits_b = file_commits[pair.b as usize];
                 let coupling_strength =
                     calculate_coupling_strength(cochange_count, commits_a, commits_b);
 
                 FileCoupling {
-                    file_a: pair.a,
-                    file_b: pair.b,
+                    file_a: file_paths[pair.a as usize].clone(),
+                    file_b: file_paths[pair.b as usize].clone(),
                     cochange_count,
                     coupling_strength,
                     commits_a,
@@ -197,7 +208,7 @@ impl Analyzer {
         });
 
         let generated_at = Utc::now();
-        let total_files = file_commits.len();
+        let total_files = file_paths.len();
         let summary = calculate_summary(&couplings, total_files);
 
         Ok(Analysis {
@@ -241,23 +252,17 @@ impl AnalyzerTrait for Analyzer {
 /// Represents an unordered pair of files (normalized alphabetically).
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct FilePair {
-    a: String,
-    b: String,
+    a: u32,
+    b: u32,
 }
 
 impl FilePair {
-    /// Creates a normalized file pair (alphabetically ordered).
-    fn new(a: &str, b: &str) -> Self {
-        if a <= b {
-            Self {
-                a: a.to_string(),
-                b: b.to_string(),
-            }
+    /// Creates a pair whose IDs preserve alphabetical path output ordering.
+    fn from_paths(a: u32, b: u32, paths: &[String]) -> Self {
+        if paths[a as usize] <= paths[b as usize] {
+            Self { a, b }
         } else {
-            Self {
-                a: b.to_string(),
-                b: a.to_string(),
-            }
+            Self { a: b, b: a }
         }
     }
 }
@@ -398,18 +403,20 @@ mod tests {
 
     #[test]
     fn test_file_pair_normalization() {
-        let pair1 = FilePair::new("b.rs", "a.rs");
-        let pair2 = FilePair::new("a.rs", "b.rs");
-        assert_eq!(pair1.a, "a.rs");
-        assert_eq!(pair1.b, "b.rs");
+        let paths = vec!["b.rs".to_string(), "a.rs".to_string()];
+        let pair1 = FilePair::from_paths(0, 1, &paths);
+        let pair2 = FilePair::from_paths(1, 0, &paths);
+        assert_eq!(pair1.a, 1);
+        assert_eq!(pair1.b, 0);
         assert_eq!(pair1, pair2);
     }
 
     #[test]
     fn test_file_pair_same_order() {
-        let pair = FilePair::new("a.rs", "z.rs");
-        assert_eq!(pair.a, "a.rs");
-        assert_eq!(pair.b, "z.rs");
+        let paths = vec!["z.rs".to_string(), "a.rs".to_string()];
+        let pair = FilePair::from_paths(0, 1, &paths);
+        assert_eq!(pair.a, 1);
+        assert_eq!(pair.b, 0);
     }
 
     #[test]
@@ -604,8 +611,9 @@ mod tests {
         use std::collections::hash_map::DefaultHasher;
         use std::hash::{Hash, Hasher};
 
-        let pair1 = FilePair::new("z.rs", "a.rs");
-        let pair2 = FilePair::new("a.rs", "z.rs");
+        let paths = vec!["z.rs".to_string(), "a.rs".to_string()];
+        let pair1 = FilePair::from_paths(0, 1, &paths);
+        let pair2 = FilePair::from_paths(1, 0, &paths);
 
         let mut hasher1 = DefaultHasher::new();
         pair1.hash(&mut hasher1);

--- a/src/core/language.rs
+++ b/src/core/language.rs
@@ -33,22 +33,40 @@ impl Language {
 
     /// Get language from file extension.
     pub fn from_extension(ext: &str) -> Option<Self> {
-        match ext.to_lowercase().as_str() {
-            "go" => Some(Self::Go),
-            "rs" => Some(Self::Rust),
-            "py" | "pyi" => Some(Self::Python),
-            "ts" | "mts" | "cts" => Some(Self::TypeScript),
-            "js" | "mjs" | "cjs" => Some(Self::JavaScript),
-            "tsx" => Some(Self::Tsx),
-            "jsx" => Some(Self::Jsx),
-            "java" => Some(Self::Java),
-            "c" | "h" => Some(Self::C),
-            "cpp" | "cc" | "cxx" | "hpp" | "hxx" | "hh" => Some(Self::Cpp),
-            "cs" => Some(Self::CSharp),
-            "rb" | "rake" | "gemspec" => Some(Self::Ruby),
-            "php" => Some(Self::Php),
-            "sh" | "bash" => Some(Self::Bash),
-            _ => None,
+        let matches = |candidate| ext.eq_ignore_ascii_case(candidate);
+        if matches("go") {
+            Some(Self::Go)
+        } else if matches("rs") {
+            Some(Self::Rust)
+        } else if matches("py") || matches("pyi") {
+            Some(Self::Python)
+        } else if matches("ts") || matches("mts") || matches("cts") {
+            Some(Self::TypeScript)
+        } else if matches("js") || matches("mjs") || matches("cjs") {
+            Some(Self::JavaScript)
+        } else if matches("tsx") {
+            Some(Self::Tsx)
+        } else if matches("jsx") {
+            Some(Self::Jsx)
+        } else if matches("java") {
+            Some(Self::Java)
+        } else if matches("c") || matches("h") {
+            Some(Self::C)
+        } else if ["cpp", "cc", "cxx", "hpp", "hxx", "hh"]
+            .iter()
+            .any(|candidate| matches(candidate))
+        {
+            Some(Self::Cpp)
+        } else if matches("cs") {
+            Some(Self::CSharp)
+        } else if matches("rb") || matches("rake") || matches("gemspec") {
+            Some(Self::Ruby)
+        } else if matches("php") {
+            Some(Self::Php)
+        } else if matches("sh") || matches("bash") {
+            Some(Self::Bash)
+        } else {
+            None
         }
     }
 

--- a/src/git/blame.rs
+++ b/src/git/blame.rs
@@ -13,23 +13,10 @@ use crate::core::{Error, Result};
 pub struct BlameInfo {
     /// File path.
     pub path: String,
-    /// Lines with their authors.
-    pub lines: Vec<BlameLine>,
+    /// Total number of blamed lines.
+    pub total_lines: u32,
     /// Aggregated author statistics.
     pub authors: HashMap<String, AuthorStats>,
-}
-
-/// A single line with blame information.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BlameLine {
-    /// Line number (1-indexed).
-    pub line: u32,
-    /// Author name.
-    pub author: String,
-    /// Commit SHA.
-    pub sha: String,
-    /// Commit timestamp.
-    pub timestamp: i64,
 }
 
 /// Statistics for an author.
@@ -74,69 +61,48 @@ pub fn get_blame(_repo: &Repository, root: &Path, path: &Path) -> Result<BlameIn
 fn parse_line_porcelain(output: &[u8], path: &Path) -> Result<BlameInfo> {
     let text = String::from_utf8_lossy(output);
 
-    let mut lines = Vec::new();
-    let mut author_lines: HashMap<String, Vec<i64>> = HashMap::new();
-
-    let mut current_sha = String::new();
-    let mut current_author = String::new();
+    let mut total_lines = 0u32;
+    let mut authors: HashMap<String, AuthorStats> = HashMap::new();
+    let mut current_author = "";
     let mut current_timestamp: i64 = 0;
-    let mut current_line_num: u32 = 0;
 
     for line in text.lines() {
         if line.starts_with('\t') {
             // Content line - marks end of a blame entry
-            lines.push(BlameLine {
-                line: current_line_num,
-                author: current_author.clone(),
-                sha: current_sha.clone(),
-                timestamp: current_timestamp,
-            });
-            author_lines
-                .entry(current_author.clone())
-                .or_default()
-                .push(current_timestamp);
+            total_lines += 1;
+            if let Some(stats) = authors.get_mut(current_author) {
+                stats.lines += 1;
+                stats.first_commit = stats.first_commit.min(current_timestamp);
+                stats.last_commit = stats.last_commit.max(current_timestamp);
+            } else {
+                authors.insert(
+                    current_author.to_string(),
+                    AuthorStats {
+                        lines: 1,
+                        percentage: 0.0,
+                        first_commit: current_timestamp,
+                        last_commit: current_timestamp,
+                    },
+                );
+            }
         } else if let Some(rest) = line.strip_prefix("author ") {
-            current_author = rest.to_string();
+            current_author = rest;
         } else if let Some(rest) = line.strip_prefix("author-time ") {
             current_timestamp = rest.parse().unwrap_or(0);
-        } else if line.len() >= 40 && line.as_bytes()[0].is_ascii_hexdigit() {
-            // Header line: <sha> <orig-line> <final-line> [<num-lines>]
-            let parts: Vec<&str> = line.splitn(4, ' ').collect();
-            if parts.len() >= 3 {
-                current_sha = parts[0].to_string();
-                current_line_num = parts[2].parse().unwrap_or(0);
-            }
         }
     }
 
-    let total_lines = lines.len() as f64;
-    let mut authors = HashMap::new();
-
-    for (name, timestamps) in author_lines {
-        let line_count = timestamps.len() as u32;
-        let percentage = if total_lines > 0.0 {
-            (line_count as f64 / total_lines) * 100.0
+    for stats in authors.values_mut() {
+        stats.percentage = if total_lines > 0 {
+            (f64::from(stats.lines) / f64::from(total_lines)) * 100.0
         } else {
             0.0
         };
-
-        let first_commit = timestamps.iter().min().copied().unwrap_or(0);
-        let last_commit = timestamps.iter().max().copied().unwrap_or(0);
-
-        authors.insert(
-            name,
-            AuthorStats {
-                lines: line_count,
-                percentage,
-                first_commit,
-                last_commit,
-            },
-        );
     }
 
     Ok(BlameInfo {
         path: path.to_string_lossy().to_string(),
-        lines,
+        total_lines,
         authors,
     })
 }
@@ -175,7 +141,7 @@ mod tests {
     fn test_bus_factor_empty() {
         let info = BlameInfo {
             path: "test.rs".to_string(),
-            lines: Vec::new(),
+            total_lines: 0,
             authors: HashMap::new(),
         };
         assert_eq!(info.bus_factor(), 0);
@@ -214,7 +180,7 @@ mod tests {
 
         let info = BlameInfo {
             path: "test.rs".to_string(),
-            lines: Vec::new(),
+            total_lines: 100,
             authors,
         };
 
@@ -245,7 +211,7 @@ mod tests {
 
         let info = BlameInfo {
             path: "test.rs".to_string(),
-            lines: Vec::new(),
+            total_lines: 100,
             authors,
         };
 
@@ -269,7 +235,7 @@ mod tests {
 
         let info = BlameInfo {
             path: "test.rs".to_string(),
-            lines: Vec::new(),
+            total_lines: 80,
             authors,
         };
 
@@ -280,25 +246,11 @@ mod tests {
     fn test_ownership_ratio_empty() {
         let info = BlameInfo {
             path: "test.rs".to_string(),
-            lines: Vec::new(),
+            total_lines: 0,
             authors: HashMap::new(),
         };
 
         assert!((info.ownership_ratio()).abs() < 0.001);
-    }
-
-    #[test]
-    fn test_blame_line_struct() {
-        let line = BlameLine {
-            line: 42,
-            author: "Alice".to_string(),
-            sha: "abc123def456".to_string(),
-            timestamp: 1700000000,
-        };
-        assert_eq!(line.line, 42);
-        assert_eq!(line.author, "Alice");
-        assert_eq!(line.sha, "abc123def456");
-        assert_eq!(line.timestamp, 1700000000);
     }
 
     #[test]
@@ -355,7 +307,7 @@ mod tests {
         let blame = result.unwrap();
 
         // Verify blame results
-        assert_eq!(blame.lines.len(), 3); // 3 lines in the file
+        assert_eq!(blame.total_lines, 3); // 3 lines in the file
         assert_eq!(blame.authors.len(), 1); // 1 author
         assert!(blame.authors.contains_key("Test Author"));
 
@@ -414,7 +366,7 @@ mod tests {
 
         // Verify we have at least one author
         assert!(!blame.authors.is_empty());
-        assert_eq!(blame.lines.len(), 4); // 4 lines in the updated file
+        assert_eq!(blame.total_lines, 4); // 4 lines in the updated file
     }
 
     #[test]
@@ -432,18 +384,13 @@ mod tests {
 
         let info = BlameInfo {
             path: "test.rs".to_string(),
-            lines: vec![BlameLine {
-                line: 1,
-                author: "Alice".to_string(),
-                sha: "abc123".to_string(),
-                timestamp: 1500,
-            }],
+            total_lines: 50,
             authors,
         };
 
         let json = serde_json::to_string(&info).unwrap();
         assert!(json.contains("\"path\":\"test.rs\""));
-        assert!(json.contains("\"author\":\"Alice\""));
+        assert!(json.contains("\"total_lines\":50"));
         assert!(json.contains("\"lines\":50"));
     }
 }

--- a/src/semantic/cache.rs
+++ b/src/semantic/cache.rs
@@ -5,13 +5,99 @@
 
 use std::path::Path;
 
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{params, Connection, OptionalExtension, Transaction};
 
 use crate::core::{Error, Result};
 
 /// SQLite cache for semantic search symbols.
 pub struct EmbeddingCache {
     conn: Connection,
+}
+
+const UPSERT_SYMBOL_SQL: &str = r#"
+    INSERT INTO symbols (file_path, symbol_name, symbol_type, parent_name, signature, start_line, end_line, chunk_index, total_chunks, content_hash, enriched_text, cyclomatic_complexity, cognitive_complexity)
+    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+    ON CONFLICT(file_path, symbol_name, chunk_index) DO UPDATE SET
+        symbol_type = excluded.symbol_type,
+        parent_name = excluded.parent_name,
+        signature = excluded.signature,
+        start_line = excluded.start_line,
+        end_line = excluded.end_line,
+        total_chunks = excluded.total_chunks,
+        content_hash = excluded.content_hash,
+        enriched_text = excluded.enriched_text,
+        cyclomatic_complexity = excluded.cyclomatic_complexity,
+        cognitive_complexity = excluded.cognitive_complexity,
+        created_at = CURRENT_TIMESTAMP
+"#;
+
+const RECORD_FILE_SQL: &str = r#"
+    INSERT INTO files (file_path, file_hash)
+    VALUES (?1, ?2)
+    ON CONFLICT(file_path) DO UPDATE SET
+        file_hash = excluded.file_hash,
+        indexed_at = CURRENT_TIMESTAMP
+"#;
+
+fn upsert_symbol_on(conn: &Connection, symbol: &CachedSymbol) -> Result<()> {
+    conn.prepare_cached(UPSERT_SYMBOL_SQL)
+        .and_then(|mut stmt| {
+            stmt.execute(params![
+                symbol.file_path,
+                symbol.symbol_name,
+                symbol.symbol_type,
+                symbol.parent_name,
+                symbol.signature,
+                symbol.start_line,
+                symbol.end_line,
+                symbol.chunk_index,
+                symbol.total_chunks,
+                symbol.content_hash,
+                symbol.enriched_text,
+                symbol.cyclomatic_complexity,
+                symbol.cognitive_complexity,
+            ])
+        })
+        .map_err(|e| Error::analysis(format!("Failed to upsert symbol: {e}")))?;
+    Ok(())
+}
+
+fn delete_file_symbols_on(conn: &Connection, file_path: &str) -> Result<()> {
+    conn.prepare_cached("DELETE FROM symbols WHERE file_path = ?1")
+        .and_then(|mut stmt| stmt.execute(params![file_path]))
+        .map_err(|e| Error::analysis(format!("Failed to delete symbols: {e}")))?;
+    Ok(())
+}
+
+fn record_file_indexed_on(conn: &Connection, file_path: &str, file_hash: &str) -> Result<()> {
+    conn.prepare_cached(RECORD_FILE_SQL)
+        .and_then(|mut stmt| stmt.execute(params![file_path, file_hash]))
+        .map_err(|e| Error::analysis(format!("Failed to record file indexed: {e}")))?;
+    Ok(())
+}
+
+pub(crate) struct CacheTransaction<'connection> {
+    transaction: Transaction<'connection>,
+}
+
+impl CacheTransaction<'_> {
+    pub(crate) fn upsert_symbol(&self, symbol: &CachedSymbol) -> Result<()> {
+        upsert_symbol_on(&self.transaction, symbol)
+    }
+
+    pub(crate) fn delete_file_symbols(&self, file_path: &str) -> Result<()> {
+        delete_file_symbols_on(&self.transaction, file_path)
+    }
+
+    pub(crate) fn record_file_indexed(&self, file_path: &str, file_hash: &str) -> Result<()> {
+        record_file_indexed_on(&self.transaction, file_path, file_hash)
+    }
+
+    pub(crate) fn commit(self) -> Result<()> {
+        self.transaction
+            .commit()
+            .map_err(|e| Error::analysis(format!("Failed to commit cache transaction: {e}")))
+    }
 }
 
 /// A cached symbol with its enriched text for TF-IDF search.
@@ -60,6 +146,8 @@ impl EmbeddingCache {
                 e
             ))
         })?;
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;")
+            .map_err(|e| Error::analysis(format!("Failed to configure cache database: {e}")))?;
 
         let cache = Self { conn };
         cache.migrate_if_needed()?;
@@ -71,6 +159,8 @@ impl EmbeddingCache {
     pub fn in_memory() -> Result<Self> {
         let conn = Connection::open_in_memory()
             .map_err(|e| Error::analysis(format!("Failed to create in-memory database: {}", e)))?;
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;")
+            .map_err(|e| Error::analysis(format!("Failed to configure cache database: {e}")))?;
 
         let cache = Self { conn };
         cache.init_schema()?;
@@ -148,43 +238,15 @@ impl EmbeddingCache {
 
     /// Insert or update a symbol in the cache.
     pub fn upsert_symbol(&self, symbol: &CachedSymbol) -> Result<()> {
-        self.conn
-            .execute(
-                r#"
-                INSERT INTO symbols (file_path, symbol_name, symbol_type, parent_name, signature, start_line, end_line, chunk_index, total_chunks, content_hash, enriched_text, cyclomatic_complexity, cognitive_complexity)
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
-                ON CONFLICT(file_path, symbol_name, chunk_index) DO UPDATE SET
-                    symbol_type = excluded.symbol_type,
-                    parent_name = excluded.parent_name,
-                    signature = excluded.signature,
-                    start_line = excluded.start_line,
-                    end_line = excluded.end_line,
-                    total_chunks = excluded.total_chunks,
-                    content_hash = excluded.content_hash,
-                    enriched_text = excluded.enriched_text,
-                    cyclomatic_complexity = excluded.cyclomatic_complexity,
-                    cognitive_complexity = excluded.cognitive_complexity,
-                    created_at = CURRENT_TIMESTAMP
-            "#,
-                params![
-                    symbol.file_path,
-                    symbol.symbol_name,
-                    symbol.symbol_type,
-                    symbol.parent_name,
-                    symbol.signature,
-                    symbol.start_line,
-                    symbol.end_line,
-                    symbol.chunk_index,
-                    symbol.total_chunks,
-                    symbol.content_hash,
-                    symbol.enriched_text,
-                    symbol.cyclomatic_complexity,
-                    symbol.cognitive_complexity,
-                ],
-            )
-            .map_err(|e| Error::analysis(format!("Failed to upsert symbol: {}", e)))?;
+        upsert_symbol_on(&self.conn, symbol)
+    }
 
-        Ok(())
+    pub(crate) fn transaction(&self) -> Result<CacheTransaction<'_>> {
+        let transaction = self
+            .conn
+            .unchecked_transaction()
+            .map_err(|e| Error::analysis(format!("Failed to start cache transaction: {e}")))?;
+        Ok(CacheTransaction { transaction })
     }
 
     /// Get a symbol from the cache by file path, symbol name, and chunk index.
@@ -196,12 +258,13 @@ impl EmbeddingCache {
     ) -> Result<Option<CachedSymbol>> {
         let result = self
             .conn
-            .query_row(
+            .prepare_cached(
                 "SELECT file_path, symbol_name, symbol_type, parent_name, signature, start_line, end_line, chunk_index, total_chunks, content_hash, enriched_text, cyclomatic_complexity, cognitive_complexity FROM symbols WHERE file_path = ?1 AND symbol_name = ?2 AND chunk_index = ?3",
-                params![file_path, symbol_name, chunk_index],
-                row_to_symbol,
             )
-            .optional()
+            .and_then(|mut stmt| {
+                stmt.query_row(params![file_path, symbol_name, chunk_index], row_to_symbol)
+                    .optional()
+            })
             .map_err(|e| Error::analysis(format!("Failed to get symbol: {}", e)))?;
 
         Ok(result)
@@ -211,7 +274,7 @@ impl EmbeddingCache {
     pub fn get_all_symbols(&self) -> Result<Vec<CachedSymbol>> {
         let mut stmt = self
             .conn
-            .prepare("SELECT file_path, symbol_name, symbol_type, parent_name, signature, start_line, end_line, chunk_index, total_chunks, content_hash, enriched_text, cyclomatic_complexity, cognitive_complexity FROM symbols")
+            .prepare_cached("SELECT file_path, symbol_name, symbol_type, parent_name, signature, start_line, end_line, chunk_index, total_chunks, content_hash, enriched_text, cyclomatic_complexity, cognitive_complexity FROM symbols")
             .map_err(|e| Error::analysis(format!("Failed to prepare query: {}", e)))?;
 
         let symbols = stmt
@@ -227,7 +290,7 @@ impl EmbeddingCache {
     pub fn get_symbols_for_file(&self, file_path: &str) -> Result<Vec<CachedSymbol>> {
         let mut stmt = self
             .conn
-            .prepare("SELECT file_path, symbol_name, symbol_type, parent_name, signature, start_line, end_line, chunk_index, total_chunks, content_hash, enriched_text, cyclomatic_complexity, cognitive_complexity FROM symbols WHERE file_path = ?1")
+            .prepare_cached("SELECT file_path, symbol_name, symbol_type, parent_name, signature, start_line, end_line, chunk_index, total_chunks, content_hash, enriched_text, cyclomatic_complexity, cognitive_complexity FROM symbols WHERE file_path = ?1")
             .map_err(|e| Error::analysis(format!("Failed to prepare query: {}", e)))?;
 
         let symbols = stmt
@@ -241,42 +304,23 @@ impl EmbeddingCache {
 
     /// Delete all symbols for a file.
     pub fn delete_file_symbols(&self, file_path: &str) -> Result<()> {
-        self.conn
-            .execute(
-                "DELETE FROM symbols WHERE file_path = ?1",
-                params![file_path],
-            )
-            .map_err(|e| Error::analysis(format!("Failed to delete symbols: {}", e)))?;
-        Ok(())
+        delete_file_symbols_on(&self.conn, file_path)
     }
 
     /// Record that a file has been indexed.
     pub fn record_file_indexed(&self, file_path: &str, file_hash: &str) -> Result<()> {
-        self.conn
-            .execute(
-                r#"
-                INSERT INTO files (file_path, file_hash)
-                VALUES (?1, ?2)
-                ON CONFLICT(file_path) DO UPDATE SET
-                    file_hash = excluded.file_hash,
-                    indexed_at = CURRENT_TIMESTAMP
-            "#,
-                params![file_path, file_hash],
-            )
-            .map_err(|e| Error::analysis(format!("Failed to record file indexed: {}", e)))?;
-        Ok(())
+        record_file_indexed_on(&self.conn, file_path, file_hash)
     }
 
     /// Get the stored hash for a file.
     pub fn get_file_hash(&self, file_path: &str) -> Result<Option<String>> {
         let result = self
             .conn
-            .query_row(
-                "SELECT file_hash FROM files WHERE file_path = ?1",
-                params![file_path],
-                |row| row.get(0),
-            )
-            .optional()
+            .prepare_cached("SELECT file_hash FROM files WHERE file_path = ?1")
+            .and_then(|mut stmt| {
+                stmt.query_row(params![file_path], |row| row.get(0))
+                    .optional()
+            })
             .map_err(|e| Error::analysis(format!("Failed to get file hash: {}", e)))?;
 
         Ok(result)
@@ -285,7 +329,8 @@ impl EmbeddingCache {
     /// Remove a file from the files table.
     pub fn remove_file(&self, file_path: &str) -> Result<()> {
         self.conn
-            .execute("DELETE FROM files WHERE file_path = ?1", params![file_path])
+            .prepare_cached("DELETE FROM files WHERE file_path = ?1")
+            .and_then(|mut stmt| stmt.execute(params![file_path]))
             .map_err(|e| Error::analysis(format!("Failed to remove file: {}", e)))?;
         self.delete_file_symbols(file_path)?;
         Ok(())
@@ -295,7 +340,7 @@ impl EmbeddingCache {
     pub fn get_all_indexed_files(&self) -> Result<Vec<String>> {
         let mut stmt = self
             .conn
-            .prepare("SELECT file_path FROM files")
+            .prepare_cached("SELECT file_path FROM files")
             .map_err(|e| Error::analysis(format!("Failed to prepare query: {}", e)))?;
 
         let files = stmt
@@ -311,7 +356,8 @@ impl EmbeddingCache {
     pub fn symbol_count(&self) -> Result<usize> {
         let count: i64 = self
             .conn
-            .query_row("SELECT COUNT(*) FROM symbols", [], |row| row.get(0))
+            .prepare_cached("SELECT COUNT(*) FROM symbols")
+            .and_then(|mut stmt| stmt.query_row([], |row| row.get(0)))
             .map_err(|e| Error::analysis(format!("Failed to count symbols: {}", e)))?;
         Ok(count as usize)
     }

--- a/src/semantic/sync.rs
+++ b/src/semantic/sync.rs
@@ -21,7 +21,6 @@ use super::cache::{CachedSymbol, EmbeddingCache};
 use super::chunking::{extract_chunks, format_chunk_text, Chunk};
 
 /// Intermediate structure for a parsed chunk ready for caching.
-#[derive(Clone)]
 struct ParsedChunk {
     file_path: String,
     symbol_name: String,
@@ -125,7 +124,7 @@ impl<'a> SyncManager<'a> {
         let root = root_path.to_path_buf();
         let parse_counter = Arc::new(AtomicUsize::new(0));
 
-        let parsed_files: Vec<_> = files_to_index
+        let mut parsed_files: Vec<_> = files_to_index
             .par_iter()
             .filter_map(|path| {
                 let result = match parse_file(path, &root) {
@@ -151,22 +150,24 @@ impl<'a> SyncManager<'a> {
 
         // Collect all chunks
         let mut all_chunks: Vec<ParsedChunk> = Vec::new();
-        for parsed_file in &parsed_files {
-            all_chunks.extend(parsed_file.chunks.iter().cloned());
+        for parsed_file in &mut parsed_files {
+            all_chunks.append(&mut parsed_file.chunks);
         }
+        let chunk_count = all_chunks.len();
+        let transaction = self.cache.transaction()?;
 
         // Delete existing symbols for all files being re-indexed (must happen
         // before the empty check so that removed functions don't persist).
         for parsed_file in &parsed_files {
-            self.cache.delete_file_symbols(&parsed_file.rel_path)?;
+            transaction.delete_file_symbols(&parsed_file.rel_path)?;
         }
 
         if all_chunks.is_empty() {
             for parsed_file in &parsed_files {
-                self.cache
-                    .record_file_indexed(&parsed_file.rel_path, &parsed_file.file_hash)?;
+                transaction.record_file_indexed(&parsed_file.rel_path, &parsed_file.file_hash)?;
                 stats.indexed += 1;
             }
+            transaction.commit()?;
             return Ok(stats);
         }
 
@@ -179,23 +180,23 @@ impl<'a> SyncManager<'a> {
             bar
         });
 
-        for (i, chunk) in all_chunks.iter().enumerate() {
+        for (i, chunk) in all_chunks.into_iter().enumerate() {
             let cached_symbol = CachedSymbol {
-                file_path: chunk.file_path.clone(),
-                symbol_name: chunk.symbol_name.clone(),
-                symbol_type: chunk.symbol_type.clone(),
-                parent_name: chunk.parent_name.clone(),
-                signature: chunk.signature.clone(),
+                file_path: chunk.file_path,
+                symbol_name: chunk.symbol_name,
+                symbol_type: chunk.symbol_type,
+                parent_name: chunk.parent_name,
+                signature: chunk.signature,
                 start_line: chunk.start_line,
                 end_line: chunk.end_line,
                 chunk_index: chunk.chunk_index,
                 total_chunks: chunk.total_chunks,
-                content_hash: chunk.content_hash.clone(),
-                enriched_text: chunk.enriched_text.clone(),
+                content_hash: chunk.content_hash,
+                enriched_text: chunk.enriched_text,
                 cyclomatic_complexity: chunk.cyclomatic_complexity,
                 cognitive_complexity: chunk.cognitive_complexity,
             };
-            self.cache.upsert_symbol(&cached_symbol)?;
+            transaction.upsert_symbol(&cached_symbol)?;
 
             if let Some(ref bar) = write_bar {
                 bar.set_position((i + 1) as u64);
@@ -208,11 +209,11 @@ impl<'a> SyncManager<'a> {
 
         // Record all files as indexed
         for parsed_file in &parsed_files {
-            self.cache
-                .record_file_indexed(&parsed_file.rel_path, &parsed_file.file_hash)?;
+            transaction.record_file_indexed(&parsed_file.rel_path, &parsed_file.file_hash)?;
             stats.indexed += 1;
-            stats.symbols += parsed_file.chunks.len();
         }
+        stats.symbols = chunk_count;
+        transaction.commit()?;
 
         stats.errors = files_to_index.len() - parsed_files.len();
 


### PR DESCRIPTION
## Summary

Targeted hot-loop, algorithm, and memory optimizations across the heaviest analyzers, with output equivalence verified against the baseline.

- **git blame** stores only line count + per-author aggregates (drops ~per-line String allocations)
- **mutation** shares one `Arc<Vec<u8>>` per file, hoists line parsing, runs mutants in parallel via `effective_jobs()` (same-file mutants serialized, results deterministically sorted)
- **PageRank** precomputes out-degrees and reuses `Vec` buffers (repomap + graph)
- **betweenness** uses `Vec` scratch state with rayon fold/reduce
- **tdg** parses in parallel through the thread-local parser
- **duplicates** iterative union-find (union by size), no `Vec<char>`/speculative operator Strings, dead field removed
- **temporal** interns paths as `u32` ids
- **semantic index** WAL + `synchronous=NORMAL`, cached statements, single sync transaction
- language/cohesion/flag allocation cleanups

## Benchmarks (criterion, this repo)

| Benchmark | Before | After | Delta |
|---|---:|---:|---:|
| tdg/50 | 11.43 ms | 1.25 ms | **-89%** |
| duplicates/10 | 3.95 ms | 0.53 ms | **-87%** |
| complexity/10 | 1.81 ms | 0.63 ms | **-65%** |
| temporal/30 | 32.75 ms | 16.45 ms | **-50%** |
| temporal/10 | 21.70 ms | 12.38 ms | -43% |
| repomap/49 | 1.65 ms | 1.33 ms | -19% |
| ownership/30 | 7.35 ms | 6.43 ms | -13% |

Outputs verified equivalent (duplicates: identical 4439 pairs/180 groups; temporal/repomap/tdg/ownership exact; betweenness within 1 ULP from fold/reduce order). **BLAKE3 was kept over xxh3** because xxh3 changed clone membership — accuracy takes priority over the suggested micro-opt.

## Verification

`cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (1832 unit + 46 integration + property/doc) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)