### PR TITLE
Fix code-review findings from the security/perf work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,10 +100,14 @@ jobs:
   audit:
     name: Security audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable

--- a/src/analyzers/mutation/safety.rs
+++ b/src/analyzers/mutation/safety.rs
@@ -8,15 +8,17 @@ use std::fs::{self, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{LazyLock, OnceLock};
+use std::sync::{Arc, LazyLock, OnceLock};
 use std::time::Duration;
 
 use crate::core::{Error, Result};
 
 /// Global counter for generating unique temp file names across threads.
 static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
-static ACTIVE_MUTATIONS: LazyLock<parking_lot::Mutex<HashMap<PathBuf, Vec<u8>>>> =
-    LazyLock::new(|| parking_lot::Mutex::new(HashMap::new()));
+type ActiveMutations = Arc<parking_lot::Mutex<HashMap<PathBuf, Vec<u8>>>>;
+
+static ACTIVE_MUTATIONS: LazyLock<ActiveMutations> =
+    LazyLock::new(|| Arc::new(parking_lot::Mutex::new(HashMap::new())));
 static SIGNAL_HANDLER: OnceLock<std::result::Result<(), String>> = OnceLock::new();
 static INTERRUPTED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
@@ -76,6 +78,8 @@ pub struct MutationGuard {
     original: Vec<u8>,
     /// Whether the file has been modified.
     modified: bool,
+    active_mutations: ActiveMutations,
+    interrupted: Option<Arc<std::sync::atomic::AtomicBool>>,
 }
 
 impl MutationGuard {
@@ -83,6 +87,14 @@ impl MutationGuard {
     ///
     /// Reads and stores the original file content for later restoration.
     pub fn new(path: impl AsRef<Path>) -> Result<Self> {
+        Self::new_with_state(path, Arc::clone(&ACTIVE_MUTATIONS), None)
+    }
+
+    fn new_with_state(
+        path: impl AsRef<Path>,
+        active_mutations: ActiveMutations,
+        interrupted: Option<Arc<std::sync::atomic::AtomicBool>>,
+    ) -> Result<Self> {
         let path = path.as_ref().to_path_buf();
         let original = fs::read(&path).map_err(Error::Io)?;
 
@@ -90,14 +102,26 @@ impl MutationGuard {
             path,
             original,
             modified: false,
+            active_mutations,
+            interrupted,
         })
+    }
+
+    fn is_interrupted(&self) -> bool {
+        self.interrupted
+            .as_deref()
+            .unwrap_or(&INTERRUPTED)
+            .load(Ordering::SeqCst)
     }
 
     /// Apply a mutation to the file.
     ///
     /// This writes the mutated content to the file atomically.
     pub fn apply(&mut self, content: &[u8]) -> Result<()> {
-        let mut active = ACTIVE_MUTATIONS.lock();
+        let mut active = self.active_mutations.lock();
+        if self.is_interrupted() {
+            return Ok(());
+        }
         active.insert(self.path.clone(), self.original.clone());
         if let Err(error) = atomic_write(&self.path, content) {
             active.remove(&self.path);
@@ -130,7 +154,7 @@ impl MutationGuard {
         if self.modified {
             atomic_write(&self.path, &self.original)?;
             self.modified = false;
-            ACTIVE_MUTATIONS.lock().remove(&self.path);
+            self.active_mutations.lock().remove(&self.path);
         }
         Ok(())
     }
@@ -164,15 +188,23 @@ impl Drop for MutationGuard {
                 let _ = fs::write(&self.path, &self.original);
             }
         }
-        ACTIVE_MUTATIONS.lock().remove(&self.path);
+        self.active_mutations.lock().remove(&self.path);
+    }
+}
+
+fn restore_registered_mutations(
+    active_mutations: &parking_lot::Mutex<HashMap<PathBuf, Vec<u8>>>,
+    interrupted: &std::sync::atomic::AtomicBool,
+) {
+    interrupted.store(true, Ordering::SeqCst);
+    let active = active_mutations.lock();
+    for (path, original) in active.iter() {
+        let _ = atomic_write(path, original);
     }
 }
 
 pub fn restore_active_mutations() {
-    let active = ACTIVE_MUTATIONS.lock();
-    for (path, original) in active.iter() {
-        let _ = atomic_write(path, original);
-    }
+    restore_registered_mutations(&ACTIVE_MUTATIONS, &INTERRUPTED);
 }
 
 pub fn install_signal_handler() -> Result<()> {
@@ -431,14 +463,39 @@ mod tests {
 
     #[test]
     fn test_restore_active_mutations_restores_modified_files() {
+        let active_mutations = Arc::new(parking_lot::Mutex::new(HashMap::new()));
+        let interrupted = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let temp_dir = TempDir::new().unwrap();
         let file_path = temp_dir.path().join("test.rs");
         fs::write(&file_path, b"original").unwrap();
-        let mut guard = MutationGuard::new(&file_path).unwrap();
+        let mut guard = MutationGuard::new_with_state(
+            &file_path,
+            Arc::clone(&active_mutations),
+            Some(Arc::clone(&interrupted)),
+        )
+        .unwrap();
         guard.apply(b"mutated").unwrap();
 
-        restore_active_mutations();
+        restore_registered_mutations(&active_mutations, &interrupted);
 
+        assert_eq!(fs::read(&file_path).unwrap(), b"original");
+        guard.apply(b"mutated again").unwrap();
+        assert_eq!(fs::read(&file_path).unwrap(), b"original");
+    }
+
+    #[test]
+    fn test_mutation_guard_apply_is_noop_after_interrupt() {
+        let active_mutations = Arc::new(parking_lot::Mutex::new(HashMap::new()));
+        let interrupted = Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("test.rs");
+        fs::write(&file_path, b"original").unwrap();
+        let mut guard =
+            MutationGuard::new_with_state(&file_path, active_mutations, Some(interrupted)).unwrap();
+
+        guard.apply(b"mutated").unwrap();
+
+        assert!(!guard.is_modified());
         assert_eq!(fs::read(&file_path).unwrap(), b"original");
     }
 

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -40,9 +40,9 @@ fn ensure_secure_clone_base(path: &Path) -> Result<()> {
             path.display()
         )));
     }
-    if metadata.mode() & 0o002 != 0 {
+    if metadata.mode() & 0o077 != 0 {
         return Err(Error::Remote(format!(
-            "Clone base '{}' must not be world-writable",
+            "Clone base '{}' must not grant permissions to group or other users",
             path.display()
         )));
     }
@@ -290,6 +290,19 @@ mod tests {
         let base = temp.path().join("omen-repos");
         std::fs::create_dir(&base).unwrap();
         std::fs::set_permissions(&base, std::fs::Permissions::from_mode(0o707)).unwrap();
+
+        assert!(ensure_secure_clone_base(&base).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_secure_clone_base_rejects_group_readable_directory() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let base = temp.path().join("omen-repos");
+        std::fs::create_dir(&base).unwrap();
+        std::fs::set_permissions(&base, std::fs::Permissions::from_mode(0o750)).unwrap();
 
         assert!(ensure_secure_clone_base(&base).is_err());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -311,7 +311,13 @@ fn run_with_path(cli: &Cli, path: &PathBuf) -> omen::core::Result<()> {
                     .find(|entry| entry.get("analyzer").and_then(Value::as_str) == Some(name))?
                     .get("result")?
                     .clone();
-                serde_json::from_value(value).ok()
+                match serde_json::from_value(value) {
+                    Ok(result) => Some(result),
+                    Err(error) => {
+                        tracing::warn!(analyzer = name, %error, "Failed to parse collected analyzer result");
+                        None
+                    }
+                }
             }
 
             let file_set = filtered_file_set(path, &config, Some(args))?;

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -331,8 +331,7 @@ impl McpServer {
             {
                 Ok(read) => read,
                 Err(error) => {
-                    write_parse_error(&mut writer, &format!("read error: {error}"))?;
-                    continue;
+                    return Err(error.into());
                 }
             };
             if read == 0 {
@@ -349,9 +348,11 @@ impl McpServer {
                 continue;
             }
 
-            bytes.pop();
-            if bytes.last() == Some(&b'\r') {
+            if has_newline {
                 bytes.pop();
+                if bytes.last() == Some(&b'\r') {
+                    bytes.pop();
+                }
             }
             if bytes.is_empty() {
                 continue;
@@ -1408,6 +1409,26 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    struct AlwaysErrorReader {
+        attempts: usize,
+    }
+
+    impl Read for AlwaysErrorReader {
+        fn read(&mut self, _buffer: &mut [u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::other("persistent read failure"))
+        }
+    }
+
+    impl BufRead for AlwaysErrorReader {
+        fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+            self.attempts += 1;
+            assert_eq!(self.attempts, 1, "run_stream retried a failed reader");
+            Err(std::io::Error::other("persistent read failure"))
+        }
+
+        fn consume(&mut self, _amount: usize) {}
+    }
+
     fn create_test_server() -> (McpServer, TempDir) {
         let temp_dir = TempDir::new().unwrap();
         let config = Config::default();
@@ -1499,6 +1520,32 @@ mod tests {
         assert_eq!(responses.len(), 2);
         assert_eq!(responses[0]["error"]["code"], -32700);
         assert_eq!(responses[1]["id"], 1);
+    }
+
+    #[test]
+    fn test_stdio_processes_final_request_without_trailing_newline() {
+        let (server, _root) = create_test_server();
+        let input = br#"{"jsonrpc":"2.0","id":1,"method":"initialize"}"#;
+        let mut output = Vec::new();
+
+        server.run_stream(input.as_slice(), &mut output).unwrap();
+
+        let response: Value = serde_json::from_slice(&output).unwrap();
+        assert_eq!(response["id"], 1);
+        assert!(response.get("result").is_some());
+        assert!(response.get("error").is_none());
+    }
+
+    #[test]
+    fn test_stdio_stops_after_persistent_read_error() {
+        let (server, _root) = create_test_server();
+        let reader = AlwaysErrorReader { attempts: 0 };
+        let mut output = Vec::new();
+
+        let error = server.run_stream(reader, &mut output).unwrap_err();
+
+        assert!(error.to_string().contains("persistent read failure"));
+        assert!(output.is_empty());
     }
 
     #[test]

--- a/src/score/mod.rs
+++ b/src/score/mod.rs
@@ -402,8 +402,21 @@ pub fn compute_from_components(components: &Components<'_>, file_count: usize) -
 /// Used by `report generate` to avoid redundantly re-running all sub-analyzers.
 pub fn compute_from_data_dir(data_dir: &std::path::Path, file_count: usize) -> Result<Analysis> {
     fn load<T: serde::de::DeserializeOwned>(data_dir: &std::path::Path, name: &str) -> Option<T> {
-        let content = std::fs::read_to_string(data_dir.join(name)).ok()?;
-        serde_json::from_str(&content).ok()
+        let path = data_dir.join(name);
+        let content = match std::fs::read_to_string(&path) {
+            Ok(content) => content,
+            Err(error) => {
+                tracing::warn!(path = %path.display(), %error, "Failed to read score component");
+                return None;
+            }
+        };
+        match serde_json::from_str(&content) {
+            Ok(result) => Some(result),
+            Err(error) => {
+                tracing::warn!(path = %path.display(), %error, "Failed to parse score component");
+                None
+            }
+        }
     }
 
     let complexity = load(data_dir, "complexity.json");


### PR DESCRIPTION
## Summary

Follow-up addressing the real issues an automated review surfaced on the merged security and performance PRs.

- **MCP framing (critical)**: the stdio reader popped the trailing byte unconditionally, so a final JSON-RPC request without a trailing newline lost its last byte and failed to parse. Now the newline is stripped only when present. Also, a persistent stdin read error returned `continue` without consuming input, spinning the loop and flooding stdout — it now returns the error. Both covered by new `run_stream` tests.
- **Clone directory hardening**: the temp clone base permission check only rejected world-writable; it now rejects any group/other bits (`mode & 0o077`), requiring 0o700-equivalent.
- **Mutation SIGINT race**: restoration now sets the interrupt flag before taking the registry lock, and `MutationGuard::apply` refuses to write once interrupted, closing the window where a worker could re-mutate a file between restore and `process::exit`. The global-state tests are isolated so they no longer clobber sibling tests under parallel `cargo test` (verified at 1, 4, and 16 threads).
- **Score diagnostics**: file-read and JSON-parse failures in the score data loaders now `tracing::warn!` before dropping a component, instead of failing silently.
- **CI hardening**: the new `cargo-audit` job gets `permissions: contents: read` and `persist-credentials: false`.

Verified NOT a bug and intentionally unchanged: `compute_from_components` weight plumbing — `omen all` and `omen score` produce byte-identical scores (weights are never configurable).

## Verification

`cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` all pass; mutation suite verified non-flaky at 1/4/16 test threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)