### PR TITLE
Auto-configure the omen MCP server from the plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1058,7 +1058,7 @@ Verify installation with `/skills` to see available Omen skills.
 
 ### Prerequisites
 
-Skills require the Omen MCP server to be configured (see MCP Server section above).
+Skills invoke the `omen` CLI directly, so they require the `omen` binary on your `PATH` (see Installation). Installing the plugin also registers the Omen MCP server automatically (`command: omen`, `args: ["mcp"]`) via each plugin's `mcpServers` declaration, so no manual command entry is needed; you can still configure it by hand (see the MCP Server section above) if you prefer.
 
 ## Real-World Repository Analysis Examples
 

--- a/plugins/development/plugin.json
+++ b/plugins/development/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "omen-development",
   "description": "Code analysis skills for active development: find bugs, assess impact, plan refactoring, audit architecture, and more",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "author": {
     "name": "Jonathan Reyes",
     "email": "me@jonathanreyes.com"
@@ -15,5 +15,11 @@
     "refactoring",
     "architecture",
     "code-review"
-  ]
+  ],
+  "mcpServers": {
+    "omen": {
+      "command": "omen",
+      "args": ["mcp"]
+    }
+  }
 }

--- a/plugins/reporting/plugin.json
+++ b/plugins/reporting/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "omen-reporting",
   "description": "Generate comprehensive HTML health reports with research-backed insights from specialized domain analysts",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "author": {
     "name": "Jonathan Reyes",
     "email": "me@jonathanreyes.com"
@@ -15,5 +15,11 @@
     "health-report",
     "insights",
     "technical-debt"
-  ]
+  ],
+  "mcpServers": {
+    "omen": {
+      "command": "omen",
+      "args": ["mcp"]
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Installing an omen Claude Code plugin left the MCP server unconfigured, so users hit **"Command is required"** with an empty command field when setting it up.

- Both `plugins/development/plugin.json` and `plugins/reporting/plugin.json` now declare the server via `mcpServers` (`command: omen`, `args: ["mcp"]`, stdio), so Claude Code registers it automatically on install — pre-filled and overridable — per the [plugin MCP reference](https://code.claude.com/docs/en/plugins-reference).
- Corrected the README "Prerequisites": the skills invoke the `omen` **CLI** directly (they need the binary on `PATH`), not the MCP server; the server is now bundled by the plugin. Bumped both plugin versions (dev 4.2.0 -> 4.3.0, reporting 2.0.1 -> 2.1.0).

## Verification

Both plugin manifests and the marketplace manifest are valid JSON. The declared command matches the documented manual setup (`omen mcp`, stdio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)