### PR TITLE
Standardize CLI flags and gate convention

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -1,0 +1,34 @@
+# Deprecations
+
+Single source of truth for everything scheduled for removal. When cutting a
+breaking (major) release, work this list top to bottom and remove each entry
+plus its code.
+
+Every deprecation in the codebase is tagged with a greppable marker so you can
+find all sites for a given removal milestone:
+
+```
+rg "DEPRECATED(remove-in: 5.0)"
+```
+
+The marker format is `DEPRECATED(remove-in: <version>): <what to use instead>`,
+placed in a doc comment or code comment at each site.
+
+## Remove in 5.0
+
+### CLI flags
+
+| Deprecated | Replacement | Sites |
+|---|---|---|
+| `--check` (complexity, score, mutation) | `--gate error` | `src/cli/mod.rs` (the three `pub check` fields), `resolve_gate_mode` in `src/main.rs` maps a bare `--check` to `--gate error` |
+| `--top-k` / `-k` (search query) | `--top` / `-n` | `src/cli/mod.rs` (`top_k` field, `alias = "top-k"`) |
+
+Note: `--days` (churn) is a **kept** alias for `--since`, not scheduled for
+removal, so it carries no marker. `all`-payload key `duplicates` and report
+artifact names `duplicates.json` / `hotspots.json` are deferred to the output
+schema change (they are part of the JSON contract); see `TODO(output-schema)`
+comments in `src/main.rs`.
+
+<!-- Future work (output-schema standardization) will add entries here for the
+     duplicated path fields (`path`/`file_path` emitted alongside canonical
+     `file`), `AnalysisSummary` alias, etc., using the same marker convention. -->

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -7,7 +7,7 @@ plus its code.
 Every deprecation in the codebase is tagged with a greppable marker so you can
 find all sites for a given removal milestone:
 
-```
+```sh
 rg "DEPRECATED(remove-in: 5.0)"
 ```
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -196,11 +196,18 @@ pub struct DiffArgs {
     #[arg(short, long)]
     pub target: Option<String>,
 
-    // Only `top`/`offset` are wired up (see `run_diff_analyzer` in main.rs);
-    // `diff` analyzes a git diff, not a filtered file set, so `glob`/`exclude`/
-    // `changed_since` parse but currently have no effect on this command.
-    #[command(flatten)]
-    pub common: AnalyzerArgs,
+    // `diff` analyzes a git diff, not a filtered file set, so it only takes
+    // pagination flags (not the full `AnalyzerArgs`, which would also add
+    // `--glob`/`--exclude`/`--changed-since` -- flags that would parse but
+    // silently do nothing, since diff has no file-set filtering to apply
+    // them to).
+    /// Limit output to the top N results (0 = unlimited)
+    #[arg(short = 'n', long)]
+    pub top: Option<usize>,
+
+    /// Skip the first N results (use with --top for pagination)
+    #[arg(long)]
+    pub offset: Option<usize>,
 }
 
 #[derive(Args)]
@@ -214,10 +221,11 @@ pub struct ComplexityArgs {
     pub check: bool,
 
     /// Gate mode: 'off' just reports, 'warn' reports and warns on stderr (exit 0),
-    /// 'error' reports and exits 2 if thresholds are exceeded. If both --check and
-    /// --gate are given, --gate wins.
-    #[arg(long, value_enum, default_value = "off")]
-    pub gate: GateMode,
+    /// 'error' reports and exits 2 if thresholds are exceeded (default: off). If
+    /// both --check and --gate are given, --gate always wins, including an
+    /// explicit `--gate off`.
+    #[arg(long, value_enum)]
+    pub gate: Option<GateMode>,
 
     /// Maximum cyclomatic complexity (default: from config or 20)
     #[arg(long)]
@@ -312,10 +320,11 @@ pub struct ScoreArgs {
     pub check: bool,
 
     /// Gate mode: 'off' just reports, 'warn' reports and warns on stderr (exit 0),
-    /// 'error' reports and exits 2 if score is below --fail-under. If both --check
-    /// and --gate are given, --gate wins.
-    #[arg(long, value_enum, default_value = "off")]
-    pub gate: GateMode,
+    /// 'error' reports and exits 2 if score is below --fail-under (default: off).
+    /// If both --check and --gate are given, --gate always wins, including an
+    /// explicit `--gate off`.
+    #[arg(long, value_enum)]
+    pub gate: Option<GateMode>,
 
     /// Minimum score to pass (default: from config)
     #[arg(long)]
@@ -494,8 +503,15 @@ pub struct SearchQueryArgs {
     pub query: String,
 
     /// Maximum number of results.
-    /// DEPRECATED(remove-in: 5.0): `--top-k` is an alias for `--top`; use `--top`.
-    #[arg(short = 'k', long = "top", alias = "top-k", default_value = "10")]
+    /// DEPRECATED(remove-in: 5.0): `-k`/`--top-k` are aliases for `-n`/`--top`;
+    /// use `-n`/`--top`.
+    #[arg(
+        short = 'n',
+        long = "top",
+        alias = "top-k",
+        short_alias = 'k',
+        default_value = "10"
+    )]
     pub top_k: usize,
 
     /// Minimum similarity score (0.0-1.0)
@@ -535,10 +551,11 @@ pub struct MutationArgs {
     pub check: bool,
 
     /// Gate mode: 'off' just reports, 'warn' reports and warns on stderr (exit 0),
-    /// 'error' reports and exits 2 if mutation score is below --min-score. If both
-    /// --check and --gate are given, --gate wins.
-    #[arg(long, value_enum, default_value = "off")]
-    pub gate: GateMode,
+    /// 'error' reports and exits 2 if mutation score is below --min-score (default:
+    /// off). If both --check and --gate are given, --gate always wins, including
+    /// an explicit `--gate off`.
+    #[arg(long, value_enum)]
+    pub gate: Option<GateMode>,
 
     /// Minimum mutation score (0.0-1.0)
     #[arg(long, default_value = "0.8")]
@@ -2029,23 +2046,40 @@ mod tests {
     }
 
     #[test]
-    fn test_diff_common_top_offset() {
+    fn test_diff_top_offset() {
         let cli = parse(&["omen", "diff", "--top", "3", "--offset", "1"]);
         if let Command::Diff(args) = cli.command {
-            assert_eq!(args.common.top, Some(3));
-            assert_eq!(args.common.offset, Some(1));
+            assert_eq!(args.top, Some(3));
+            assert_eq!(args.offset, Some(1));
         } else {
             panic!("Expected Diff command");
         }
     }
 
     #[test]
-    fn test_diff_common_top_short_n() {
+    fn test_diff_top_short_n() {
         let cli = parse(&["omen", "diff", "-n", "3"]);
         if let Command::Diff(args) = cli.command {
-            assert_eq!(args.common.top, Some(3));
+            assert_eq!(args.top, Some(3));
         } else {
             panic!("Expected Diff command");
+        }
+    }
+
+    #[test]
+    fn test_diff_rejects_no_op_filter_flags() {
+        // diff has no filtered file set to apply glob/exclude/changed-since
+        // to, so these must not parse -- advertising flags that silently do
+        // nothing is worse than rejecting them outright.
+        for args in [
+            vec!["omen", "diff", "--glob", "*.rs"],
+            vec!["omen", "diff", "--exclude", "tests/**"],
+            vec!["omen", "diff", "--changed-since", "main"],
+        ] {
+            assert!(
+                Cli::try_parse_from(&args).is_err(),
+                "expected {args:?} to be rejected"
+            );
         }
     }
 
@@ -2069,6 +2103,31 @@ mod tests {
     }
 
     #[test]
+    fn test_search_query_top_short_n_is_primary() {
+        // -n is now the canonical short flag for search's result limit,
+        // matching -n/--top everywhere else in the CLI.
+        if let SearchSubcommand::Query(args) =
+            parse_search_subcommand(&["omen", "search", "query", "test", "-n", "15"])
+        {
+            assert_eq!(args.top_k, 15);
+        } else {
+            panic!("Expected Query subcommand");
+        }
+    }
+
+    #[test]
+    fn test_search_query_top_short_k_deprecated_alias_still_parses() {
+        // -k is a deprecated short alias for -n/--top; must keep working.
+        if let SearchSubcommand::Query(args) =
+            parse_search_subcommand(&["omen", "search", "query", "test", "-k", "18"])
+        {
+            assert_eq!(args.top_k, 18);
+        } else {
+            panic!("Expected Query subcommand");
+        }
+    }
+
+    #[test]
     fn test_search_query_top_k_alias_still_parses() {
         // --top-k is a deprecated hidden alias for --top; must keep working.
         if let SearchSubcommand::Query(args) =
@@ -2085,28 +2144,36 @@ mod tests {
     // -----------------------------------------------------------------
 
     #[test]
-    fn test_complexity_gate_defaults_to_off() {
+    fn test_complexity_gate_defaults_to_none() {
+        // Unset (not `Some(GateMode::Off)`) so `resolve_gate_mode` can tell
+        // "no --gate at all" apart from an explicit `--gate off`.
         let args = parse_complexity_args(&["omen", "complexity"]);
-        assert!(matches!(args.gate, GateMode::Off));
+        assert_eq!(args.gate, None);
     }
 
     #[test]
     fn test_complexity_gate_error_parses() {
         let args = parse_complexity_args(&["omen", "complexity", "--gate", "error"]);
-        assert!(matches!(args.gate, GateMode::Error));
+        assert_eq!(args.gate, Some(GateMode::Error));
     }
 
     #[test]
     fn test_complexity_gate_warn_parses() {
         let args = parse_complexity_args(&["omen", "complexity", "--gate", "warn"]);
-        assert!(matches!(args.gate, GateMode::Warn));
+        assert_eq!(args.gate, Some(GateMode::Warn));
+    }
+
+    #[test]
+    fn test_complexity_gate_off_parses_explicitly() {
+        let args = parse_complexity_args(&["omen", "complexity", "--gate", "off"]);
+        assert_eq!(args.gate, Some(GateMode::Off));
     }
 
     #[test]
     fn test_complexity_check_still_parses_deprecated() {
         let args = parse_complexity_args(&["omen", "complexity", "--check"]);
         assert!(args.check);
-        assert!(matches!(args.gate, GateMode::Off));
+        assert_eq!(args.gate, None);
     }
 
     #[test]
@@ -2115,10 +2182,10 @@ mod tests {
     }
 
     #[test]
-    fn test_score_gate_defaults_to_off() {
+    fn test_score_gate_defaults_to_none() {
         let cli = parse(&["omen", "score"]);
         if let Command::Score(cmd) = cli.command {
-            assert!(matches!(cmd.args.gate, GateMode::Off));
+            assert_eq!(cmd.args.gate, None);
         } else {
             panic!("expected Score command");
         }
@@ -2128,7 +2195,7 @@ mod tests {
     fn test_score_gate_error_parses() {
         let cli = parse(&["omen", "score", "--gate", "error"]);
         if let Command::Score(cmd) = cli.command {
-            assert!(matches!(cmd.args.gate, GateMode::Error));
+            assert_eq!(cmd.args.gate, Some(GateMode::Error));
         } else {
             panic!("expected Score command");
         }
@@ -2138,35 +2205,78 @@ mod tests {
     fn test_score_gate_warn_parses() {
         let cli = parse(&["omen", "score", "--gate", "warn"]);
         if let Command::Score(cmd) = cli.command {
-            assert!(matches!(cmd.args.gate, GateMode::Warn));
+            assert_eq!(cmd.args.gate, Some(GateMode::Warn));
         } else {
             panic!("expected Score command");
         }
     }
 
     #[test]
-    fn test_mutation_gate_defaults_to_off() {
+    fn test_score_gate_off_parses_explicitly() {
+        let cli = parse(&["omen", "score", "--gate", "off"]);
+        if let Command::Score(cmd) = cli.command {
+            assert_eq!(cmd.args.gate, Some(GateMode::Off));
+        } else {
+            panic!("expected Score command");
+        }
+    }
+
+    #[test]
+    fn test_mutation_gate_defaults_to_none() {
         let args = parse_mutation_args(&["omen", "mutation"]);
-        assert!(matches!(args.gate, GateMode::Off));
+        assert_eq!(args.gate, None);
     }
 
     #[test]
     fn test_mutation_gate_error_parses() {
         let args = parse_mutation_args(&["omen", "mutation", "--gate", "error"]);
-        assert!(matches!(args.gate, GateMode::Error));
+        assert_eq!(args.gate, Some(GateMode::Error));
     }
 
     #[test]
     fn test_mutation_gate_warn_parses() {
         let args = parse_mutation_args(&["omen", "mutation", "--gate", "warn"]);
-        assert!(matches!(args.gate, GateMode::Warn));
+        assert_eq!(args.gate, Some(GateMode::Warn));
+    }
+
+    #[test]
+    fn test_mutation_gate_off_parses_explicitly() {
+        let args = parse_mutation_args(&["omen", "mutation", "--gate", "off"]);
+        assert_eq!(args.gate, Some(GateMode::Off));
     }
 
     #[test]
     fn test_mutation_check_still_parses_deprecated() {
         let args = parse_mutation_args(&["omen", "mutation", "--check"]);
         assert!(args.check);
-        assert!(matches!(args.gate, GateMode::Off));
+        assert_eq!(args.gate, None);
+    }
+
+    #[test]
+    fn test_complexity_gate_off_and_check_both_parse() {
+        // Regression: `--check --gate off` must parse cleanly and preserve
+        // both values so `resolve_gate_mode` can let --gate off win.
+        let args = parse_complexity_args(&["omen", "complexity", "--check", "--gate", "off"]);
+        assert!(args.check);
+        assert_eq!(args.gate, Some(GateMode::Off));
+    }
+
+    #[test]
+    fn test_score_gate_off_and_check_both_parse() {
+        let cli = parse(&["omen", "score", "--check", "--gate", "off"]);
+        if let Command::Score(cmd) = cli.command {
+            assert!(cmd.args.check);
+            assert_eq!(cmd.args.gate, Some(GateMode::Off));
+        } else {
+            panic!("expected Score command");
+        }
+    }
+
+    #[test]
+    fn test_mutation_gate_off_and_check_both_parse() {
+        let args = parse_mutation_args(&["omen", "mutation", "--check", "--gate", "off"]);
+        assert!(args.check);
+        assert_eq!(args.gate, Some(GateMode::Off));
     }
 
     // -----------------------------------------------------------------

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -52,7 +52,7 @@ pub enum Command {
     Complexity(ComplexityArgs),
 
     /// Detect Self-Admitted Technical Debt
-    #[command(alias = "debt")]
+    #[command(visible_alias = "debt")]
     Satd(AnalyzerArgs),
 
     /// Detect incomplete/placeholder implementations (todo!(), NotImplementedError, empty bodies)
@@ -66,11 +66,11 @@ pub enum Command {
     Churn(ChurnArgs),
 
     /// Detect code duplicates/clones
-    #[command(alias = "dup", alias = "duplicates")]
+    #[command(alias = "dup", visible_alias = "duplicates")]
     Clones(AnalyzerArgs),
 
     /// Predict defect-prone files using PMAT
-    #[command(alias = "predict")]
+    #[command(visible_alias = "predict")]
     Defect(AnalyzerArgs),
 
     /// Analyze recent changes (JIT risk)
@@ -89,7 +89,12 @@ pub enum Command {
     Graph(AnalyzerArgs),
 
     /// Find complexity/churn hotspots
-    #[command(alias = "hs")]
+    // CLI-layer alias note: the canonical command name is `hotspot` (singular);
+    // the report data contract (`.omen/data/hotspots.json`, the `report validate`
+    // file list, and the MCP tool-name mapping in src/mcp/mod.rs) still uses the
+    // plural `hotspots`. `hotspots` is accepted here as a visible alias so both
+    // spellings work from the CLI without touching the JSON/report contract.
+    #[command(alias = "hs", visible_alias = "hotspots")]
     Hotspot(AnalyzerArgs),
 
     /// Detect temporally coupled files
@@ -97,7 +102,7 @@ pub enum Command {
     Temporal(AnalyzerArgs),
 
     /// Analyze code ownership and bus factor
-    #[command(alias = "own", alias = "bus-factor")]
+    #[command(alias = "own", visible_alias = "bus-factor")]
     Ownership(AnalyzerArgs),
 
     /// Calculate CK cohesion metrics
@@ -144,7 +149,7 @@ pub enum Command {
     Outline(OutlineArgs),
 
     /// Analyze blast radius of a symbol change (callers/callees by BFS depth)
-    #[command(alias = "blast")]
+    #[command(visible_alias = "blast")]
     Impact(ImpactArgs),
 
     /// One-call symbol report: source, signature, location, callers/callees, complexity
@@ -167,7 +172,7 @@ pub struct AnalyzerArgs {
     pub changed_since: Option<String>,
 
     /// Limit output to the top N results (0 = unlimited)
-    #[arg(long)]
+    #[arg(short = 'n', long)]
     pub top: Option<usize>,
 
     /// Skip the first N results (use with --top for pagination)
@@ -190,6 +195,12 @@ pub struct DiffArgs {
     /// Target branch to diff against (default: auto-detect main/master)
     #[arg(short, long)]
     pub target: Option<String>,
+
+    // Only `top`/`offset` are wired up (see `run_diff_analyzer` in main.rs);
+    // `diff` analyzes a git diff, not a filtered file set, so `glob`/`exclude`/
+    // `changed_since` parse but currently have no effect on this command.
+    #[command(flatten)]
+    pub common: AnalyzerArgs,
 }
 
 #[derive(Args)]
@@ -197,9 +208,16 @@ pub struct ComplexityArgs {
     #[command(flatten)]
     pub common: AnalyzerArgs,
 
-    /// Check mode: fail if any function exceeds thresholds
+    /// Check mode: fail if any function exceeds thresholds.
+    /// DEPRECATED(remove-in: 5.0): use `--gate error` instead.
     #[arg(long)]
     pub check: bool,
+
+    /// Gate mode: 'off' just reports, 'warn' reports and warns on stderr (exit 0),
+    /// 'error' reports and exits 2 if thresholds are exceeded. If both --check and
+    /// --gate are given, --gate wins.
+    #[arg(long, value_enum, default_value = "off")]
+    pub gate: GateMode,
 
     /// Maximum cyclomatic complexity (default: from config or 20)
     #[arg(long)]
@@ -225,7 +243,7 @@ pub struct StubsArgs {
     pub gate_severity: GateSeverity,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
 pub enum GateMode {
     Off,
     Warn,
@@ -244,7 +262,13 @@ pub struct ChurnArgs {
     #[command(flatten)]
     pub common: AnalyzerArgs,
 
-    /// Number of days to analyze
+    /// Time period to analyze (e.g., 3m, 6m, 1y, 2y, all). Canonical time window
+    /// flag; --days is a documented alias for the same window. If both are given,
+    /// --since wins.
+    #[arg(long)]
+    pub since: Option<String>,
+
+    /// Number of days to analyze (alias for --since)
     #[arg(long)]
     pub days: Option<u32>,
 }
@@ -282,9 +306,16 @@ pub enum ScoreSubcommand {
 
 #[derive(Args)]
 pub struct ScoreArgs {
-    /// Check mode: fail if score is below threshold
+    /// Check mode: fail if score is below threshold.
+    /// DEPRECATED(remove-in: 5.0): use `--gate error` instead.
     #[arg(long)]
     pub check: bool,
+
+    /// Gate mode: 'off' just reports, 'warn' reports and warns on stderr (exit 0),
+    /// 'error' reports and exits 2 if score is below --fail-under. If both --check
+    /// and --gate are given, --gate wins.
+    #[arg(long, value_enum, default_value = "off")]
+    pub gate: GateMode,
 
     /// Minimum score to pass (default: from config)
     #[arg(long)]
@@ -462,8 +493,9 @@ pub struct SearchQueryArgs {
     /// Natural language query
     pub query: String,
 
-    /// Maximum number of results
-    #[arg(short = 'k', long, default_value = "10")]
+    /// Maximum number of results.
+    /// DEPRECATED(remove-in: 5.0): `--top-k` is an alias for `--top`; use `--top`.
+    #[arg(short = 'k', long = "top", alias = "top-k", default_value = "10")]
     pub top_k: usize,
 
     /// Minimum similarity score (0.0-1.0)
@@ -497,9 +529,16 @@ pub struct MutationArgs {
     #[arg(long, default_value = "CRR,ROR,AOR")]
     pub operators: String,
 
-    /// Check mode: fail if mutation score below threshold
+    /// Check mode: fail if mutation score below threshold.
+    /// DEPRECATED(remove-in: 5.0): use `--gate error` instead.
     #[arg(long)]
     pub check: bool,
+
+    /// Gate mode: 'off' just reports, 'warn' reports and warns on stderr (exit 0),
+    /// 'error' reports and exits 2 if mutation score is below --min-score. If both
+    /// --check and --gate are given, --gate wins.
+    #[arg(long, value_enum, default_value = "off")]
+    pub gate: GateMode,
 
     /// Minimum mutation score (0.0-1.0)
     #[arg(long, default_value = "0.8")]
@@ -1977,5 +2016,224 @@ mod tests {
         } else {
             panic!("Expected Symbol command");
         }
+    }
+
+    // -----------------------------------------------------------------
+    // Pagination: --top/-n/--offset, --top-k alias
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn test_analyzer_args_top_short_n() {
+        let args = parse_complexity_args(&["omen", "complexity", "-n", "5"]);
+        assert_eq!(args.common.top, Some(5));
+    }
+
+    #[test]
+    fn test_diff_common_top_offset() {
+        let cli = parse(&["omen", "diff", "--top", "3", "--offset", "1"]);
+        if let Command::Diff(args) = cli.command {
+            assert_eq!(args.common.top, Some(3));
+            assert_eq!(args.common.offset, Some(1));
+        } else {
+            panic!("Expected Diff command");
+        }
+    }
+
+    #[test]
+    fn test_diff_common_top_short_n() {
+        let cli = parse(&["omen", "diff", "-n", "3"]);
+        if let Command::Diff(args) = cli.command {
+            assert_eq!(args.common.top, Some(3));
+        } else {
+            panic!("Expected Diff command");
+        }
+    }
+
+    #[test]
+    fn test_mutation_top_offset() {
+        let args = parse_mutation_args(&["omen", "mutation", "--top", "4", "--offset", "2"]);
+        assert_eq!(args.common.top, Some(4));
+        assert_eq!(args.common.offset, Some(2));
+    }
+
+    #[test]
+    fn test_search_query_top_long_flag_still_works() {
+        // --top is now the canonical long flag for search's result limit.
+        if let SearchSubcommand::Query(args) =
+            parse_search_subcommand(&["omen", "search", "query", "test", "--top", "15"])
+        {
+            assert_eq!(args.top_k, 15);
+        } else {
+            panic!("Expected Query subcommand");
+        }
+    }
+
+    #[test]
+    fn test_search_query_top_k_alias_still_parses() {
+        // --top-k is a deprecated hidden alias for --top; must keep working.
+        if let SearchSubcommand::Query(args) =
+            parse_search_subcommand(&["omen", "search", "query", "test", "--top-k", "25"])
+        {
+            assert_eq!(args.top_k, 25);
+        } else {
+            panic!("Expected Query subcommand");
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Gate/check: --gate off|warn|error, --check deprecated alias
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn test_complexity_gate_defaults_to_off() {
+        let args = parse_complexity_args(&["omen", "complexity"]);
+        assert!(matches!(args.gate, GateMode::Off));
+    }
+
+    #[test]
+    fn test_complexity_gate_error_parses() {
+        let args = parse_complexity_args(&["omen", "complexity", "--gate", "error"]);
+        assert!(matches!(args.gate, GateMode::Error));
+    }
+
+    #[test]
+    fn test_complexity_gate_warn_parses() {
+        let args = parse_complexity_args(&["omen", "complexity", "--gate", "warn"]);
+        assert!(matches!(args.gate, GateMode::Warn));
+    }
+
+    #[test]
+    fn test_complexity_check_still_parses_deprecated() {
+        let args = parse_complexity_args(&["omen", "complexity", "--check"]);
+        assert!(args.check);
+        assert!(matches!(args.gate, GateMode::Off));
+    }
+
+    #[test]
+    fn test_complexity_rejects_invalid_gate_value() {
+        assert!(Cli::try_parse_from(["omen", "complexity", "--gate", "bogus"]).is_err());
+    }
+
+    #[test]
+    fn test_score_gate_defaults_to_off() {
+        let cli = parse(&["omen", "score"]);
+        if let Command::Score(cmd) = cli.command {
+            assert!(matches!(cmd.args.gate, GateMode::Off));
+        } else {
+            panic!("expected Score command");
+        }
+    }
+
+    #[test]
+    fn test_score_gate_error_parses() {
+        let cli = parse(&["omen", "score", "--gate", "error"]);
+        if let Command::Score(cmd) = cli.command {
+            assert!(matches!(cmd.args.gate, GateMode::Error));
+        } else {
+            panic!("expected Score command");
+        }
+    }
+
+    #[test]
+    fn test_score_gate_warn_parses() {
+        let cli = parse(&["omen", "score", "--gate", "warn"]);
+        if let Command::Score(cmd) = cli.command {
+            assert!(matches!(cmd.args.gate, GateMode::Warn));
+        } else {
+            panic!("expected Score command");
+        }
+    }
+
+    #[test]
+    fn test_mutation_gate_defaults_to_off() {
+        let args = parse_mutation_args(&["omen", "mutation"]);
+        assert!(matches!(args.gate, GateMode::Off));
+    }
+
+    #[test]
+    fn test_mutation_gate_error_parses() {
+        let args = parse_mutation_args(&["omen", "mutation", "--gate", "error"]);
+        assert!(matches!(args.gate, GateMode::Error));
+    }
+
+    #[test]
+    fn test_mutation_gate_warn_parses() {
+        let args = parse_mutation_args(&["omen", "mutation", "--gate", "warn"]);
+        assert!(matches!(args.gate, GateMode::Warn));
+    }
+
+    #[test]
+    fn test_mutation_check_still_parses_deprecated() {
+        let args = parse_mutation_args(&["omen", "mutation", "--check"]);
+        assert!(args.check);
+        assert!(matches!(args.gate, GateMode::Off));
+    }
+
+    // -----------------------------------------------------------------
+    // Time window: --since canonical, --days alias (churn)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn test_churn_since_flag() {
+        let cli = parse(&["omen", "churn", "--since", "6m"]);
+        if let Command::Churn(args) = cli.command {
+            assert_eq!(args.since, Some("6m".to_string()));
+        } else {
+            panic!("expected Churn command");
+        }
+    }
+
+    #[test]
+    fn test_churn_since_default_none() {
+        let cli = parse(&["omen", "churn"]);
+        if let Command::Churn(args) = cli.command {
+            assert_eq!(args.since, None);
+        } else {
+            panic!("expected Churn command");
+        }
+    }
+
+    #[test]
+    fn test_churn_days_still_parses_alongside_since() {
+        let cli = parse(&["omen", "churn", "--days", "30", "--since", "6m"]);
+        if let Command::Churn(args) = cli.command {
+            assert_eq!(args.days, Some(30));
+            assert_eq!(args.since, Some("6m".to_string()));
+        } else {
+            panic!("expected Churn command");
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Command-name aliases (clones/duplicates, hotspot/hotspots)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn test_alias_hotspots_for_hotspot() {
+        assert_parses_to!(&["omen", "hotspots"], Command::Hotspot(_));
+    }
+
+    #[test]
+    fn test_clones_visible_alias_duplicates_shown_in_help() {
+        let cmd = Cli::command();
+        let clones = cmd
+            .get_subcommands()
+            .find(|c| c.get_name() == "clones")
+            .expect("clones subcommand exists");
+        assert!(clones
+            .get_visible_aliases()
+            .any(|alias| alias == "duplicates"));
+    }
+
+    #[test]
+    fn test_hotspot_visible_alias_hotspots_shown_in_help() {
+        let cmd = Cli::command();
+        let hotspot = cmd
+            .get_subcommands()
+            .find(|c| c.get_name() == "hotspot")
+            .expect("hotspot subcommand exists");
+        assert!(hotspot
+            .get_visible_aliases()
+            .any(|alias| alias == "hotspots"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,15 +33,17 @@ fn logging_filter(verbose: bool, rust_log: Option<&str>) -> EnvFilter {
 /// Resolve the effective gate mode from the canonical `--gate` flag and the
 /// deprecated boolean `--check` flag, shared by `complexity`, `score`, and
 /// `mutation` (`stubs` only ever had `--gate`, so it calls `gate_dispatch`
-/// directly). `--gate` wins whenever it is explicitly set to anything other
-/// than its `Off` default; a bare `--check` with no `--gate` maps to `Error`,
-/// preserving every pre-existing `--check` invocation.
-fn resolve_gate_mode(gate: GateMode, check: bool) -> GateMode {
-    if gate == GateMode::Off && check {
+/// directly). `gate` is `Option<GateMode>` -- not defaulted in clap -- so an
+/// explicitly passed `--gate off` can be told apart from "no --gate at all";
+/// `--gate` (any value, including `off`) always wins over `--check`. A bare
+/// `--check` with no `--gate` maps to `Error`, preserving every pre-existing
+/// `--check` invocation.
+fn resolve_gate_mode(gate: Option<GateMode>, check: bool) -> GateMode {
+    gate.unwrap_or(if check {
         GateMode::Error
     } else {
-        gate
-    }
+        GateMode::Off
+    })
 }
 
 /// Shared gate/check verdict dispatch used by `complexity`, `score`,
@@ -204,7 +206,7 @@ fn run_with_path(cli: &Cli, path: &PathBuf) -> omen::core::Result<()> {
             run_stubs(path, &config, args, format)?;
         }
         Command::Diff(args) => {
-            run_diff_analyzer(path, args.target.as_deref(), format, &args.common)?;
+            run_diff_analyzer(path, args.target.as_deref(), format, args.top, args.offset)?;
         }
         Command::Changes(args) => {
             run_changes_analyzer(path, &config, format, args)?;
@@ -773,12 +775,13 @@ fn run_diff_analyzer(
     path: &Path,
     target: Option<&str>,
     format: Format,
-    args: &AnalyzerArgs,
+    top: Option<usize>,
+    offset: Option<usize>,
 ) -> omen::core::Result<()> {
     let analyzer = omen::analyzers::changes::Analyzer::default();
     let result = analyzer.analyze_diff(path, target)?;
     let value = serde_json::to_value(&result)?;
-    format_with_limits(value, format, args.top, args.offset, &mut stdout())?;
+    format_with_limits(value, format, top, offset, &mut stdout())?;
     Ok(())
 }
 
@@ -1685,7 +1688,15 @@ fn run_mutation(
 
             if !result.files.is_empty() {
                 println!("## Files\n");
-                for file in &result.files {
+                // Apply the same --top/--offset pagination the JSON/SARIF
+                // branches get from `format_with_limits`, so `mutation -f
+                // markdown --top N` doesn't dump every file while JSON does
+                // not. Summary totals above are computed from the full
+                // `result`, not this paginated slice.
+                let offset = args.common.offset.unwrap_or(0);
+                let top = args.common.top.unwrap_or(0); // 0 = unlimited
+                let limit = if top == 0 { usize::MAX } else { top };
+                for file in result.files.iter().skip(offset).take(limit) {
                     println!("### {} (score: {:.1}%)\n", file.path, file.score * 100.0);
                     if file.skipped > 0 {
                         println!(
@@ -2020,22 +2031,51 @@ mod tests {
     }
 
     #[test]
-    fn resolve_gate_mode_defaults_to_gate_value_when_check_false() {
-        assert_eq!(resolve_gate_mode(GateMode::Off, false), GateMode::Off);
-        assert_eq!(resolve_gate_mode(GateMode::Warn, false), GateMode::Warn);
-        assert_eq!(resolve_gate_mode(GateMode::Error, false), GateMode::Error);
+    fn resolve_gate_mode_no_gate_no_check_is_off() {
+        assert_eq!(resolve_gate_mode(None, false), GateMode::Off);
+    }
+
+    #[test]
+    fn resolve_gate_mode_explicit_gate_used_when_check_false() {
+        assert_eq!(resolve_gate_mode(Some(GateMode::Off), false), GateMode::Off);
+        assert_eq!(
+            resolve_gate_mode(Some(GateMode::Warn), false),
+            GateMode::Warn
+        );
+        assert_eq!(
+            resolve_gate_mode(Some(GateMode::Error), false),
+            GateMode::Error
+        );
     }
 
     #[test]
     fn resolve_gate_mode_bare_check_maps_to_error() {
-        assert_eq!(resolve_gate_mode(GateMode::Off, true), GateMode::Error);
+        // --check with no --gate at all: preserves every pre-existing --check
+        // invocation, which must still exit 2 on violation.
+        assert_eq!(resolve_gate_mode(None, true), GateMode::Error);
     }
 
     #[test]
     fn resolve_gate_mode_explicit_gate_wins_over_check() {
         // --gate warn --check: --gate must win, not silently escalate to error.
-        assert_eq!(resolve_gate_mode(GateMode::Warn, true), GateMode::Warn);
-        assert_eq!(resolve_gate_mode(GateMode::Error, true), GateMode::Error);
+        assert_eq!(
+            resolve_gate_mode(Some(GateMode::Warn), true),
+            GateMode::Warn
+        );
+        assert_eq!(
+            resolve_gate_mode(Some(GateMode::Error), true),
+            GateMode::Error
+        );
+    }
+
+    #[test]
+    fn resolve_gate_mode_explicit_gate_off_wins_over_check() {
+        // Regression: `--check --gate off` must resolve to Off, not silently
+        // escalate to Error just because the bare-check branch also produces
+        // Error. Before the fix, `gate: GateMode` (non-Option, defaulting to
+        // Off) made an explicit `--gate off` indistinguishable from "no
+        // --gate at all", so this case incorrectly resolved to Error.
+        assert_eq!(resolve_gate_mode(Some(GateMode::Off), true), GateMode::Off);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,41 @@ fn logging_filter(verbose: bool, rust_log: Option<&str>) -> EnvFilter {
     EnvFilter::new(directive)
 }
 
+/// Resolve the effective gate mode from the canonical `--gate` flag and the
+/// deprecated boolean `--check` flag, shared by `complexity`, `score`, and
+/// `mutation` (`stubs` only ever had `--gate`, so it calls `gate_dispatch`
+/// directly). `--gate` wins whenever it is explicitly set to anything other
+/// than its `Off` default; a bare `--check` with no `--gate` maps to `Error`,
+/// preserving every pre-existing `--check` invocation.
+fn resolve_gate_mode(gate: GateMode, check: bool) -> GateMode {
+    if gate == GateMode::Off && check {
+        GateMode::Error
+    } else {
+        gate
+    }
+}
+
+/// Shared gate/check verdict dispatch used by `complexity`, `score`,
+/// `mutation`, and `stubs`. Callers detect the threshold violation themselves
+/// (each analyzer's report shape differs) and hand the resulting
+/// `Error::ThresholdViolation` to this function only when a violation
+/// occurred; this function decides what to do with it:
+///
+/// - `off`   -- report only, never called with a violation (callers should
+///   skip the gate check entirely when the resolved mode is `Off`).
+/// - `warn`  -- print a one-line summary to stderr, exit 0 (`Ok`).
+/// - `error` -- return the violation, which `main` maps to exit code 2.
+fn gate_dispatch(gate: GateMode, violation: omen::core::Error) -> omen::core::Result<()> {
+    match gate {
+        GateMode::Off => Ok(()),
+        GateMode::Warn => {
+            eprintln!("\nGate mode 'warn': not failing the build.");
+            Ok(())
+        }
+        GateMode::Error => Err(violation),
+    }
+}
+
 fn main() -> ExitCode {
     let cli = Cli::parse();
     tracing_subscriber::registry()
@@ -153,8 +188,9 @@ fn run_with_path(cli: &Cli, path: &PathBuf) -> omen::core::Result<()> {
             }
         }
         Command::Complexity(args) => {
-            if args.check {
-                run_complexity_check(path, &config, args, format)?;
+            let gate = resolve_gate_mode(args.gate, args.check);
+            if gate != GateMode::Off {
+                run_complexity_check(path, &config, args, format, gate)?;
             } else {
                 run_analyzer::<omen::analyzers::complexity::Analyzer>(
                     path,
@@ -168,7 +204,7 @@ fn run_with_path(cli: &Cli, path: &PathBuf) -> omen::core::Result<()> {
             run_stubs(path, &config, args, format)?;
         }
         Command::Diff(args) => {
-            run_diff_analyzer(path, args.target.as_deref(), format)?;
+            run_diff_analyzer(path, args.target.as_deref(), format, &args.common)?;
         }
         Command::Changes(args) => {
             run_changes_analyzer(path, &config, format, args)?;
@@ -196,9 +232,19 @@ fn run_with_path(cli: &Cli, path: &PathBuf) -> omen::core::Result<()> {
             dispatch_analyzer(&cli.command, path, &config, format)?;
         }
         Command::Churn(args) => {
-            let days = args.days.unwrap_or_else(|| {
+            // --since is canonical; --days is a documented alias for the same
+            // window. If both are given, --since wins. Note "all"/"forever"
+            // parse to `None` (unlimited), so `--since` must be checked as a
+            // whole branch rather than folded into `--days` via `.or(..)` --
+            // otherwise an explicit `--since all` would fall through to
+            // `--days`/config instead of meaning "no limit".
+            let days = if let Some(ref since) = args.since {
+                omen::git::parse_since_to_days(since).unwrap_or(u32::MAX)
+            } else if let Some(days) = args.days {
+                days
+            } else {
                 omen::git::parse_since_to_days(&config.churn.since).unwrap_or(u32::MAX)
-            });
+            };
             run_churn_analyzer(path, &config, format, days, &args.common)?;
         }
         Command::Flags(args) => {
@@ -218,8 +264,9 @@ fn run_with_path(cli: &Cli, path: &PathBuf) -> omen::core::Result<()> {
             )?;
         }
         Command::Score(cmd) => {
-            if cmd.args.check {
-                run_score_check(path, &config, &cmd.args, format)?;
+            let gate = resolve_gate_mode(cmd.args.gate, cmd.args.check);
+            if gate != GateMode::Off {
+                run_score_check(path, &config, &cmd.args, format, gate)?;
             } else {
                 match &cmd.subcommand {
                     Some(ScoreSubcommand::Trend(args)) => {
@@ -382,6 +429,17 @@ fn run_with_path(cli: &Cli, path: &PathBuf) -> omen::core::Result<()> {
                         run_and_collect!(&ctx, omen::analyzers::repomap::Analyzer, "repomap"),
                         run_and_collect!(&ctx, omen::analyzers::smells::Analyzer, "smells"),
                         run_and_collect!(&ctx, omen::analyzers::flags::Analyzer, "flags"),
+                        // TODO(output-schema): the CLI-canonical command name for this
+                        // analyzer is `clones` (see Command::Clones in src/cli/mod.rs),
+                        // but this `all` payload entry -- and the module name, the
+                        // report artifact `duplicates.json`, and `report validate`'s
+                        // file list below -- all still say `duplicates`. Renaming the
+                        // "analyzer" value here is a JSON output-shape change (breaks
+                        // any consumer filtering `analyzer == "duplicates"`), so it is
+                        // intentionally deferred to the separate output-schema task
+                        // rather than done here. The CLI layer already accepts both
+                        // `clones` and `duplicates` as command names (see
+                        // `visible_alias = "duplicates"` on Command::Clones).
                         run_and_collect!(&ctx, omen::analyzers::duplicates::Analyzer, "duplicates"),
                     ]
                 });
@@ -711,10 +769,16 @@ fn run_analyzer_instance<A: Analyzer>(
     Ok(())
 }
 
-fn run_diff_analyzer(path: &Path, target: Option<&str>, format: Format) -> omen::core::Result<()> {
+fn run_diff_analyzer(
+    path: &Path,
+    target: Option<&str>,
+    format: Format,
+    args: &AnalyzerArgs,
+) -> omen::core::Result<()> {
     let analyzer = omen::analyzers::changes::Analyzer::default();
     let result = analyzer.analyze_diff(path, target)?;
-    format.format(&result, &mut stdout())?;
+    let value = serde_json::to_value(&result)?;
+    format_with_limits(value, format, args.top, args.offset, &mut stdout())?;
     Ok(())
 }
 
@@ -739,6 +803,7 @@ fn run_complexity_check(
     config: &Config,
     args: &ComplexityArgs,
     format: Format,
+    gate: GateMode,
 ) -> omen::core::Result<()> {
     let file_set = filtered_file_set(path, config, Some(&args.common))?;
     let ctx = build_context(path, &file_set, config);
@@ -788,13 +853,16 @@ fn run_complexity_check(
                 "\nThresholds: cyclomatic <= {}, cognitive <= {}",
                 max_cyclomatic, max_cognitive
             );
-            Err(omen::core::Error::threshold_violation(
-                format!(
-                    "{} function(s) exceed complexity thresholds",
-                    violations.len()
+            gate_dispatch(
+                gate,
+                omen::core::Error::threshold_violation(
+                    format!(
+                        "{} function(s) exceed complexity thresholds",
+                        violations.len()
+                    ),
+                    violations.len() as f64,
                 ),
-                violations.len() as f64,
-            ))
+            )
         }
     }
 }
@@ -859,21 +927,17 @@ fn run_stubs(
         eprintln!("  {}:{} [{}] {}", v.file, v.line, v.severity, v.snippet);
     }
 
-    match args.gate {
-        GateMode::Off => unreachable!("handled above"),
-        GateMode::Warn => {
-            eprintln!("\nGate mode 'warn': not failing the build.");
-            Ok(())
-        }
-        GateMode::Error => Err(omen::core::Error::threshold_violation(
+    gate_dispatch(
+        args.gate,
+        omen::core::Error::threshold_violation(
             format!(
                 "{} stub(s) at or above severity '{}'",
                 violations.len(),
                 gate_severity
             ),
             violations.len() as f64,
-        )),
-    }
+        ),
+    )
 }
 
 fn run_score_check(
@@ -881,6 +945,7 @@ fn run_score_check(
     config: &Config,
     args: &ScoreArgs,
     format: Format,
+    gate: GateMode,
 ) -> omen::core::Result<()> {
     let file_set = FileSet::from_path(path, config)?;
     let ctx = build_context(path, &file_set, config);
@@ -913,7 +978,7 @@ fn run_score_check(
                     &mut stdout(),
                 )?;
             }
-            Err(e)
+            gate_dispatch(gate, e)
         }
     }
 }
@@ -1019,6 +1084,10 @@ fn run_report(
                 .unwrap_or_default();
 
             // Count total analyzers to run
+            // NOTE: "duplicates"/"hotspots" here are report artifact names, not CLI
+            // command names ("clones"/"hotspot" respectively) -- see the TODO(output-
+            // schema) note near the `all` command's analyzer collection above for why
+            // the mismatch isn't resolved here.
             let analyzer_names = [
                 "complexity",
                 "satd",
@@ -1483,7 +1552,11 @@ fn run_mutation(
     use omen::analyzers::mutation::ml_predictor::{SurvivabilityPredictor, TrainingData};
     use omen::analyzers::mutation::MutantStatus;
 
-    let mut file_set = FileSet::from_path(path, config)?;
+    // Route glob/exclude/changed-since through the same shared helper every
+    // other analyzer uses, instead of hand-rolling glob/exclude here. This
+    // also means mutation now honors --changed-since, which it previously
+    // ignored entirely.
+    let file_set = filtered_file_set(path, config, Some(&args.common))?;
 
     // Load predictor model if --skip-predicted is specified omen:ignore
     let predictor = if args.skip_predicted.is_some() {
@@ -1502,16 +1575,6 @@ fn run_mutation(
     } else {
         None
     };
-
-    // Apply glob filter if specified
-    if let Some(ref pattern) = args.common.glob {
-        file_set = file_set.filter_by_glob(pattern);
-    }
-
-    // Apply exclude filter if specified
-    for pattern in &args.common.exclude {
-        file_set = file_set.exclude_by_glob(pattern);
-    }
 
     // Show analysis progress
     let spinner = if is_tty() {
@@ -1538,17 +1601,17 @@ fn run_mutation(
         .map(|s| s.trim().to_uppercase())
         .collect();
 
-    // Build analyzer
+    // Build analyzer. Note: the gate/--check threshold is intentionally
+    // *not* wired through `mutation::Analyzer::min_score` here (that would
+    // make `analyze()` itself return `Err` before the report is written to
+    // stdout, unlike every other gated command). Instead the CLI evaluates
+    // the threshold itself below, after the report has been emitted.
     let mut analyzer = mutation::Analyzer::new()
         .operators(operators)
         .test_command(args.test_command.clone())
         .timeout(args.timeout)
         .dry_run(args.dry_run)
         .allow_dirty(args.allow_dirty);
-
-    if args.check {
-        analyzer = analyzer.min_score(Some(args.min_score));
-    }
 
     // Configure ML-based filtering if --skip-predicted is set omen:ignore
     if let Some(threshold) = args.skip_predicted {
@@ -1667,16 +1730,35 @@ fn run_mutation(
             );
             println!("Duration: {}ms", result.summary.duration_ms);
         }
-        Format::Sarif => format.format(&result, &mut stdout())?,
+        Format::Sarif => {
+            let value = serde_json::to_value(&result)?;
+            format_with_limits(
+                value,
+                format,
+                args.common.top,
+                args.common.offset,
+                &mut stdout(),
+            )?;
+        }
     }
 
-    // Check mode: fail if score below threshold
-    if args.check && result.summary.mutation_score < args.min_score {
-        return Err(omen::core::Error::analysis(format!(
+    // Gate/check: fail if the mutation score is below --min-score. Uses the
+    // same shared `resolve_gate_mode`/`gate_dispatch` helpers as complexity,
+    // score, and stubs, so `--gate error` (and the deprecated `--check`
+    // alias) consistently exits 2 via `Error::ThresholdViolation` rather than
+    // the generic `Error::Analysis` this used to return.
+    let gate = resolve_gate_mode(args.gate, args.check);
+    if gate != GateMode::Off && result.summary.mutation_score < args.min_score {
+        let message = format!(
             "Mutation score {:.1}% is below minimum threshold {:.1}%",
             result.summary.mutation_score * 100.0,
             args.min_score * 100.0
-        )));
+        );
+        eprintln!("{message}");
+        gate_dispatch(
+            gate,
+            omen::core::Error::threshold_violation(message, result.summary.mutation_score),
+        )?;
     }
 
     // Save results to history if --record flag is set
@@ -1935,5 +2017,46 @@ mod tests {
         assert_eq!(logging_filter(true, None).to_string(), "debug");
         assert_eq!(logging_filter(false, None).to_string(), "off");
         assert_eq!(logging_filter(true, Some("warn")).to_string(), "warn");
+    }
+
+    #[test]
+    fn resolve_gate_mode_defaults_to_gate_value_when_check_false() {
+        assert_eq!(resolve_gate_mode(GateMode::Off, false), GateMode::Off);
+        assert_eq!(resolve_gate_mode(GateMode::Warn, false), GateMode::Warn);
+        assert_eq!(resolve_gate_mode(GateMode::Error, false), GateMode::Error);
+    }
+
+    #[test]
+    fn resolve_gate_mode_bare_check_maps_to_error() {
+        assert_eq!(resolve_gate_mode(GateMode::Off, true), GateMode::Error);
+    }
+
+    #[test]
+    fn resolve_gate_mode_explicit_gate_wins_over_check() {
+        // --gate warn --check: --gate must win, not silently escalate to error.
+        assert_eq!(resolve_gate_mode(GateMode::Warn, true), GateMode::Warn);
+        assert_eq!(resolve_gate_mode(GateMode::Error, true), GateMode::Error);
+    }
+
+    #[test]
+    fn gate_dispatch_off_never_fails() {
+        let violation = omen::core::Error::threshold_violation("violated", 0.0);
+        assert!(gate_dispatch(GateMode::Off, violation).is_ok());
+    }
+
+    #[test]
+    fn gate_dispatch_warn_returns_ok() {
+        let violation = omen::core::Error::threshold_violation("violated", 0.0);
+        assert!(gate_dispatch(GateMode::Warn, violation).is_ok());
+    }
+
+    #[test]
+    fn gate_dispatch_error_returns_the_violation() {
+        let violation = omen::core::Error::threshold_violation("violated", 42.0);
+        let result = gate_dispatch(GateMode::Error, violation);
+        assert!(matches!(
+            result,
+            Err(omen::core::Error::ThresholdViolation { score, .. }) if score == 42.0
+        ));
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1423,6 +1423,26 @@ fn test_complexity_check_alias_still_exits_two() {
 }
 
 #[test]
+fn test_complexity_gate_off_wins_over_check_exits_zero() {
+    // Regression: `--check --gate off` must resolve to Off (exit 0), not
+    // silently escalate to Error just because `--check` alone would.
+    let temp = TempDir::new().unwrap();
+    write_complexity_exclude_fixture(&temp);
+
+    omen()
+        .args([
+            "-p",
+            temp.path().to_str().unwrap(),
+            "complexity",
+            "--check",
+            "--gate",
+            "off",
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
 fn test_score_gate_error_exits_two_and_emits_json() {
     omen()
         .args([
@@ -1473,6 +1493,34 @@ fn test_score_check_alias_still_exits_two() {
         .code(2);
 }
 
+#[test]
+fn test_score_gate_off_wins_over_check_exits_zero() {
+    // Regression: `--check --gate off` must resolve to Off (exit 0).
+    omen()
+        .args([
+            "-p",
+            fixtures_dir(),
+            "score",
+            "--check",
+            "--gate",
+            "off",
+            "--fail-under",
+            "99",
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_score_default_gate_off_exits_zero_on_violation() {
+    // No --gate and no --check: default GateMode::Off must report only and
+    // exit 0, even though the score is well below --fail-under.
+    omen()
+        .args(["-p", fixtures_dir(), "score", "--fail-under", "99"])
+        .assert()
+        .success();
+}
+
 /// `--dry-run` only generates mutants (no test execution), so the mutation
 /// score is always 0.0 (0 killed / 0 scored) -- reliably below the default
 /// `--min-score` of 0.8. This lets the gate be exercised deterministically
@@ -1488,21 +1536,46 @@ fn write_mutation_gate_fixture() -> TempDir {
 }
 
 #[test]
-fn test_mutation_gate_error_exits_two_on_dry_run() {
+fn test_mutation_gate_error_exits_two_and_emits_report_before_failing() {
+    // Regression guard: a naive gate implementation can return Err from
+    // inside the analyzer itself (before the report is ever written), which
+    // would make this test pass for the wrong reason -- exit 2 with no
+    // report at all. Requesting JSON and asserting the stdout is valid,
+    // non-empty mutation output proves the report reaches stdout *before*
+    // the gate fails, matching complexity/score/stubs.
     let temp = write_mutation_gate_fixture();
 
-    omen()
+    let output = omen()
         .args([
             "-p",
             temp.path().to_str().unwrap(),
+            "-f",
+            "json",
             "mutation",
             "--dry-run",
             "--gate",
             "error",
         ])
-        .assert()
-        .code(2)
-        .stderr(predicate::str::contains("Mutation score"));
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("mutation report should be valid JSON on stdout");
+    assert!(
+        parsed.get("summary").is_some(),
+        "mutation report should include a summary: {parsed:#?}"
+    );
+    assert_eq!(
+        parsed["summary"]["mutation_score"], 0.0,
+        "dry-run mutation score should be 0.0: {parsed:#?}"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Mutation score"),
+        "expected gate failure message on stderr: {stderr}"
+    );
 }
 
 #[test]
@@ -1547,6 +1620,25 @@ fn test_mutation_check_alias_still_exits_two_on_dry_run() {
         ])
         .assert()
         .code(2);
+}
+
+#[test]
+fn test_mutation_gate_off_wins_over_check_exits_zero() {
+    // Regression: `--check --gate off` must resolve to Off (exit 0).
+    let temp = write_mutation_gate_fixture();
+
+    omen()
+        .args([
+            "-p",
+            temp.path().to_str().unwrap(),
+            "mutation",
+            "--dry-run",
+            "--check",
+            "--gate",
+            "off",
+        ])
+        .assert()
+        .success();
 }
 
 #[test]
@@ -1596,6 +1688,8 @@ fn test_mutation_top_offset_flags_parse_and_run() {
             "--dry-run",
             "--top",
             "1",
+            "--offset",
+            "0",
         ])
         .assert()
         .success();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1354,3 +1354,320 @@ fn test_all_three_formats_succeed() {
             .success();
     }
 }
+
+// ---------------------------------------------------------------------------
+// Gate/check: --gate off|warn|error, --check deprecated alias, exit codes
+// ---------------------------------------------------------------------------
+//
+// Convention under test: off = report only (exit 0); warn = report + one-line
+// stderr summary (exit 0); error = report; on violation return
+// Error::ThresholdViolation, which main() maps to exit code 2. --check is a
+// deprecated alias for --gate error; --gate wins if both are given.
+
+#[test]
+fn test_complexity_gate_error_exits_two_on_violation() {
+    let temp = TempDir::new().unwrap();
+    write_complexity_exclude_fixture(&temp);
+
+    omen()
+        .args([
+            "-p",
+            temp.path().to_str().unwrap(),
+            "complexity",
+            "--gate",
+            "error",
+        ])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("Complexity threshold exceeded"));
+}
+
+#[test]
+fn test_complexity_gate_warn_exits_zero_on_violation() {
+    let temp = TempDir::new().unwrap();
+    write_complexity_exclude_fixture(&temp);
+
+    omen()
+        .args([
+            "-p",
+            temp.path().to_str().unwrap(),
+            "complexity",
+            "--gate",
+            "warn",
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Gate mode 'warn'"));
+}
+
+#[test]
+fn test_complexity_gate_off_default_exits_zero_on_violation() {
+    let temp = TempDir::new().unwrap();
+    write_complexity_exclude_fixture(&temp);
+
+    omen()
+        .args(["-p", temp.path().to_str().unwrap(), "complexity"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_complexity_check_alias_still_exits_two() {
+    let temp = TempDir::new().unwrap();
+    write_complexity_exclude_fixture(&temp);
+
+    omen()
+        .args(["-p", temp.path().to_str().unwrap(), "complexity", "--check"])
+        .assert()
+        .code(2);
+}
+
+#[test]
+fn test_score_gate_error_exits_two_and_emits_json() {
+    omen()
+        .args([
+            "-p",
+            fixtures_dir(),
+            "-f",
+            "json",
+            "score",
+            "--gate",
+            "error",
+            "--fail-under",
+            "99",
+        ])
+        .assert()
+        .code(2)
+        .stdout(predicate::str::contains("\"violations\""));
+}
+
+#[test]
+fn test_score_gate_warn_exits_zero() {
+    omen()
+        .args([
+            "-p",
+            fixtures_dir(),
+            "score",
+            "--gate",
+            "warn",
+            "--fail-under",
+            "99",
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Gate mode 'warn'"));
+}
+
+#[test]
+fn test_score_check_alias_still_exits_two() {
+    omen()
+        .args([
+            "-p",
+            fixtures_dir(),
+            "score",
+            "--check",
+            "--fail-under",
+            "99",
+        ])
+        .assert()
+        .code(2);
+}
+
+/// `--dry-run` only generates mutants (no test execution), so the mutation
+/// score is always 0.0 (0 killed / 0 scored) -- reliably below the default
+/// `--min-score` of 0.8. This lets the gate be exercised deterministically
+/// without running real tests.
+fn write_mutation_gate_fixture() -> TempDir {
+    let temp = TempDir::new().unwrap();
+    std::fs::write(
+        temp.path().join("lib.rs"),
+        "pub fn is_positive(x: i32) -> bool { x > 0 }\n",
+    )
+    .unwrap();
+    temp
+}
+
+#[test]
+fn test_mutation_gate_error_exits_two_on_dry_run() {
+    let temp = write_mutation_gate_fixture();
+
+    omen()
+        .args([
+            "-p",
+            temp.path().to_str().unwrap(),
+            "mutation",
+            "--dry-run",
+            "--gate",
+            "error",
+        ])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("Mutation score"));
+}
+
+#[test]
+fn test_mutation_gate_warn_exits_zero_on_dry_run() {
+    let temp = write_mutation_gate_fixture();
+
+    omen()
+        .args([
+            "-p",
+            temp.path().to_str().unwrap(),
+            "mutation",
+            "--dry-run",
+            "--gate",
+            "warn",
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Gate mode 'warn'"));
+}
+
+#[test]
+fn test_mutation_gate_off_default_exits_zero_on_dry_run() {
+    let temp = write_mutation_gate_fixture();
+
+    omen()
+        .args(["-p", temp.path().to_str().unwrap(), "mutation", "--dry-run"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_mutation_check_alias_still_exits_two_on_dry_run() {
+    let temp = write_mutation_gate_fixture();
+
+    omen()
+        .args([
+            "-p",
+            temp.path().to_str().unwrap(),
+            "mutation",
+            "--dry-run",
+            "--check",
+        ])
+        .assert()
+        .code(2);
+}
+
+#[test]
+fn test_operational_error_exits_one_not_two() {
+    // Sanity check that op errors (bad path) are distinct from gate
+    // violations: exit 1, not 2, and not success.
+    omen()
+        .args(["-p", "/definitely/not/a/repository", "-f", "json", "score"])
+        .assert()
+        .code(1);
+}
+
+// ---------------------------------------------------------------------------
+// Pagination: diff/mutation routed through format_with_limits
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_diff_top_offset_flags_parse_and_run() {
+    // diff's git plumbing (target resolution, no-diff cases) is exercised
+    // elsewhere; this only checks that --top/--offset reach format_with_limits
+    // without panicking and that the output stays valid JSON either way.
+    let output = omen()
+        .args([
+            "-p", ".", "-f", "json", "diff", "--top", "1", "--offset", "0",
+        ])
+        .output()
+        .unwrap();
+    if output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            serde_json::from_str::<serde_json::Value>(&stdout).is_ok(),
+            "diff --top/--offset should produce valid JSON when successful"
+        );
+    }
+}
+
+#[test]
+fn test_mutation_top_offset_flags_parse_and_run() {
+    let temp = write_mutation_gate_fixture();
+    omen()
+        .args([
+            "-p",
+            temp.path().to_str().unwrap(),
+            "-f",
+            "json",
+            "mutation",
+            "--dry-run",
+            "--top",
+            "1",
+        ])
+        .assert()
+        .success();
+}
+
+// ---------------------------------------------------------------------------
+// Filtering: mutation routed through filtered_file_set (glob/exclude/changed-since)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_mutation_glob_and_exclude_still_work() {
+    let temp = TempDir::new().unwrap();
+    std::fs::write(
+        temp.path().join("keep.rs"),
+        "pub fn keep(x: i32) -> bool { x > 0 }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        temp.path().join("skip.py"),
+        "def skip(x):\n    return x > 0\n",
+    )
+    .unwrap();
+
+    omen()
+        .args([
+            "-p",
+            temp.path().to_str().unwrap(),
+            "mutation",
+            "--dry-run",
+            "-g",
+            "*.rs",
+        ])
+        .assert()
+        .success();
+}
+
+// ---------------------------------------------------------------------------
+// Time window: --since / --days on churn
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_churn_since_flag_runs_successfully() {
+    omen()
+        .args(["-p", ".", "-f", "json", "churn", "--since", "6m"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_churn_days_alias_still_runs_successfully() {
+    omen()
+        .args(["-p", ".", "-f", "json", "churn", "--days", "180"])
+        .assert()
+        .success();
+}
+
+// ---------------------------------------------------------------------------
+// Command-name aliases: clones/duplicates, hotspot/hotspots
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_duplicates_alias_runs_like_clones() {
+    omen()
+        .args(["-p", fixtures_dir(), "-f", "json", "duplicates"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_hotspots_alias_runs_like_hotspot() {
+    omen()
+        .args(["-p", fixtures_dir(), "-f", "json", "hotspots"])
+        .assert()
+        .success();
+}


### PR DESCRIPTION
## Summary

First half of the CLI standardization (flags + gates only; the JSON output schema is a separate follow-up). Backward compatible — every existing invocation still works via aliases.

- **Pagination**: `-n` short for `--top` everywhere; `search --top-k` folded into `--top` (alias kept); `diff` and `mutation` now honor `--top`/`--offset` through the shared `format_with_limits`.
- **Filtering**: `mutation` now uses the shared `filtered_file_set` (so `--glob`/`--exclude`/`--changed-since` all work).
- **Time window**: `churn` gains `--since` (`3m`/`6m`/`1y`/`all`); `--days` kept as an alias.
- **Gate**: unified `--gate off|warn|error` across `complexity`/`score`/`mutation`/`stubs` via shared `resolve_gate_mode` + `gate_dispatch`. `error` returns `ThresholdViolation` (exit 2); `warn` exits 0; `--check` kept as a deprecated alias. Fixed a real bug: `mutation --check` aborted in `analyze()` before the report was written — it now emits the report, then exits 2 on violation, like the others.
- **Command names**: `clones`/`hotspot` canonical, `duplicates`/`hotspots` as visible aliases; consistent alias-visibility policy. (The `all`-payload key and report filenames are deferred to the output-schema change, marked with `TODO(output-schema)`.)
- **Deprecations** are tagged with a greppable `DEPRECATED(remove-in: 5.0)` marker and catalogued in a new `DEPRECATIONS.md`, so the breaking-change cleanup is a single grep.

## Verification

`cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (2039 lib + 85 integration + property/doc) all pass. New parse tests for every alias, exit-code integration tests (gate error = 2, warn = 0, op error = 1) for complexity/score/mutation/stubs, and the plugin-skill command parse test stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable warning and error gate modes for complexity, score, stubs, and mutation analysis.
  - Added pagination and file-filtering options to diff and mutation reports.
  - Added visible command aliases, including `duplicates` and `hotspots`.
  - Added the canonical `--since`, `--top`, and `-n` options.

- **Deprecations**
  - Documented upcoming removals and migration guidance.
  - Retained `--check`, `--days`, and `--top-k` as deprecated aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->