### PR TITLE
ci: bump omen action to latest release (omen-v4.26.1)

### DIFF
--- a/.github/workflows/omen.yml
+++ b/.github/workflows/omen.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Run Omen
         id: omen
-        uses: panbanda/omen@omen-v4.21.2
+        uses: panbanda/omen@omen-v4.26.1
         with:
           summary: 'true'
           comment: 'true'

--- a/README.md
+++ b/README.md
@@ -947,7 +947,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: panbanda/omen@omen-v4.21.2
+      - uses: panbanda/omen@omen-v4.26.1
         id: omen
         with:
           version: latest
@@ -971,6 +971,9 @@ jobs:
 
 > [!IMPORTANT]
 > `fetch-depth: 0` is required because history-based analysis needs complete git history. `pull-requests: write` is required when `comment` is enabled, and `issues: write` is required when `label` is enabled. Workflows that disable those features can omit the corresponding write permissions.
+
+> [!NOTE]
+> Pin the action to a release tag (the latest is [`omen-v4.26.1`](https://github.com/panbanda/omen/releases/latest)) and bump it as new releases ship. The `version: latest` input above controls which omen **binary** the action downloads and is independent of the action tag.
 
 ### Inputs
 


### PR DESCRIPTION
Updates `.github/workflows/omen.yml` from `omen-v4.21.2` to `omen-v4.26.1` so the self-analysis workflow uses the current composite action (job summaries, binary caching, and the actionable PR comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)