### PR TITLE
Refresh docs site: current CLI, config, Action, and new stubs analyzer

### DIFF
--- a/docs/analyzers/change-risk.md
+++ b/docs/analyzers/change-risk.md
@@ -100,17 +100,7 @@ Patterns to watch for in high-risk commits:
 
 ## Configuration
 
-In `omen.toml`:
-
-```toml
-[changes]
-# Number of recent commits to analyze
-limit = 100
-
-# Percentile thresholds for risk classification
-high_percentile = 95
-medium_percentile = 80
-```
+`changes` is an accepted top-level `omen.toml` section, but its field list isn't documented here -- `omen.example.toml` (the canonical example config) does not include a `[changes]` block. Run `omen changes --help` for the current set of CLI flags, including how many recent commits are analyzed.
 
 ## Comparison with File-Level Defect Prediction
 

--- a/docs/analyzers/complexity.md
+++ b/docs/analyzers/complexity.md
@@ -83,7 +83,7 @@ Compare this to the cyclomatic complexity of 6 for the same function. The cognit
 
 ### Nesting Depth
 
-In addition to the complexity scores, the analyzer reports maximum nesting depth per function. Deeply nested code is hard to read regardless of the type of nesting. The default threshold flags functions that exceed 4 levels of nesting.
+In addition to the complexity scores, the analyzer reports maximum nesting depth per function. Deeply nested code is hard to read regardless of the type of nesting.
 
 ## How Omen Computes It
 
@@ -93,26 +93,22 @@ Because the analysis is AST-based, it works correctly across all 13 supported la
 
 ## Thresholds
 
-Default thresholds can be overridden in `omen.toml`:
+Default error thresholds can be overridden in `omen.toml`:
 
-| Metric | Warning | Error | Config Key |
-|--------|---------|-------|------------|
-| Cyclomatic complexity | 10 | 20 | `cyclomatic_warn`, `cyclomatic_error` |
-| Cognitive complexity | 15 | 30 | `cognitive_warn`, `cognitive_error` |
-| Nesting depth | 4 | -- | `max_nesting` |
+| Metric | Error | Config Key |
+|--------|-------|------------|
+| Cyclomatic complexity | 20 | `cyclomatic_error` |
+| Cognitive complexity | 30 | `cognitive_error` |
 
-These defaults are based on widely adopted industry thresholds. The cyclomatic warning at 10 follows McCabe's original recommendation. The cognitive thresholds at 15/30 follow SonarSource's recommended defaults. The nesting depth limit of 4 reflects the Linux kernel coding standard and is commonly adopted elsewhere.
+These defaults are based on widely adopted industry thresholds. McCabe's original paper recommends treating 10 as a caution point; Omen's default error threshold of 20 flags functions well past that point. The cognitive threshold of 30 follows SonarSource's guidance for functions that have become hard to follow.
 
 ### Customizing Thresholds
 
 ```toml
 # omen.toml
 [complexity]
-cyclomatic_warn = 10
 cyclomatic_error = 20
-cognitive_warn = 15
 cognitive_error = 30
-max_nesting = 4
 ```
 
 ## Output
@@ -129,6 +125,9 @@ omen complexity --language python
 
 # Analyze a specific directory
 omen -p ./src/core complexity
+
+# Exclude paths in addition to omen.toml (repeatable)
+omen complexity -e "**/generated/**" -e "**/*.pb.go"
 ```
 
 The output lists every function that exceeds a threshold, sorted by complexity score descending. Each entry includes the file path, function name, line number, cyclomatic score, cognitive score, and nesting depth.

--- a/docs/analyzers/dead-code.md
+++ b/docs/analyzers/dead-code.md
@@ -60,7 +60,13 @@ Functions that are exported or public are not flagged as dead code because they 
 
 ### Rust-specific handling
 
-For Rust projects, Omen can leverage `cargo check` output for more reliable dead code detection. The Rust compiler's own dead code analysis accounts for conditional compilation (`#[cfg(...)]`), trait bounds, and macro expansions that tree-sitter parsing alone cannot resolve.
+For Rust projects, `--cargo-check` layers rustc's own dead-code diagnostics on top of Omen's tree-sitter analysis for more reliable detection. The Rust compiler's dead code analysis accounts for conditional compilation (`#[cfg(...)]`), trait bounds, and macro expansions that tree-sitter parsing alone cannot resolve.
+
+```bash
+omen deadcode --cargo-check
+```
+
+`--cargo-check` runs `cargo check`, which executes any build scripts (`build.rs`) and proc macros in the target repository. Only use it on repositories whose build scripts you trust -- it is not safe to run against arbitrary or untrusted source, including via `omen -p owner/repo --cargo-check deadcode` against a repository you haven't reviewed.
 
 ## Example Output
 
@@ -165,7 +171,7 @@ A public function in a library may have no callers within the repository but be 
 
 ### Conditional compilation
 
-Code behind feature flags, `#[cfg(...)]` attributes, or `#ifdef` blocks may appear dead in one configuration but be live in another. Omen's tree-sitter analysis sees the code as written, not as compiled. For Rust projects, using `cargo check` integration provides better accuracy.
+Code behind feature flags, `#[cfg(...)]` attributes, or `#ifdef` blocks may appear dead in one configuration but be live in another. Omen's tree-sitter analysis sees the code as written, not as compiled. For Rust projects, `--cargo-check` (trusted repositories only -- see above) provides better accuracy.
 
 ## Practical Applications
 

--- a/docs/analyzers/defect-prediction.md
+++ b/docs/analyzers/defect-prediction.md
@@ -105,19 +105,7 @@ Low risk: 103 (72.5%)
 
 ## Configuration
 
-In `omen.toml`:
-
-```toml
-[defect]
-# Adjust factor weights (must sum to 1.0)
-process_weight = 0.30
-metrics_weight = 0.25
-age_weight = 0.20
-size_weight = 0.25
-
-# Time window for process metrics
-since = "6m"
-```
+`defect` is not one of the accepted `omen.toml` sections, so the PMAT factor weights shown above are not currently configurable through the config file. Run `omen defect --help` for the current set of CLI flags.
 
 ## Interpreting Results
 

--- a/docs/analyzers/diff-analysis.md
+++ b/docs/analyzers/diff-analysis.md
@@ -126,11 +126,11 @@ jobs:
           fetch-depth: 0  # Full history required for accurate diff
 
       - name: Install Omen
-        run: brew install panbanda/omen/omen
+        run: brew install panbanda/brews/omen
 
       - name: Run diff analysis
         run: |
-          RISK=$(omen -f json diff --target origin/main | jq -r '.risk_level')
+          RISK=$(omen -f json diff --target origin/main | jq -r '.level')
           echo "Risk level: $RISK"
 
           if [ "$RISK" = "HIGH" ]; then
@@ -152,7 +152,7 @@ jobs:
 diff-analysis:
   stage: review
   script:
-    - brew install panbanda/omen/omen
+    - brew install panbanda/brews/omen
     - omen -f json diff --target origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
@@ -163,7 +163,7 @@ diff-analysis:
 To fail a pipeline when the diff risk exceeds a threshold:
 
 ```bash
-SCORE=$(omen -f json diff --target origin/main | jq '.risk_score')
+SCORE=$(omen -f json diff --target origin/main | jq '.score')
 if [ "$(echo "$SCORE > 0.5" | bc -l)" -eq 1 ]; then
   echo "Diff risk score $SCORE exceeds threshold (0.5)"
   exit 1
@@ -172,13 +172,7 @@ fi
 
 ## Configuration
 
-In `omen.toml`:
-
-```toml
-[diff]
-# Default target branch when --target is not specified
-default_target = "main"
-```
+`diff` is not one of the accepted `omen.toml` sections. When `--target` is omitted, Omen auto-detects `main` or `master` as the comparison branch; there is no config file override for the default target. Run `omen diff --help` for the current set of CLI flags.
 
 ## Relationship to Other Analyzers
 

--- a/docs/analyzers/feature-flags.md
+++ b/docs/analyzers/feature-flags.md
@@ -22,7 +22,7 @@ Omen detects flags from popular feature flag providers, identifies all reference
 
 ## Built-in Providers
 
-Omen recognizes feature flag patterns from five providers out of the box, covering the most common platforms across JavaScript/TypeScript, Python, and Ruby ecosystems.
+Omen can recognize feature flag patterns from six providers -- `launchdarkly`, `flipper`, `split`, `unleash`, `generic`, and `env` -- covering the most common platforms across JavaScript/TypeScript, Python, and Ruby ecosystems. Detection is opt-in: `[feature_flags] providers` in `omen.toml` defaults to an empty list, so no built-in provider runs until you enable it. See [Configuration](#configuration) later in this page.
 
 ### LaunchDarkly
 
@@ -137,66 +137,51 @@ A flag is considered stale when the most recent commit touching any line that re
 
 This is a conservative heuristic: a flag that was introduced 6 months ago and hasn't been touched since is very likely either fully rolled out (and the flag can be removed) or abandoned (and the flag-guarded code is dead weight).
 
-The threshold is configurable:
+Lower thresholds are more aggressive about flagging staleness. Higher thresholds tolerate longer-lived flags, which may be appropriate for organizations with longer release cycles or flags that are intentionally long-lived (like kill switches).
+
+## Configuration
+
+The `[feature_flags]` section in `omen.toml` controls which built-in providers run and the staleness threshold:
 
 ```toml
 # omen.toml
-[flags]
-stale_threshold_days = 90
+[feature_flags]
+stale_days = 90
+providers = ["launchdarkly"]
 ```
 
-Lower values are more aggressive about flagging staleness. Higher values tolerate longer-lived flags, which may be appropriate for organizations with longer release cycles or flags that are intentionally long-lived (like kill switches).
+`providers` defaults to an empty list -- no built-in detection runs until you list the providers you want (`launchdarkly`, `flipper`, `split`, `unleash`, `generic`, `env`).
 
-## Custom Provider Configuration
+### Custom Provider Configuration
 
-For internal feature flag systems or providers not covered by the built-in set, Omen supports custom provider definitions in `omen.toml`. Custom providers are defined using tree-sitter query patterns.
-
-### Example: Custom Provider
-
-Suppose your codebase uses a homegrown feature flag library where flags are checked via `FeatureGate.check("flag-name")`:
+For internal feature flag systems or providers not covered by the built-in set, Omen supports custom provider definitions in `omen.toml`. Custom providers are defined using tree-sitter query patterns and are checked alongside built-in providers.
 
 ```toml
 # omen.toml
-[flags]
-stale_threshold_days = 90
+[feature_flags]
+stale_days = 90
+providers = ["launchdarkly"]
 
-[[flags.custom_providers]]
-name = "FeatureGate"
-languages = ["typescript", "javascript"]
-
-# Tree-sitter query to match the pattern.
-# The @flag capture must extract the flag key string.
-query = """
-(call_expression
-  function: (member_expression
-    object: (identifier) @_obj
-    property: (property_identifier) @_method)
-  arguments: (arguments
-    (string) @flag)
-  (#eq? @_obj "FeatureGate")
-  (#eq? @_method "check"))
-"""
-
-[[flags.custom_providers]]
-name = "feature_enabled"
-languages = ["python"]
-
-query = """
+[[feature_flags.custom_providers]]
+name = "my_feature_system"
+languages = ["ruby", "python"]
+query = '''
 (call
-  function: (identifier) @_func
+  receiver: (constant) @receiver
+  (#eq? @receiver "Feature")
+  method: (identifier) @method
+  (#match? @method "^enabled\\?$")
   arguments: (argument_list
-    (string) @flag)
-  (#eq? @_func "feature_enabled"))
-"""
+    .
+    (simple_symbol) @flag_key))
+'''
 ```
 
 Each custom provider requires:
 
 - **name**: A human-readable name for the provider (appears in output).
 - **languages**: Which languages this provider applies to.
-- **query**: A tree-sitter query pattern. The query must include a capture named `@flag` that matches the string literal containing the flag key.
-
-Custom providers are checked alongside built-in providers. If a flag matches both a built-in and a custom provider, the built-in provider takes precedence.
+- **query**: A tree-sitter query pattern. The query must include a capture named `@flag_key` that matches the string or symbol literal containing the flag key.
 
 ### Writing Tree-sitter Queries
 

--- a/docs/analyzers/hotspots.md
+++ b/docs/analyzers/hotspots.md
@@ -112,14 +112,8 @@ In `omen.toml`:
 
 ```toml
 [hotspot]
-# Time window for churn data
-since = "6m"
-
 # Number of top hotspots to display
 top = 20
-
-# Minimum severity to report
-min_severity = "moderate"
 ```
 
 ## Relationship to Other Analyzers

--- a/docs/analyzers/mutation-testing.md
+++ b/docs/analyzers/mutation-testing.md
@@ -98,7 +98,7 @@ Runs all 21 operators. Takes significantly longer but provides the most complete
 ### Dry Run
 
 ```bash
-omen mutation --mode dry-run
+omen mutation --dry-run
 ```
 
 Generates all mutations and reports them without executing the test suite. Useful for reviewing what mutations would be created, estimating runtime, and validating configuration.
@@ -199,63 +199,52 @@ These thresholds are based on empirical data from Papadakis et al. (2019). In pr
 
 ## Configuration
 
-```toml
-# omen.toml
-[mutation]
-# Execution mode: "fast", "thorough", "dry-run"
-mode = "fast"
+Mutation testing is configured entirely through CLI flags rather than `omen.toml` -- `mutation` is not one of the accepted top-level configuration sections. The relevant flags:
 
-# Staleness threshold for incremental mode (in commits)
-incremental_lookback = 1
+| Flag | Purpose |
+|------|---------|
+| `--mode fast\|thorough` | Which operator set to run (see Execution Modes above) |
+| `--dry-run` | Generate mutants and report them without running the test suite |
+| `--jobs N` | Limit parallel worker count (default: all available cores) |
+| `--coverage <path>` | Coverage file to skip untested code (auto-detected if omitted) |
+| `--incremental` | Only mutate files changed since the last run |
+| `--glob <pattern>` | Restrict mutation to files matching a glob |
+| `--output-survivors <path>` | Write surviving mutants to a file for investigation |
+| `--record` | Append outcomes to `.omen/mutation-history.jsonl` for later training |
+| `--skip-predicted <threshold>` | Skip mutants the trained model predicts will be killed above this confidence |
+| `--model <path>` | Use a custom trained-model path instead of `.omen/mutation-model.json` |
+| `--allow-dirty` | Permit running against a working tree with uncommitted changes |
 
-# Maximum number of parallel test workers
-jobs = 0  # 0 = use all available cores
+### Working Tree Safety
 
-# Test command to run for each mutation
-test_command = "cargo test"
+By default, mutation testing refuses to run against a dirty working tree, because it applies mutants directly to source files and could otherwise clobber uncommitted work. Commit or stash your changes first, or pass `--allow-dirty` only once you've reviewed and are prepared to lose the current changes:
 
-# Timeout per mutation test run (seconds)
-timeout = 60
-
-# Operators to include (empty = all applicable operators for detected languages)
-operators = []
-
-# Operators to exclude
-exclude_operators = []
-
-# Files/directories to exclude from mutation
-exclude = ["tests/", "test_helpers/", "fixtures/"]
-
-# Coverage file path (empty = auto-detect)
-coverage_path = ""
+```bash
+omen mutation --allow-dirty
 ```
 
-### Customizing the Test Command
+### Test Command
 
-Omen needs to know how to run your test suite. The `test_command` is the shell command that will be executed for each mutation. It should:
+Omen runs your project's test suite for each mutation. A fast, focused test command keeps mutation runs practical, since the total runtime scales with the number of mutants:
 
-- Run the relevant tests (not necessarily the entire suite)
-- Exit with code 0 on success, non-zero on failure
-- Be as fast as possible (mutations multiply the total runtime)
-
-```toml
+```bash
 # Rust
-test_command = "cargo test --lib"
+cargo test --lib
 
 # JavaScript/TypeScript
-test_command = "npm test"
+npm test
 
 # Python
-test_command = "pytest tests/ -x --no-header -q"
+pytest tests/ -x --no-header -q
 
 # Go
-test_command = "go test ./..."
+go test ./...
 
 # Ruby
-test_command = "bundle exec rspec --fail-fast"
+bundle exec rspec --fail-fast
 ```
 
-The `-x` / `--fail-fast` flags (where available) are recommended: once a test fails, the mutation is killed and there is no need to run remaining tests.
+`-x` / `--fail-fast` flags (where available) are recommended: once a test fails, the mutation is killed and there is no need to run remaining tests. Run `omen mutation --help` for the current flag that selects the test command for your project.
 
 ## Output
 
@@ -267,7 +256,7 @@ omen mutation
 omen -f json mutation
 
 # Dry run to see what would be mutated
-omen mutation --mode dry-run
+omen mutation --dry-run
 
 # Incremental mode for PRs
 omen mutation --incremental

--- a/docs/analyzers/overview.md
+++ b/docs/analyzers/overview.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Analyzers Overview
 
-Omen ships with 19 analyzers that cover structural quality, defect risk, historical patterns, dependency health, and specialized concerns. Each analyzer is available as a top-level subcommand and can be run independently or as part of a full suite via `omen all`.
+Omen ships with 20 analyzers that cover structural quality, defect risk, historical patterns, dependency health, and specialized concerns. Each analyzer is available as a top-level subcommand and can be run independently or as part of a full suite via `omen all`.
 
 All analyzers parse source code through tree-sitter grammars, producing syntax-aware results rather than regex-based approximations. Output is available as formatted tables (default) or JSON (`-f json`).
 
@@ -58,8 +58,23 @@ Analyzers focused on specific concerns that cut across the categories above.
 | Analyzer | Command | What It Measures |
 |----------|---------|------------------|
 | [SATD Detection](./satd.md) | `omen satd` | Self-Admitted Technical Debt in comments (TODO, FIXME, HACK, etc.) |
+| [Stubs Detection](./stubs.md) | `omen stubs` | Incomplete/placeholder implementations (`todo!()`, elided bodies, empty bodies) |
 | [Feature Flags](./feature-flags.md) | `omen flags` | Feature flag usage, stale flags, flag-related complexity |
 | [Mutation Testing](./mutation-testing.md) | `omen mutation` | Test suite effectiveness by injecting controlled code mutations |
+
+## Agent-Facing Commands
+
+Beyond the analyzers above, Omen ships commands designed specifically for LLM/agent workflows rather than human review:
+
+| Command | What It Does |
+|---------|---------------|
+| `omen context` | Agent-oriented repository overview and navigation hints, budgeted with `--max-tokens` |
+| `omen outline` | Token-cheap map of a file's imports, classes, and top-level functions |
+| `omen impact <symbol>` | Blast-radius analysis: transitive callers and callees of a symbol |
+| `omen symbol <symbol>` | One-call symbol report: source, location, callers/callees, and complexity |
+| [`omen search`](../semantic-search.md) | Semantic (natural-language) symbol search -- `search index` and `search query` |
+
+These are also exposed as MCP tools (`context`, `outline`, `impact`, `get_symbol`, `semantic_search`) -- see [MCP Server](../integrations/mcp-server.md).
 
 ## Running Multiple Analyzers
 
@@ -81,5 +96,8 @@ All commands accept the same global flags:
 |------|-------------|
 | `-p <path>` | Target path (local directory, file, or `owner/repo` for remote) |
 | `-f json` | JSON output |
+| `--compact` | Minify JSON output to a single line |
 | `--language <lang>` | Filter to a specific language |
-| `--config <path>` | Path to `omen.toml` configuration file |
+| `-c, --config <path>` | Path to a configuration file |
+| `-e, --exclude <glob>` | Exclude a glob pattern from analysis (repeatable) |
+| `--top N` / `--offset N` | Paginate results |

--- a/docs/analyzers/repomap.md
+++ b/docs/analyzers/repomap.md
@@ -41,14 +41,14 @@ omen -p gin-gonic/gin repomap
 
 ### Usage with LLM context
 
-The repository map is most commonly used to provide context to an LLM. The `omen context` command includes a `--repo-map` flag for this purpose:
+The repository map is most commonly used to provide context to an LLM. Run it directly for a ranked symbol list, or use the broader `omen context` command when you want an agent-oriented overview rather than the raw symbol map:
 
 ```bash
-# Include top 50 symbols by PageRank in LLM context
-omen context --repo-map --top 50
+# Top 50 symbols by PageRank
+omen repomap --top 50
 
-# Combine with other context sources
-omen context --repo-map --top 30 --file src/core/engine.go
+# Broader agent context, budgeted by token count
+omen context --max-tokens 8000
 ```
 
 This produces output suitable for pasting into a prompt or piping to an LLM-based tool.
@@ -133,7 +133,7 @@ This is particularly useful for:
 ```bash
 # Pipe repository map into an LLM prompt
 echo "Given this codebase structure:" > prompt.txt
-omen context --repo-map --top 50 >> prompt.txt
+omen repomap --top 50 >> prompt.txt
 echo "How should I implement a caching layer?" >> prompt.txt
 ```
 

--- a/docs/analyzers/satd.md
+++ b/docs/analyzers/satd.md
@@ -178,24 +178,18 @@ The output is sorted by severity (highest first), then by file path. This puts s
 
 ## Configuration
 
-Default markers can be extended or replaced in `omen.toml`:
+The `[satd]` section accepts one option: `custom_markers`, a list of additional comment markers to detect on top of the built-in set (TODO, FIXME, HACK, BUG, and others):
 
 ```toml
 [satd]
-# Add custom markers to existing categories
-[satd.markers]
-design = ["HACK", "KLUDGE", "SMELL", "REFACTOR", "UGLY", "WORKAROUND", "CLEANUP"]
-defect = ["BUG", "FIXME", "BROKEN", "DEFECT", "REGRESSION"]
-requirement = ["TODO", "FEAT", "MISSING", "NEEDED", "PLACEHOLDER"]
-test = ["FAILING", "SKIP", "DISABLED", "FLAKY", "PENDING"]
-performance = ["SLOW", "OPTIMIZE", "PERF", "N+1", "BOTTLENECK"]
-security = ["SECURITY", "VULN", "UNSAFE", "INSECURE", "XXE", "SQLI", "XSS"]
-
-# Exclude specific directories from SATD scanning
-exclude = ["vendor", "third_party", "generated"]
+custom_markers = ["KLUDGE", "TECHDEBT"]
 ```
 
-When custom markers are specified, they replace the defaults for that category entirely. If you want to add markers without removing the defaults, include the default markers in your list.
+To exclude directories from SATD scanning specifically, use the top-level `exclude` list, which applies to every analyzer:
+
+```toml
+exclude = ["vendor/**", "third_party/**", "**/*.generated.*"]
+```
 
 ## How Omen Detects SATD
 

--- a/docs/analyzers/stubs.md
+++ b/docs/analyzers/stubs.md
@@ -1,0 +1,154 @@
+---
+sidebar_position: 17
+---
+
+# Stubs Detection
+
+```bash
+omen stubs
+```
+
+The stubs analyzer finds incomplete or placeholder implementations: code that was never finished, as opposed to code a developer deliberately marked as debt. SATD is debt a developer chose to keep; a stub is work that was left mid-task -- the kind of thing an agent or human leaves behind before coming back to finish it (and sometimes never does).
+
+Detection is entirely AST-based via tree-sitter, so trigger words that appear inside string literals or comments unrelated to a function body are never false positives.
+
+## Pattern Types
+
+Omen classifies each stub finding into one of three pattern types.
+
+### `not_implemented` (High severity)
+
+Explicit not-implemented idioms -- code that unambiguously declares itself unfinished.
+
+| Language | Example |
+|----------|---------|
+| Rust | `todo!()`, `unimplemented!()` |
+| Python | `raise NotImplementedError` |
+| JavaScript/TypeScript | `throw new Error("not implemented")` |
+| Go | `panic("not implemented")` |
+| Java/C# | `NotImplementedException`, `UnsupportedOperationException` (with an unfinished-work message) |
+
+```rust
+fn calculate_discount(order: &Order) -> f64 {
+    todo!()
+}
+```
+
+### `elision` (Medium severity)
+
+Comments that admit work was skipped, inside a function body -- the author documented that something is missing rather than writing it.
+
+```python
+def process_payment(order):
+    # ... rest of the implementation
+    pass
+```
+
+```javascript
+function validateInput(data) {
+  // your code here
+}
+```
+
+Typical phrases: "rest of the implementation", "for brevity", "placeholder", "your code here".
+
+### `empty_body` (Medium severity)
+
+A function or method with an empty body that cannot legitimately be empty: it has a non-void return type, or it contains an elision comment. An empty body that is a deliberate no-op (matching a suppressed idiom -- see below) is not flagged.
+
+```go
+func (s *Service) FetchUser(id string) (*User, error) {
+}
+```
+
+## What Omen Does Not Flag
+
+Several idioms look like stubs but are legitimate, and Omen suppresses them:
+
+- **`unreachable!()`** in Rust -- this asserts a code path is provably impossible, not unfinished.
+- **`.pyi` stub files, `@overload`, `@abstractmethod`, `Protocol`, and `ABC`** in Python -- these are intentional interface declarations, not incomplete implementations.
+- **`UnsupportedOperationException`** in Java without an "unfinished" style message -- this is a legitimate way to reject an operation a class deliberately does not support (for example, an immutable collection rejecting mutation).
+
+Because detection is tree-sitter AST-based rather than string matching, a string literal containing the text `"todo!()"` or a comment describing what `NotImplementedError` does is never mistaken for an actual stub site.
+
+Each stub site produces exactly one finding, regardless of how many trigger patterns it happens to match.
+
+## Output
+
+Each detected stub includes:
+
+- **File path** and **line number**
+- **Pattern type** (`not_implemented`, `elision`, `empty_body`)
+- **Severity** (high or medium, per the pattern type)
+- **Snippet** for context
+
+```bash
+# Table output (default)
+omen stubs
+
+# JSON output
+omen -f json stubs
+
+# Analyze a specific directory
+omen -p ./src stubs
+```
+
+## CI Gate
+
+`omen stubs` supports a gate independent of the repository score, similar in spirit to a linter's `--deny`:
+
+```bash
+# Report only, exit 0 regardless of findings (default)
+omen stubs --gate off
+
+# Warn but do not fail the build
+omen stubs --gate warn
+
+# Fail CI if any stub is found
+omen stubs --gate error
+
+# Only fail on high-severity stubs (todo!()-style idioms); warn on the rest
+omen stubs --gate error --gate-severity high
+```
+
+`--gate error` exits with code 2 when a stub at or above `--gate-severity` (default: `low`, i.e. everything) is found. The JSON report is still written to stdout regardless of the gate outcome, so CI logs retain the full finding list even when the build fails.
+
+## MCP
+
+The `stubs` MCP tool is read-only: it reports findings with the same pagination (`limit`/`offset`) as every other tool, but it does not expose the CLI's `--gate` option -- gating is a CI concern, not something an LLM client should trigger mid-conversation.
+
+## How It Feeds the Health Score
+
+Stubs feed into the composite health score's SATD/debt component alongside self-admitted technical debt. If a stub site also happens to contain a SATD marker comment (for example a `// TODO: implement this` immediately above a `todo!()`), the two detectors deduplicate against each other so a single site is not counted twice against the score.
+
+## Why It Matters
+
+Unfinished work that looks complete -- it compiles, it's committed, it may even pass a shallow review -- is more dangerous than code that's obviously missing, because nothing signals it needs attention until it's called in production. This risk has grown with AI-assisted development: an agent can leave a `todo!()` or an elided function body behind mid-task, and unlike a human contributor, it will not necessarily flag that the work is incomplete in the PR description.
+
+## Practical Use
+
+### CI Quality Gate
+
+Block merges that leave unfinished work behind:
+
+```yaml
+- name: Check for unfinished stubs
+  run: omen stubs --gate error
+```
+
+### Triage by Severity
+
+Start with `not_implemented` findings, which are unambiguous:
+
+```bash
+omen -f json stubs | jq '[.items[] | select(.pattern_type == "not_implemented")]'
+```
+
+### Combine With SATD
+
+Since stubs and SATD both surface unfinished-work signals but from different sources (explicit markers vs. AST idioms), running both together gives a more complete picture of what's left to do in a codebase:
+
+```bash
+omen satd
+omen stubs
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,21 +4,24 @@ sidebar_position: 16
 
 # Configuration
 
-Omen reads configuration from `omen.toml` in the project root, or from `.omen/omen.toml`. YAML (`omen.yaml`) and JSON (`omen.json`) are also supported. Omen searches for configuration files in this order and uses the first one found:
+Omen automatically discovers configuration by searching for `omen.toml` and then `.omen/omen.toml` under the analyzed repository. An explicit `-c`/`--config <PATH>` accepts TOML (the default for unrecognized extensions), YAML (`.yaml`/`.yml`), or JSON (`.json`) -- automatic discovery only looks for TOML files.
 
-1. Path specified with `-c` / `--config`
-2. `omen.toml` in the target directory
-3. `.omen/omen.toml` in the target directory
+`OMEN_`-prefixed environment variables override file values. Use a double underscore for nested keys, for example `OMEN_COMPLEXITY__CYCLOMATIC_ERROR=25`.
 
 All options are optional. When a value is not specified, Omen uses sensible defaults. You do not need a configuration file to run any analyzer.
 
-## Generating a Configuration File
+Configuration structs use `#[serde(deny_unknown_fields)]`, so unknown keys -- including unknown nested keys -- are rejected with an error instead of being silently ignored. This means a typo in a config file fails loudly rather than being ignored.
+
+## Creating a Configuration File
+
+There is no `omen init` command. Copy the annotated example and customize it:
 
 ```bash
-omen init
+curl -O https://raw.githubusercontent.com/panbanda/omen/main/omen.example.toml
+mv omen.example.toml omen.toml
 ```
 
-This creates an `omen.toml` in the current directory with all sections and their default values. Edit it to match your project's standards.
+If you use Claude Code, the `setup-config` skill can analyze your repository and generate an `omen.toml` with intelligent defaults for your tech stack, including detected feature flag providers and language-specific exclude patterns.
 
 ## Using a Custom Config Path
 
@@ -27,81 +30,93 @@ omen -c ./config/omen.toml complexity
 omen --config /etc/omen/global.toml score
 ```
 
-The `-c` flag works with all subcommands.
+The `-c` flag works with all subcommands and, unlike automatic discovery, accepts TOML, YAML, or JSON.
 
-## Configuration Sections
+## Accepted Top-Level Keys
 
-### `exclude_patterns`
+The accepted top-level keys are `exclude`, `exclude_built_assets`, `complexity`, `satd`, `churn`, `duplicates`, `hotspot`, `score`, `feature_flags`, `temporal`, and `changes`. Any other top-level key is rejected.
 
-An array of glob patterns for files and directories that should be excluded from analysis. These patterns are applied in addition to `.gitignore` rules.
+### `exclude`
+
+An array of glob patterns for files and directories that should be excluded from analysis, in addition to `.gitignore` rules.
 
 ```toml
-exclude_patterns = [
-    "**/node_modules/**",
-    "**/vendor/**",
-    "**/target/**",
-    "**/.git/**",
-    "**/dist/**",
-    "**/build/**",
-    "**/*_test.go",
-    "**/*_test.rs",
-    "**/*_spec.rb",
+exclude = [
+    # Test files
+    "*_test.rs",
+    "*_test.go",
     "**/*_test.py",
-    "**/test_*.py",
     "**/*.test.ts",
     "**/*.test.js",
     "**/*.spec.ts",
     "**/*.spec.js",
-    "**/__tests__/**",
-    "**/__pycache__/**",
-    "**/bin/**",
-    "**/obj/**",
-    "**/*.min.js",
+    "tests/**",
+    "test/**",
+    "**/testdata/**",
+
+    # Generated code
+    "**/mocks/**",
+    "**/*.pb.go",
+    "**/*.gen.go",
     "**/*.generated.*",
+
+    # Dependencies
+    "vendor/**",
+    "node_modules/**",
+    "**/site-packages/**",
+
+    # Build/output directories
+    "target/**",
+    "dist/**",
+    "build/**",
+    "bin/**",
+    ".git/**",
+    ".omen/**",
+
+    # Lock files
+    "Cargo.lock",
+    "go.sum",
+    "package-lock.json",
+    "yarn.lock",
+    "poetry.lock",
 ]
 ```
 
-Patterns use standard glob syntax. `**` matches any number of directories. Patterns are matched against the file path relative to the analysis root.
+Patterns use standard glob syntax. `**` matches any number of directories. Patterns are matched against the file path relative to the analysis root. The same patterns can be passed ad hoc on the command line with a repeatable `-e`/`--exclude` flag, which most analyzers accept:
+
+```bash
+omen complexity -e "**/vendor/**" -e "**/*.pb.go"
+```
 
 ### `[complexity]`
 
-Controls thresholds for cyclomatic complexity, cognitive complexity, and nesting depth. These thresholds determine which functions appear in warnings and errors, and affect the repository score.
+Controls thresholds for cyclomatic and cognitive complexity. These thresholds determine which functions are flagged as errors and affect the repository score.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `cyclomatic_warn` | integer | `10` | Cyclomatic complexity at or above this triggers a warning |
 | `cyclomatic_error` | integer | `20` | Cyclomatic complexity at or above this triggers an error |
-| `cognitive_warn` | integer | `15` | Cognitive complexity at or above this triggers a warning |
 | `cognitive_error` | integer | `30` | Cognitive complexity at or above this triggers an error |
-| `max_nesting` | integer | `4` | Maximum nesting depth before flagging |
 
 ```toml
 [complexity]
-cyclomatic_warn = 10
 cyclomatic_error = 20
-cognitive_warn = 15
 cognitive_error = 30
-max_nesting = 4
 ```
 
 Cyclomatic complexity counts linearly independent paths through a function (branches, loops, logical operators). Cognitive complexity measures how difficult a function is for a human to understand, penalizing nested control flow more heavily. See [Research References](./research.md) for the academic foundations of both metrics.
 
 ### `[satd]`
 
-Configures Self-Admitted Technical Debt detection. SATD analysis scans comments for markers that indicate developers have knowingly left behind suboptimal code.
+Configures Self-Admitted Technical Debt detection.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `categories` | array of strings | `["DEFECT", "DESIGN", "IMPLEMENTATION", "DOCUMENTATION", "TEST", "REQUIREMENT"]` | SATD categories to detect |
-| `custom_markers` | array of strings | `[]` | Additional comment markers to treat as SATD |
+| `custom_markers` | array of strings | `[]` | Additional comment markers to treat as SATD, beyond the built-in set (TODO, FIXME, HACK, BUG, and others) |
 
 ```toml
 [satd]
-categories = ["DEFECT", "DESIGN", "IMPLEMENTATION", "DOCUMENTATION", "TEST", "REQUIREMENT"]
-custom_markers = ["KLUDGE", "REFACTOR", "TECHDEBT", "CLEANUP"]
+custom_markers = []
 ```
-
-The six default categories correspond to the SATD taxonomy from Maldonado and Shihab (2015). Built-in markers include `TODO`, `FIXME`, `HACK`, `XXX`, `WORKAROUND`, and `TEMPORARY`. Custom markers extend this list with project-specific terms.
 
 ### `[churn]`
 
@@ -133,7 +148,7 @@ Shorter windows focus on recent activity and are faster to compute. Longer windo
 
 ### `[duplicates]`
 
-Configures the code clone detector, which identifies duplicated code blocks across the codebase.
+Configures the code clone detector (MinHash + LSH), which identifies duplicated code blocks across the codebase.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -150,7 +165,7 @@ Lower `min_tokens` values will detect smaller duplicated fragments but increase 
 
 ### `[hotspot]`
 
-Controls the hotspot analyzer, which identifies files that combine high complexity with high change frequency -- the intersection where bugs are most likely.
+Controls the hotspot analyzer, which identifies files that combine high complexity with high change frequency.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -167,196 +182,51 @@ Controls the composite repository score behavior.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `fail_under` | float | `70.0` | Exit with a non-zero code if the score is below this value |
+| `fail_under` | float | none (no gate) | Exit with a non-zero code if the score is below this value |
 
 ```toml
 [score]
 fail_under = 70.0
 ```
 
-The `fail_under` threshold is useful in CI pipelines. When the computed score is below this value, `omen score` exits with code 1, which can be used to fail a build or block a merge.
-
-### `[score.thresholds]`
-
-Per-category thresholds that define what score each dimension must reach to be considered healthy. Each value is a score from 0 to 100. Lower thresholds are more lenient; higher thresholds demand cleaner code.
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `complexity` | float | `85` | Target score for the complexity dimension |
-| `duplication` | float | `65` | Target score for the duplication dimension |
-| `satd` | float | `80` | Target score for the SATD dimension |
-| `tdg` | float | `90` | Target score for the technical debt gradient dimension |
-| `coupling` | float | `70` | Target score for the coupling dimension |
-| `smells` | float | `90` | Target score for the architectural smells dimension |
-| `cohesion` | float | `80` | Target score for the cohesion (CK metrics) dimension |
-
-```toml
-[score.thresholds]
-complexity = 85
-duplication = 65
-satd = 80
-tdg = 90
-coupling = 70
-smells = 90
-cohesion = 80
-```
-
-These thresholds influence how each analyzer's raw results are normalized into the 0-100 composite score. See [Repository Score](./repository-score.md) for details on how the composite score is calculated.
+The `fail_under` threshold is useful in CI pipelines and pre-push hooks. When set and the computed score is below this value, `omen score` exits with a non-zero code, which can be used to fail a build or block a merge. Achieving a score of 100 is nearly impossible for real-world codebases -- run `omen score` to see your current score, then set the threshold slightly below it and raise it over time. See [Repository Score](./repository-score.md) for how the composite score is calculated.
 
 ### `[feature_flags]`
 
-Configures detection of feature flags in the codebase. Omen can identify usage of common feature flag SDKs and detect potentially stale flags.
+Configures detection of feature flags in the codebase.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `stale_days` | integer | `90` | Number of days after which an unmodified feature flag is considered stale |
-| `providers` | array of strings | `[]` | Feature flag providers to detect (e.g., `"launchdarkly"`, `"split"`, `"unleash"`, `"flipper"`) |
+| `stale_days` | integer | `90` | Days before a flag is considered stale |
+| `providers` | array of strings | `[]` | Built-in providers to enable: `launchdarkly`, `flipper`, `split`, `unleash`, `generic`, `env`. If empty, no built-in detection runs. |
 | `custom_providers` | array of tables | `[]` | Custom provider definitions using tree-sitter queries |
 
 ```toml
 [feature_flags]
 stale_days = 90
-providers = ["launchdarkly", "split", "unleash"]
+providers = ["launchdarkly"]
 
 [[feature_flags.custom_providers]]
-name = "internal_flags"
-language = "typescript"
-query = '(call_expression function: (member_expression object: (identifier) @obj property: (property_identifier) @prop) (#eq? @obj "FeatureFlags") (#eq? @prop "isEnabled"))'
+name = "my_feature_system"
+languages = ["ruby", "python"]
+query = '''
+(call
+  receiver: (constant) @receiver
+  (#eq? @receiver "Feature")
+  method: (identifier) @method
+  (#match? @method "^enabled\\?$")
+  arguments: (argument_list
+    .
+    (simple_symbol) @flag_key))
+'''
 ```
 
 Custom providers let you define tree-sitter queries to detect project-specific feature flag patterns that the built-in detectors do not cover.
 
-### `[semantic_search]`
+### `[temporal]` and `[changes]`
 
-Configures the semantic search engine used by `omen search`.
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `max_results` | integer | `20` | Maximum number of results returned by a query |
-| `min_score` | float | `0.3` | Minimum cosine similarity score for a result to be included |
-
-```toml
-[semantic_search]
-max_results = 20
-min_score = 0.3
-```
-
-### `[semantic_search.provider]`
-
-Controls which embedding model is used for semantic search.
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `type` | string | `"candle"` | Embedding provider: `"candle"`, `"open_ai"`, `"cohere"`, or `"voyage"` |
-| `model` | string | varies | Model identifier (provider-specific) |
-| `api_key_env` | string | none | Environment variable containing the API key (external providers only) |
-
-```toml
-[semantic_search.provider]
-type = "candle"
-# model = "all-MiniLM-L6-v2"   # default for candle
-
-# OpenAI alternative:
-# type = "open_ai"
-# model = "text-embedding-3-small"
-# api_key_env = "OPENAI_API_KEY"
-
-# Cohere alternative:
-# type = "cohere"
-# model = "embed-english-v3.0"
-# api_key_env = "COHERE_API_KEY"
-
-# Voyage alternative (code-optimized):
-# type = "voyage"
-# model = "voyage-code-2"
-# api_key_env = "VOYAGE_API_KEY"
-```
-
-The default `candle` provider runs locally with no API key. External providers require a valid API key in the specified environment variable. See [Semantic Search](./semantic-search.md) for details on each provider.
+`temporal` (temporal coupling) and `changes` (JIT commit-level risk) are also accepted top-level configuration sections. Most projects can rely on the defaults for these analyzers; consult `omen <command> --help` for the current set of CLI flags each one accepts.
 
 ## Complete Example
 
-Below is a complete `omen.toml` showing all sections with their default values.
-
-```toml
-exclude_patterns = [
-    "**/node_modules/**",
-    "**/vendor/**",
-    "**/target/**",
-    "**/.git/**",
-    "**/dist/**",
-    "**/build/**",
-    "**/*_test.go",
-    "**/*_test.rs",
-    "**/*_spec.rb",
-    "**/*_test.py",
-    "**/test_*.py",
-    "**/*.test.ts",
-    "**/*.test.js",
-    "**/*.spec.ts",
-    "**/*.spec.js",
-    "**/__tests__/**",
-    "**/__pycache__/**",
-    "**/bin/**",
-    "**/obj/**",
-    "**/*.min.js",
-    "**/*.generated.*",
-]
-
-[complexity]
-cyclomatic_warn = 10
-cyclomatic_error = 20
-cognitive_warn = 15
-cognitive_error = 30
-max_nesting = 4
-
-[satd]
-categories = ["DEFECT", "DESIGN", "IMPLEMENTATION", "DOCUMENTATION", "TEST", "REQUIREMENT"]
-custom_markers = []
-
-[churn]
-since = "6m"
-top = 20
-
-[duplicates]
-min_tokens = 50
-min_similarity = 0.9
-
-[hotspot]
-top = 20
-
-[score]
-fail_under = 70.0
-
-[score.thresholds]
-complexity = 85
-duplication = 65
-satd = 80
-tdg = 90
-coupling = 70
-smells = 90
-cohesion = 80
-
-[feature_flags]
-stale_days = 90
-providers = []
-
-[semantic_search]
-max_results = 20
-min_score = 0.3
-
-[semantic_search.provider]
-type = "candle"
-```
-
-## Environment Variables
-
-Some configuration values can be set or overridden through environment variables:
-
-| Variable | Purpose |
-|----------|---------|
-| `OPENAI_API_KEY` | API key for OpenAI embedding provider |
-| `COHERE_API_KEY` | API key for Cohere embedding provider |
-| `VOYAGE_API_KEY` | API key for Voyage AI embedding provider |
-
-API key environment variables are only required when using the corresponding external embedding provider for semantic search.
+`omen.example.toml` in the repository root is kept up to date with every accepted section and is the canonical starting point -- copy it rather than hand-writing a config from scratch. Its contents are `exclude`, `[complexity]`, `[satd]`, `[churn]`, `[duplicates]`, `[hotspot]`, `[score]`, and `[feature_flags]`, matching the sections documented above.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,7 +9,7 @@ sidebar_position: 2
 ### Homebrew (macOS and Linux)
 
 ```bash
-brew install panbanda/omen/omen
+brew install panbanda/brews/omen
 ```
 
 ### Build from Source
@@ -32,7 +32,7 @@ docker pull ghcr.io/panbanda/omen:latest
 To analyze the current directory:
 
 ```bash
-docker run --rm -v "$(pwd):/repo" ghcr.io/panbanda/omen:latest all
+docker run --rm -v "$(pwd):/repo" ghcr.io/panbanda/omen:latest -p /repo all
 ```
 
 To analyze a specific path inside the container:
@@ -76,10 +76,11 @@ Each analyzer is a top-level subcommand:
 
 ```bash
 omen complexity
-omen coupling
+omen graph
 omen clones
 omen smells
-omen dead-code
+omen deadcode
+omen stubs
 ```
 
 ### Check the Repository Score
@@ -121,15 +122,16 @@ omen -p ./src/api complexity
 omen -p /absolute/path/to/project score
 ```
 
-### Generate a Configuration File
+### Create a Configuration File
 
-Omen supports project-level configuration through `omen.toml`. Generate a default config:
+Omen supports project-level configuration through `omen.toml`. There is no `omen init` command to scaffold one; instead, copy the annotated example and customize it:
 
 ```bash
-omen init
+curl -O https://raw.githubusercontent.com/panbanda/omen/main/omen.example.toml
+mv omen.example.toml omen.toml
 ```
 
-This creates an `omen.toml` in the current directory with default thresholds, analyzer settings, and output preferences. Edit it to customize behavior for your project.
+If you use Claude Code, the `setup-config` skill can analyze your repository and generate an `omen.toml` with intelligent defaults for your tech stack instead. See [Configuration](./configuration.md) for the full list of accepted sections.
 
 ### Filter by Language
 
@@ -138,12 +140,26 @@ omen complexity --language rust
 omen clones --language typescript
 ```
 
+### Exclude Files From Analysis
+
+Most analyzers accept a repeatable `-e`/`--exclude` flag for glob patterns, in addition to whatever is configured in `omen.toml`:
+
+```bash
+omen complexity -e "**/vendor/**" -e "**/*.pb.go"
+```
+
 ### Pipeline Integration
+
+All commands support minified JSON with the global `--compact` flag, which pairs well with CI logging:
+
+```bash
+omen -f json score --compact
+```
 
 A typical CI step that fails if the repository score drops below 60:
 
 ```bash
-SCORE=$(omen -f json score | jq '.score')
+SCORE=$(omen -f json score | jq '.overall_score')
 if [ "$(echo "$SCORE < 60" | bc)" -eq 1 ]; then
   echo "Repository score $SCORE is below threshold (60)"
   exit 1

--- a/docs/integrations/ci-cd.md
+++ b/docs/integrations/ci-cd.md
@@ -4,11 +4,11 @@ sidebar_position: 2
 
 # CI/CD Integration
 
-Omen is designed to run in CI pipelines as a quality gate, risk assessment tool, and health tracker. All commands support JSON output (`-f json`) for programmatic parsing, and `omen score` returns non-zero exit codes when the score falls below a configured threshold.
+Omen is designed to run in CI pipelines as a quality gate, risk assessment tool, and health tracker. All commands support JSON output (`-f json`) for programmatic parsing, and `omen score` returns a non-zero exit code when the score falls below a configured `fail_under` threshold.
 
 ## GitHub Action
 
-Omen provides a composite GitHub Action for automated PR analysis. It runs diff risk analysis and health scoring on every pull request.
+Omen provides a composite GitHub Action for automated PR analysis. It runs diff risk analysis (on pull request events) and health scoring on every run, and can write results to the job summary, post a sticky PR comment, apply a risk label, and fail the build on high risk.
 
 ### Basic Usage
 
@@ -27,7 +27,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: panbanda/omen@omen-v4.23.0
+      - uses: panbanda/omen@omen-v4.26.1
         id: omen
 
       - name: Print results
@@ -36,68 +36,115 @@ jobs:
           echo "Health: ${{ steps.omen.outputs.health-grade }} (${{ steps.omen.outputs.health-score }})"
 ```
 
-`fetch-depth: 0` is required. Omen needs full git history for accurate analysis.
+`fetch-depth: 0` is required. Omen needs full git history for accurate analysis (churn, ownership, hotspot, and temporal coupling all depend on it).
 
-### With PR Comment and Labels
-
-```yaml
-      - uses: panbanda/omen@omen-v4.23.0
-        id: omen
-        with:
-          comment: true
-          label: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-```
-
-Requires additional permissions:
+### Complete Workflow
 
 ```yaml
+name: Omen Analysis
+
+on:
+  pull_request:
+
 permissions:
   contents: read
   pull-requests: write
   issues: write
+
+jobs:
+  omen:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: panbanda/omen@omen-v4.26.1
+        id: omen
+        with:
+          version: latest
+          path: .
+          comment: true
+          label: true
+          label-template: 'risk: {{level}}'
+          label-color-low: '0e8a16'
+          label-color-medium: 'fbca04'
+          label-color-high: 'd93f0b'
+          check: true
+          check-threshold: high
+          summary: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Print results
+        run: |
+          echo "Risk: ${{ steps.omen.outputs.risk-level }} (${{ steps.omen.outputs.risk-score }})"
+          echo "Health: ${{ steps.omen.outputs.health-grade }} (${{ steps.omen.outputs.health-score }})"
 ```
+
+`pull-requests: write` is required when `comment` is enabled, and `issues: write` is required when `label` is enabled. Workflows that disable both features can drop to `contents: read` only.
+
+Pin the action to a release tag (the latest at time of writing is `omen-v4.26.1`; check the [releases page](https://github.com/panbanda/omen/releases/latest) for the current one) and bump it as new releases ship. The `version: latest` input controls which omen **binary** the action downloads and is independent of the action tag itself.
 
 ### Action Inputs
 
 | Input | Default | Description |
 |-------|---------|-------------|
-| `version` | `latest` | Omen version to install |
-| `path` | `.` | Repository path to analyze |
-| `comment` | `false` | Post/update a sticky PR comment |
-| `label` | `false` | Add a risk-level label |
-| `label-template` | `risk: &#123;&#123;level&#125;&#125;` | Label name template |
-| `check` | `false` | Fail if risk meets threshold |
-| `check-threshold` | `high` | Risk level to fail on (`low`, `medium`, `high`) |
+| `version` | `latest` | Omen version to install (for example `"4.20.3"`), or `latest` for the newest stable release |
+| `path` | `.` | Repository path to analyze, relative to the workflow workspace |
+| `comment` | `false` | Post or update a sticky analysis comment on pull requests |
+| `label` | `false` | Create and apply a risk-level label to pull requests |
+| `label-template` | `risk: &#123;&#123;level&#125;&#125;` | Label name template. Use `{{level}}` for risk level replacement |
+| `label-color-low` | `0e8a16` | Hex color (without `#`) for the low-risk label |
+| `label-color-medium` | `fbca04` | Hex color (without `#`) for the medium-risk label |
+| `label-color-high` | `d93f0b` | Hex color (without `#`) for the high-risk label |
+| `check` | `false` | Fail pull request analysis when the risk level meets or exceeds the configured threshold |
+| `check-threshold` | `high` | Risk level threshold for check failure (`low`, `medium`, `high`) |
+| `summary` | `true` | Write risk, change-size, repository health, and score-component results to the job step summary |
+| `github-token` | `${{ github.token }}` | GitHub token used to resolve and download releases and, when enabled, manage pull request comments and labels |
 
 ### Action Outputs
 
 | Output | Example | Description |
 |--------|---------|-------------|
-| `risk-score` | `0.42` | Diff risk score (0.0 - 1.0) |
-| `risk-level` | `medium` | Risk level (`low`, `medium`, `high`) |
-| `health-score` | `76.9` | Health score (0 - 100) |
-| `health-grade` | `C` | Health grade (A - F) |
-| `diff-json` | `{...}` | Full `omen diff` JSON |
-| `score-json` | `{...}` | Full `omen score` JSON |
+| `risk-score` | `0.42` | Pull request diff risk score (0.0 - 1.0); empty on non-pull-request events |
+| `risk-level` | `medium` | Pull request risk level (`low`, `medium`, `high`); empty on non-pull-request events |
+| `health-score` | `76.9` | Repository health score (0 - 100) |
+| `health-grade` | `C` | Health grade (A, B, C, D, F) |
+| `diff-json` | `{...}` | Full `omen diff` JSON output; empty on non-pull-request events |
+| `score-json` | `{...}` | Full `omen score` JSON output |
+
+If a JSON output would exceed the GitHub Actions output-size guard (900KB), the action writes it to a temporary file and returns the file path instead of inline JSON. Consumers should accept either form.
+
+### Job Summary
+
+When `summary: true` (the default), the action writes a job-summary table with health, PR risk, and change-size metrics, followed by a component-score breakdown table. Diff risk and change-size metrics are only available on pull request events; on other events the summary notes that they were skipped.
+
+### Sticky PR Comment
+
+When `comment: true` on a pull request event, the action posts (or updates, on subsequent pushes) a single comment marked with an `<!-- omen-analysis -->` marker. The comment leads with a **Needs attention** section that surfaces the lowest-scoring components below their attention thresholds, each with a one-line explanation and the CLI command to investigate it locally. Below that, collapsible sections cover the full component-score table, PR risk factors, recommendations, and a short "investigate locally" cheat sheet. The comment footer reports the omen version that generated it.
+
+### Risk Label
+
+When `label: true` on a pull request event, the action creates (if needed) and applies a label named from `label-template` with `{{level}}` replaced by the risk level, using the corresponding `label-color-*` input. Any stale risk label from a previous run (a different level) is removed first.
 
 ### Quality Gate via Action
 
 ```yaml
-      - uses: panbanda/omen@omen-v4.23.0
+      - uses: panbanda/omen@omen-v4.26.1
         with:
           check: true
           check-threshold: high  # fail on high risk PRs
 ```
 
+The check only runs for pull request events; on other events it is skipped with a warning, since diff risk analysis requires a PR base to compare against.
+
 ## GitHub Actions (Manual)
 
-For more control, you can install Omen manually and run commands directly.
+For more control, you can install Omen manually and run commands directly instead of using the composite action.
 
 ### Quality Gate with Repository Score
 
-The simplest integration: fail the build if the repository score drops below a threshold.
+The simplest integration: fail the build if the repository score drops below a threshold configured in `omen.toml`.
 
 ```yaml
 name: Code Quality
@@ -112,20 +159,20 @@ jobs:
           fetch-depth: 0  # Full history needed for churn, ownership, hotspot analyzers
 
       - name: Install Omen
-        run: brew install panbanda/omen/omen
+        run: brew install panbanda/brews/omen
 
       - name: Check repository score
         run: omen score
 ```
 
-`omen score` exits with code 1 if the score is below the configured minimum (default: 60). No additional scripting is needed for a basic pass/fail gate.
+`omen score` exits non-zero if the score is below `[score] fail_under` in `omen.toml`. If `fail_under` is not set, the command always exits 0.
 
-For a custom threshold:
+For a custom threshold without editing `omen.toml`:
 
 ```yaml
       - name: Check repository score
         run: |
-          SCORE=$(omen -f json score | jq '.score')
+          SCORE=$(omen -f json score | jq '.overall_score')
           echo "Repository score: $SCORE"
           if [ "$(echo "$SCORE < 70" | bc)" -eq 1 ]; then
             echo "::error::Repository score $SCORE is below threshold (70)"
@@ -152,103 +199,20 @@ jobs:
           fetch-depth: 0
 
       - name: Install Omen
-        run: brew install panbanda/omen/omen
+        run: brew install panbanda/brews/omen
 
       - name: Analyze PR changes
         run: |
-          omen diff --target ${{ github.base_ref }}
+          omen diff --target origin/${{ github.base_ref }}
 
       - name: Check change risk
         run: |
-          RESULT=$(omen -f json diff --target ${{ github.base_ref }})
-          RISK=$(echo "$RESULT" | jq '.risk_score')
+          RESULT=$(omen -f json diff --target origin/${{ github.base_ref }})
+          RISK=$(echo "$RESULT" | jq '.score')
           echo "Change risk score: $RISK"
 
           if [ "$(echo "$RISK > 0.8" | bc)" -eq 1 ]; then
             echo "::warning::High-risk changes detected (risk score: $RISK). Extra review recommended."
-          fi
-```
-
-### Complete Workflow
-
-A full workflow that runs quality gates, risk assessment, and posts a summary comment on the PR:
-
-```yaml
-name: Omen Analysis
-on:
-  pull_request:
-    types: [opened, synchronize]
-
-jobs:
-  analyze:
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Install Omen
-        run: brew install panbanda/omen/omen
-
-      - name: Run analysis
-        id: analysis
-        run: |
-          # Repository score
-          SCORE=$(omen -f json score | jq '.score')
-          echo "score=$SCORE" >> "$GITHUB_OUTPUT"
-
-          # Diff analysis
-          DIFF=$(omen -f json diff --target ${{ github.base_ref }})
-          RISK=$(echo "$DIFF" | jq '.risk_score')
-          CHANGED=$(echo "$DIFF" | jq '.files_changed')
-          echo "risk=$RISK" >> "$GITHUB_OUTPUT"
-          echo "changed=$CHANGED" >> "$GITHUB_OUTPUT"
-
-          # SATD check
-          SATD_SECURITY=$(omen -f json satd | jq '[.items[] | select(.category == "security")] | length')
-          echo "security_debt=$SATD_SECURITY" >> "$GITHUB_OUTPUT"
-
-          # Stale flags
-          STALE_FLAGS=$(omen -f json flags | jq '[.flags[] | select(.stale)] | length')
-          echo "stale_flags=$STALE_FLAGS" >> "$GITHUB_OUTPUT"
-
-      - name: Post summary comment
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const score = '${{ steps.analysis.outputs.score }}';
-            const risk = '${{ steps.analysis.outputs.risk }}';
-            const changed = '${{ steps.analysis.outputs.changed }}';
-            const securityDebt = '${{ steps.analysis.outputs.security_debt }}';
-            const staleFlags = '${{ steps.analysis.outputs.stale_flags }}';
-
-            const body = `## Omen Analysis
-
-            | Metric | Value |
-            |--------|-------|
-            | Repository Score | ${score}/100 |
-            | Change Risk | ${risk} |
-            | Files Changed | ${changed} |
-            | Security Debt Items | ${securityDebt} |
-            | Stale Feature Flags | ${staleFlags} |
-            `;
-
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: body
-            });
-
-      - name: Fail on quality gate
-        run: |
-          SCORE=${{ steps.analysis.outputs.score }}
-          if [ "$(echo "$SCORE < 60" | bc)" -eq 1 ]; then
-            echo "::error::Repository score $SCORE is below minimum threshold (60)"
-            exit 1
           fi
 ```
 
@@ -257,7 +221,7 @@ jobs:
 For CI environments where installing Rust tooling is impractical, use the Docker image:
 
 ```bash
-docker run --rm -v "$(pwd):/repo" ghcr.io/panbanda/omen:latest score /repo
+docker run --rm -v "$(pwd):/repo" ghcr.io/panbanda/omen:latest -p /repo score
 ```
 
 In a GitHub Actions workflow:
@@ -268,7 +232,7 @@ In a GitHub Actions workflow:
           docker run --rm \
             -v "${{ github.workspace }}:/repo" \
             ghcr.io/panbanda/omen:latest \
-            -f json score /repo
+            -f json -p /repo score
 ```
 
 The Docker image includes all tree-sitter grammars and requires no additional dependencies.
@@ -284,20 +248,11 @@ pre-push:
     omen-score:
       run: omen score
       fail_text: "Repository score is below the minimum threshold. Run 'omen score' for details."
-
-    omen-satd-security:
-      run: |
-        SECURITY=$(omen -f json satd | jq '[.items[] | select(.category == "security")] | length')
-        if [ "$SECURITY" -gt 0 ]; then
-          echo "Found $SECURITY unresolved security debt items"
-          exit 1
-        fi
-      fail_text: "Unresolved security debt detected. Run 'omen satd' for details."
 ```
 
 ## JSON Output
 
-All Omen commands support `-f json` for machine-readable output. This is the recommended format for CI integration because it provides structured data that can be parsed with `jq` or any JSON library.
+All Omen commands support `-f json` for machine-readable output. This is the recommended format for CI integration because it provides structured data that can be parsed with `jq` or any JSON library. Add the global `--compact` flag to minify the output.
 
 ```bash
 # Repository score with component breakdown
@@ -326,29 +281,14 @@ Configure the pass/fail threshold in `omen.toml`:
 
 ```toml
 [score]
-minimum_score = 60
+fail_under = 60.0
 ```
 
-When `omen score` runs, it compares the computed score against this threshold. If the score is below the minimum, the command exits with code 1. If the threshold is not set, the command always exits with code 0 (no gate).
-
-The threshold can also be overridden on the command line:
-
-```bash
-omen score --minimum 75
-```
+When `omen score` runs, it compares the computed score against this threshold. If the score is below the threshold, the command exits non-zero. If `fail_under` is not set, the command always exits 0 (no gate).
 
 ## Tips for CI Integration
 
 **Use `fetch-depth: 0`.** Many analyzers (churn, ownership, hotspot, temporal coupling, defect prediction) require Git history. Shallow clones will produce incomplete or missing results for these analyzers. Always use `fetch-depth: 0` in your checkout step.
-
-**Cache the Omen binary.** If you install via `cargo install`, cache the Cargo binary directory to avoid recompilation on every run:
-
-```yaml
-      - uses: actions/cache@v4
-        with:
-          path: ~/.cargo/bin
-          key: omen-${{ runner.os }}
-```
 
 **Run analyzers selectively.** `omen all` runs every analyzer, which may be slow on large codebases. In CI, consider running only the analyzers that matter for your quality gate:
 
@@ -356,6 +296,7 @@ omen score --minimum 75
 omen score                    # Composite score (runs necessary analyzers internally)
 omen diff --target main       # PR-specific risk
 omen satd                     # Debt check
+omen stubs --gate error       # Fail the build if any unfinished stub is found
 ```
 
 **Store results as artifacts.** Save JSON output for trend tracking:

--- a/docs/integrations/mcp-server.md
+++ b/docs/integrations/mcp-server.md
@@ -12,23 +12,26 @@ Omen includes a built-in [Model Context Protocol](https://modelcontextprotocol.i
 
 ## Why MCP
 
-LLMs generate code without knowing the structural context of the codebase they are modifying. They cannot see that a module already has cyclomatic complexity of 25, that a function was changed 47 times in the last 6 months, or that 30% of the test suite is skipped. MCP gives them access to this information through a standardized tool-calling interface.
+LLMs generate code without knowing the structural context of the codebase they are modifying. They cannot see that a module already has cyclomatic complexity of 25, that a function was changed 47 times in the last 6 months, or that a function is still a `todo!()` stub. MCP gives them access to this information through a standardized tool-calling interface.
 
 When connected to Omen's MCP server, an AI assistant can check complexity before adding a new branch, look for code clones before writing a function that might already exist, and assess defect risk before modifying a file that has historically been bug-prone.
 
 ## Available Tools
 
-The MCP server exposes 20 tools:
+`McpServer::tool_names()` is the single source of truth for the tool list; the manifest reads from it. The server currently exposes these tools:
 
 | Tool | Description |
 |------|-------------|
+| `context` | Agent-oriented repository overview and navigation hints |
+| `outline` | Token-cheap imports, classes, and function outline for a file |
 | `complexity` | Cyclomatic and cognitive complexity per function |
 | `satd` | Self-admitted technical debt in comments |
+| `stubs` | Incomplete/placeholder implementation detection (read-only; does not expose the CLI's `--gate` option) |
 | `deadcode` | Unreachable functions and unused exports |
 | `churn` | File change frequency and volume |
 | `clones` | Duplicated code blocks (Type 1, 2, 3) |
 | `defect` | Defect probability predictions |
-| `changes` | Risk scores for recent modifications |
+| `changes` | Risk scores for recent modifications (JIT) |
 | `diff` | Structural analysis of uncommitted or branch changes |
 | `tdg` | Technical debt gradient scores |
 | `graph` | Import/dependency relationships and cycles |
@@ -41,19 +44,31 @@ The MCP server exposes 20 tools:
 | `flags` | Feature flag usage and staleness |
 | `score` | Composite repository health score (0-100) |
 | `semantic_search` | Natural language code search with optional complexity filtering |
+| `get_symbol` | Source, location, callers/callees, and complexity for one symbol |
+| `impact` | Transitive caller/callee blast-radius analysis for a symbol |
 | `semantic_search_hyde` | HyDE-style search using a hypothetical code snippet as query |
 
-Each tool accepts the same parameters as its CLI counterpart and returns structured results. The `semantic_search` and `semantic_search_hyde` tools additionally support `max_complexity` (filter out high-complexity functions) and `include_projects` (cross-repo search) parameters.
+Each tool honors the parameters advertised in its MCP input schema and returns structured results. Every tool also accepts `limit` (default 50) and `offset` (default 0) for pagination. The `semantic_search` and `semantic_search_hyde` tools additionally support `max_complexity` (filter out high-complexity functions) and `include_projects` (cross-repo search) parameters.
 
-## Output Format: TOON
+## Output Format
 
-By default, tool outputs use the TOON format (Text-Optimized Object Notation). TOON is a compact serialization format designed specifically for LLM consumption:
+Tool responses are serialized as compact (minified, single-line) JSON, wrapped in an envelope containing `tool`, `total_items`, `returned`, `offset`, and `result` (plus `git_skipped_reason` when applicable). Some tools can return agent-facing Markdown instead when their advertised `format` parameter allows it. Compact JSON keeps token usage low without losing any structure -- everything available in the full JSON output is still present, just without extra whitespace.
 
-- **30-60% smaller than JSON** for typical analysis results
-- **Optimized for token efficiency**: LLMs pay per token, and analysis results can be verbose
-- **Preserves structure**: all data is accessible, just encoded more compactly
+## Transport and Filesystem Scope
 
-JSON and Markdown formats are also available. The format can be configured per-tool or globally.
+The server uses stdio transport only:
+
+```bash
+omen mcp
+```
+
+There are no host or port options -- MCP communication happens over stdin/stdout, so there is nothing to bind or expose on the network.
+
+By default, tool paths are confined to the configured repository root. Pass `--allow-external-paths` to opt out of that boundary for clients that intentionally need broader filesystem access:
+
+```bash
+omen mcp --allow-external-paths
+```
 
 ## Setup
 
@@ -92,6 +107,8 @@ claude mcp list
 
 You should see `omen` in the list of configured servers. The tools will be available in subsequent Claude Code sessions.
 
+Installing the [Claude Code plugin](./claude-code-plugin.md) registers this MCP server automatically, so manual setup is only needed if you want to configure it by hand.
+
 ### Other MCP Clients
 
 Any MCP-compatible client can connect to Omen. The server communicates over stdio transport. Start it with:
@@ -112,6 +129,9 @@ The LLM calls the `complexity` tool and summarizes the results, highlighting fun
 **"Is it safe to modify `src/auth/session.rs`?"**
 The LLM can call `churn` (how often this file changes), `ownership` (who knows this file), `defect` (defect probability), and `hotspot` (is it a hotspot) to give a risk assessment.
 
+**"Are there any unfinished stubs left in this module?"**
+The LLM calls `stubs` and reports any `todo!()`/`NotImplementedError`-style placeholders or elided implementations.
+
 **"Are there any security concerns in the comments?"**
 The LLM calls `satd` and filters for security-category items.
 
@@ -128,24 +148,10 @@ The LLM calls `graph` with the path scoped to the auth module.
 The LLM calls `flags` and filters for stale flags.
 
 **"What would break if I changed the `User` struct?"**
-The LLM calls `graph` for dependents, `temporal` for files that co-change with the User module, and `clones` to check for duplicated logic that might need parallel changes.
+The LLM calls `impact` for transitive callers/callees, `temporal` for files that co-change with the User module, and `clones` to check for duplicated logic that might need parallel changes.
 
-## Configuration
-
-MCP server settings in `omen.toml`:
-
-```toml
-[mcp]
-# Default output format for tool results
-# Options: "toon", "json", "markdown"
-format = "toon"
-
-# Whether to include file contents in results (can be large)
-include_source = false
-
-# Maximum number of results per tool call
-max_results = 100
-```
+**"Give me a quick orientation to this repository."**
+The LLM calls `context` for an agent-oriented overview, and `outline` on specific files for a token-cheap map of imports, classes, and functions before reading full source.
 
 ## Programmatic Usage
 
@@ -159,14 +165,15 @@ The MCP server returns structured data that can be parsed by any MCP client. A t
     "name": "complexity",
     "arguments": {
       "path": "./src",
-      "language": "rust"
+      "limit": 50,
+      "offset": 0
     }
   }
 }
 ```
 
 **Response** (from Omen MCP server):
-The response contains the analysis results in the configured format (TOON by default, JSON if configured).
+The response contains the analysis results as compact JSON, wrapped in the pagination envelope described above.
 
 ## Running Alongside Other MCP Servers
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -5,7 +5,7 @@ slug: /
 
 # Introduction
 
-Omen is a multi-language code analysis CLI built in Rust. It uses tree-sitter to parse source code across 13 languages and runs 19 analyzers that surface complexity, technical debt, defect risk, code clones, dependency problems, and more.
+Omen is a multi-language code analysis CLI built in Rust. It uses tree-sitter to parse source code across 13 languages and runs 20 analyzers that surface complexity, technical debt, defect risk, unfinished stubs, code clones, dependency problems, and more.
 
 ## Why Omen Exists
 
@@ -19,7 +19,7 @@ An omen is a sign of things to come. Code analysis is the same idea applied to s
 
 ## Key Capabilities
 
-### 19 Analyzers
+### 20 Analyzers
 
 Omen ships with a broad set of analyzers covering structural, historical, and predictive dimensions of code quality:
 
@@ -27,11 +27,11 @@ Omen ships with a broad set of analyzers covering structural, historical, and pr
 |---|---|
 | Structural | Complexity, coupling, cohesion, code smells, dead code |
 | Duplication | Code clone detection (Type 1, 2, and 3 clones) |
-| Technical debt | SATD detection, technical debt gradient, dependency analysis |
+| Technical debt | SATD detection, stubs detection, technical debt gradient, dependency analysis |
 | Predictive | Defect prediction, hotspot detection, churn analysis |
-| Testing | Mutation testing, coverage analysis |
+| Testing | Mutation testing |
 | Composite | Repository score, dependency graph |
-| Discovery | Semantic search, file statistics |
+| Discovery | Semantic search |
 
 ### 13 Languages
 
@@ -43,7 +43,7 @@ Omen includes a built-in MCP (Model Context Protocol) server, allowing LLMs and 
 
 ### Semantic Search
 
-Natural language code discovery powered by local vector embeddings. Omen extracts symbols from the codebase, generates embeddings using all-MiniLM-L6-v2 via the candle inference library, and indexes them in a local SQLite database. No API keys required for the default provider.
+Natural language code discovery powered by a local TF-IDF engine (sublinear TF, smooth IDF, bigram tokenization) -- no external models, no API keys, no GPU required. Omen extracts symbols from the codebase and indexes them in a local SQLite database at `.omen/search.db`.
 
 ### Mutation Testing
 

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -4,16 +4,15 @@ sidebar_position: 20
 
 # Output Formats
 
-All Omen commands support four output formats, controlled by the `-f` or `--format` flag:
+All Omen commands support three output formats, controlled by the `-f` or `--format` flag:
 
 ```bash
 omen -f markdown complexity
 omen -f json score
 omen -f text churn
-omen -f toon all
 ```
 
-The default format is markdown. The MCP server defaults to TOON.
+The default format is markdown.
 
 ## Markdown (default)
 
@@ -52,7 +51,7 @@ Markdown output renders cleanly in terminals that support Unicode box-drawing ch
 
 ## JSON
 
-Machine-parseable output with full nesting. Use this for CI/CD pipelines, scripting, or programmatic consumption.
+Machine-parseable output with full nesting. Use this for CI/CD pipelines, scripting, or programmatic consumption. This is also the format used by the MCP server.
 
 ```bash
 omen -f json complexity
@@ -98,8 +97,19 @@ JSON output is stable and suitable for piping to tools like `jq`:
 omen -f json complexity | jq '.functions[] | select(.level == "error") | .function'
 
 # Get the repository score as a number
-omen -f json score | jq '.score'
+omen -f json score | jq '.overall_score'
 ```
+
+### Compact JSON
+
+The global `--compact` flag minifies JSON output to a single line. It is a clap global flag, so it may appear before or after the subcommand, and it is ignored for non-JSON formats:
+
+```bash
+omen -f json score --compact
+omen --compact -f json complexity
+```
+
+This is the format used for MCP tool responses and is useful whenever token efficiency matters more than human readability -- for example, when piping results into an LLM prompt or storing them as a CI artifact.
 
 ## Text
 
@@ -125,42 +135,19 @@ Functions exceeding thresholds:
   src/scoring/composite.rs:89  calculate_score  cyclomatic=18  cognitive=19  nesting=4  WARN
 ```
 
-## TOON
-
-Token-Oriented Object Notation (TOON) is a compact structured format designed for LLM workflows. It is 30-60% smaller than equivalent JSON while maintaining high comprehension accuracy for language models.
-
-```bash
-omen -f toon complexity
-```
-
-Example output:
-
-```
-@complexity_analysis
-  summary{files:42 functions:318 warnings:12 errors:3}
-  #functions
-    [src/analyzer/complexity.rs:45|analyze_function|cyc:24|cog:31|nest:5|ERROR]
-    [src/git/blame.rs:112|compute_ownership|cyc:22|cog:28|nest:6|ERROR]
-    [src/scoring/composite.rs:89|calculate_score|cyc:18|cog:19|nest:4|WARN]
-```
-
-TOON reduces token consumption when analysis results are fed into LLM prompts, which matters for cost and context window utilization. It uses delimiters (`@`, `#`, `{}`, `[]`, `|`) instead of verbose JSON syntax (quoted keys, colons, commas, braces).
-
-The MCP server uses TOON as its default output format because MCP responses are consumed by language models, where token efficiency directly impacts cost and available context.
-
-For the TOON specification, see [github.com/toon-format/toon](https://github.com/toon-format/toon).
-
 ## Format Comparison
-
-The same data in all four formats, showing relative verbosity:
 
 | Format   | Approximate Token Count | Best For |
 |----------|------------------------|----------|
 | Markdown | 100% (baseline)        | Human reading, documentation, PR comments |
 | JSON     | 120-140%               | CI/CD, scripting, programmatic access |
 | Text     | 70-80%                 | Minimal environments, simple text processing |
-| TOON     | 40-60%                 | LLM consumption, MCP server, token-constrained contexts |
+| JSON + `--compact` | 90-110%      | MCP tool responses, LLM prompts, token-constrained contexts |
+
+## Pagination for Large Results
+
+Most analyzers support `--top N` and `--offset N` on the CLI to page through large result sets. The MCP server uses an equivalent `limit`/`offset` envelope on every tool call (default `limit`: 50): the response wraps the analysis result together with `tool`, `total_items`, `returned`, and `offset` fields (plus `git_skipped_reason` when applicable), so a client can request additional pages without re-running the full analysis. See [MCP Server](./integrations/mcp-server.md) for details.
 
 ## Setting a Default Format
 
-The format can be set per-invocation with `-f`. There is no configuration file option to change the default format -- it is always markdown for CLI usage and TOON for MCP. This keeps behavior predictable: running `omen complexity` in a terminal always produces the same format regardless of project configuration.
+The format can be set per-invocation with `-f`. There is no configuration file option to change the default format -- it is always markdown for CLI usage. This keeps behavior predictable: running `omen complexity` in a terminal always produces the same format regardless of project configuration.

--- a/docs/repository-score.md
+++ b/docs/repository-score.md
@@ -71,24 +71,14 @@ This means a codebase with 10 security-related SATD markers scores worse than on
 
 ## Configuration
 
-Score weights and thresholds are configurable in `omen.toml`:
+The `[score]` section in `omen.toml` accepts a single option, `fail_under`, which sets the pass/fail threshold for CI:
 
 ```toml
 [score]
-# Override component weights (must sum to 1.0)
-complexity_weight = 0.25
-duplication_weight = 0.20
-satd_weight = 0.10
-tdg_weight = 0.15
-coupling_weight = 0.10
-smells_weight = 0.05
-cohesion_weight = 0.15
-
-# Threshold for pass/fail in CI
-minimum_score = 60
+fail_under = 70.0
 ```
 
-If weights are overridden, they must sum to 1.0. Omen will error on startup if they don't.
+Component weights (the percentages in the table above) are not currently configurable through `omen.toml`. If `fail_under` is not set, `omen score` always exits 0 -- there is no gate by default.
 
 ## Score Trend Tracking
 
@@ -104,13 +94,13 @@ This walks the Git history, checks out historical commits (or reads cached snaps
 - Correlating score changes with specific releases or refactoring efforts
 - Providing evidence for technical debt reduction initiatives
 
-Available periods: `daily`, `weekly`, `monthly`. The `--since` flag accepts duration strings like `3m` (3 months), `1y` (1 year), `90d` (90 days).
+Available periods: `daily`, `weekly`, `monthly`. The `--since` flag accepts the same duration strings as `[churn] since` (`1m`, `3m`, `6m`, `1y`, `2y`, `all`) and defaults to `all` (full repository history).
 
 ## CI/CD Integration
 
 ### Exit Codes
 
-`omen score` exits with code 0 if the score meets the configured minimum threshold, and code 1 if it doesn't. This makes it directly usable as a quality gate:
+When `[score] fail_under` is configured, `omen score` exits non-zero if the score falls below it. This makes it directly usable as a quality gate:
 
 ```bash
 omen score || exit 1
@@ -136,8 +126,8 @@ For more complex CI logic, parse the JSON output:
 
 ```bash
 RESULT=$(omen -f json score)
-SCORE=$(echo "$RESULT" | jq '.score')
-COMPLEXITY=$(echo "$RESULT" | jq '.components.complexity')
+SCORE=$(echo "$RESULT" | jq '.overall_score')
+COMPLEXITY=$(echo "$RESULT" | jq '.components.complexity.score')
 
 echo "Overall: $SCORE, Complexity: $COMPLEXITY"
 

--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -47,6 +47,7 @@ Not all analyzers apply equally to all languages. Some analyzers are universal (
 |----------|:--:|:----:|:------:|:--:|:--:|:-------:|:----:|:-:|:---:|:--:|:----:|:---:|:----:|
 | Complexity | x | x | x | x | x | x | x | x | x | x | x | x | x |
 | SATD | x | x | x | x | x | x | x | x | x | x | x | x | x |
+| Stubs | x | x | x | x | x | x | x | x | x | x | x | x | x |
 | Dead Code | x | x | x | x | x | x | x | x | x | x | x | x | x |
 | Churn | x | x | x | x | x | x | x | x | x | x | x | x | x |
 | Code Clones | x | x | x | x | x | x | x | x | x | x | x | x | x |
@@ -73,6 +74,7 @@ The following analyzers work identically across all 13 languages. They rely on g
 
 - **Complexity** -- cyclomatic and cognitive complexity, nesting depth
 - **SATD** -- comment scanning for technical debt markers
+- **Stubs** -- AST-based detection of incomplete/placeholder implementations
 - **Dead Code** -- unreachable functions and unused exports
 - **Churn** -- file change frequency from Git history
 - **Code Clones** -- token-based duplicate detection
@@ -85,7 +87,7 @@ The following analyzers work identically across all 13 languages. They rely on g
 - **Ownership** -- contributor distribution from Git blame
 - **Temporal Coupling** -- co-change detection from Git history
 - **Diff Analysis** -- structural analysis of uncommitted changes
-- **Semantic Search** -- embedding-based code discovery
+- **Semantic Search** -- TF-IDF-based code discovery
 
 ### CK Metrics (Cohesion)
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -55,6 +55,7 @@ const sidebars: SidebarsConfig = {
           label: 'Specialized',
           items: [
             'analyzers/satd',
+            'analyzers/stubs',
             'analyzers/feature-flags',
             'analyzers/mutation-testing',
           ],


### PR DESCRIPTION
## Summary

The documentation site was ~6 months stale. This brings it current and adds the new `stubs` analyzer.

- Removed the nonexistent **"TOON"** output format; documented the real output model (markdown/JSON/text, global `--compact`, `limit`/`offset` pagination).
- Removed references to deleted flags (`--no-cache`, `mcp --port/--host`, `omen init`, `context --repo-map/--target/--symbol/--depth`); documented current ones (`deadcode --cargo-check`, `mcp --allow-external-paths`, `mutation --allow-dirty`, repeatable `-e/--exclude`).
- Completed the MCP tool list (`context`, `outline`, `get_symbol`, `impact`, `stubs`); noted stdio-only transport and repo-root path confinement.
- Rewrote configuration docs to match `omen.example.toml` (removed invented sections; noted `deny_unknown_fields`; corrected search as TF-IDF, not embeddings).
- Updated the GitHub Action page against the current `action.yml` (new `summary`/`github-token` inputs, permissions, `fetch-depth: 0`, the "Needs attention" PR comment, pinned `omen-v4.26.1`).
- Added **`docs/analyzers/stubs.md`** + sidebar entry, plus an agent-facing-commands section.
- Fixed extras found while verifying: wrong Homebrew tap, stale JSON field names.

## Verification

`npm ci && npm run build` succeeds with no errors and no broken-link warnings; the new stubs page builds and its sidebar link resolves. Only build artifacts are gitignored — this changes doc source only. Merging deploys via the existing `deploy.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)