### PR TITLE
Fix phantom cyclic dependencies in smells and graph (closes #479)

### DIFF
--- a/src/analyzers/graph.rs
+++ b/src/analyzers/graph.rs
@@ -34,8 +34,11 @@ use petgraph::Direction;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
+use crate::analyzers::import_resolver::{
+    build_dependency_graph, extract_resolved_imports, ImportIndex,
+};
 use crate::core::{AnalysisContext, Analyzer as AnalyzerTrait, Language, Result};
-use crate::parser::{extract_imports, Parser};
+use crate::parser::{extract_imports, ImportKind, Parser};
 
 /// Graph analyzer configuration.
 #[derive(Debug, Clone)]
@@ -50,305 +53,6 @@ pub struct Config {
     pub resolve_imports: bool,
     /// Include external dependencies.
     pub include_external: bool,
-}
-
-/// Pre-built index for O(1) file path lookups during import resolution.
-#[allow(dead_code)]
-struct FilePathIndex {
-    /// Full relative path -> relative path (identity mapping for exact matches).
-    by_full_path: HashMap<String, String>,
-    /// File stem (without extension) -> list of relative paths.
-    by_stem: HashMap<String, Vec<String>>,
-    /// File name (with extension) -> list of relative paths.
-    by_name: HashMap<String, Vec<String>>,
-    /// Normalized path segments for partial matching.
-    by_segments: HashMap<String, Vec<String>>,
-}
-
-impl FilePathIndex {
-    fn new(files: &[std::path::PathBuf], root: &Path) -> Self {
-        let mut by_full_path = HashMap::with_capacity(files.len());
-        let mut by_stem: HashMap<String, Vec<String>> = HashMap::new();
-        let mut by_name: HashMap<String, Vec<String>> = HashMap::new();
-        let mut by_segments: HashMap<String, Vec<String>> = HashMap::new();
-
-        for file in files {
-            let rel = file.strip_prefix(root).unwrap_or(file);
-            let rel_str = rel.to_string_lossy().to_string();
-
-            // Full path lookup
-            by_full_path.insert(rel_str.clone(), rel_str.clone());
-
-            // File stem lookup (e.g., "mod" from "mod.rs")
-            if let Some(stem) = rel.file_stem() {
-                let stem_str = stem.to_string_lossy().to_string();
-                by_stem.entry(stem_str).or_default().push(rel_str.clone());
-            }
-
-            // File name lookup (e.g., "mod.rs")
-            if let Some(name) = rel.file_name() {
-                let name_str = name.to_string_lossy().to_string();
-                by_name.entry(name_str).or_default().push(rel_str.clone());
-            }
-
-            // Segment-based lookup for partial path matching
-            // e.g., "src/utils/helpers" can match "utils/helpers.rs"
-            for component in rel.iter() {
-                let comp_str = component.to_string_lossy().to_string();
-                if !comp_str.is_empty() && comp_str != "." {
-                    by_segments
-                        .entry(comp_str)
-                        .or_default()
-                        .push(rel_str.clone());
-                }
-            }
-        }
-
-        Self {
-            by_full_path,
-            by_stem,
-            by_name,
-            by_segments,
-        }
-    }
-
-    /// Try to find a file matching the import path.
-    fn find_match(&self, import_path: &str, from_file: &Path) -> Option<String> {
-        // 0. Handle Rust crate-relative imports (crate::, super::, self::)
-        if import_path.starts_with("crate::")
-            || import_path.starts_with("super::")
-            || import_path.starts_with("self::")
-        {
-            let stripped = import_path
-                .strip_prefix("crate::")
-                .or_else(|| import_path.strip_prefix("super::"))
-                .or_else(|| import_path.strip_prefix("self::"))
-                .unwrap_or(import_path);
-
-            // Take the module path part (strip trailing type names which are CamelCase)
-            // e.g., crate::config::Config -> config, crate::analyzers::graph -> analyzers/graph
-            let segments: Vec<&str> = stripped.split("::").collect();
-
-            // Find the last segment that looks like a module (lowercase/snake_case)
-            let module_segments: Vec<&str> = segments
-                .iter()
-                .take_while(|s| {
-                    s.chars()
-                        .next()
-                        .map(|c| c.is_lowercase() || c == '_')
-                        .unwrap_or(false)
-                })
-                .copied()
-                .collect();
-
-            let module_path = if module_segments.is_empty() {
-                // All segments start with uppercase - use all as path
-                segments.join("/")
-            } else {
-                module_segments.join("/")
-            };
-
-            // Handle super:: relative to current file
-            if import_path.starts_with("super::") {
-                if let Some(parent) = from_file.parent().and_then(|p| p.parent()) {
-                    let resolved = parent.join(&module_path);
-                    let normalized = normalize_path(&resolved);
-                    for ext in &["", ".rs"] {
-                        let candidate = if ext.is_empty() {
-                            normalized.clone()
-                        } else {
-                            format!("{}{}", normalized, ext)
-                        };
-                        if self.by_full_path.contains_key(&candidate) {
-                            return Some(candidate);
-                        }
-                    }
-                    let mod_rs = format!("{}/mod.rs", normalized);
-                    if self.by_full_path.contains_key(&mod_rs) {
-                        return Some(mod_rs);
-                    }
-                }
-            }
-
-            // Try common Rust source roots with the module path
-            let source_roots = ["src", "lib", ""];
-            for root in &source_roots {
-                let base = if root.is_empty() {
-                    module_path.clone()
-                } else {
-                    format!("{}/{}", root, module_path)
-                };
-
-                // Try direct file match (e.g., src/config.rs)
-                let rs_path = format!("{}.rs", base);
-                if self.by_full_path.contains_key(&rs_path) {
-                    return Some(rs_path);
-                }
-
-                // Try mod.rs (e.g., src/config/mod.rs)
-                let mod_path = format!("{}/mod.rs", base);
-                if self.by_full_path.contains_key(&mod_path) {
-                    return Some(mod_path);
-                }
-            }
-
-            // Fall through to other matching strategies
-        }
-
-        // 1. Handle relative imports (./foo, ../foo)
-        if import_path.starts_with("./") || import_path.starts_with("../") {
-            if let Some(parent) = from_file.parent() {
-                let resolved = parent.join(import_path);
-                let normalized = normalize_path(&resolved);
-
-                // Try exact match with common extensions
-                for ext in &[
-                    "", ".rs", ".go", ".py", ".ts", ".tsx", ".js", ".jsx", ".java",
-                ] {
-                    let with_ext = if ext.is_empty() {
-                        normalized.clone()
-                    } else {
-                        format!(
-                            "{}.{}",
-                            normalized.trim_end_matches(&format!(".{}", &ext[1..])),
-                            &ext[1..]
-                        )
-                    };
-
-                    if self.by_full_path.contains_key(&with_ext) {
-                        return Some(with_ext);
-                    }
-
-                    // Try index files (e.g., ./utils -> ./utils/index.ts)
-                    let index_path = format!("{}/index{}", normalized, ext);
-                    if self.by_full_path.contains_key(&index_path) {
-                        return Some(index_path);
-                    }
-                }
-            }
-        }
-
-        // 2. Try exact stem match
-        if let Some(matches) = self.by_stem.get(import_path) {
-            if matches.len() == 1 {
-                return Some(matches[0].clone());
-            }
-            // Multiple matches - prefer shortest path (most specific)
-            if !matches.is_empty() {
-                let mut sorted = matches.clone();
-                sorted.sort_by_key(|s| s.len());
-                return Some(sorted[0].clone());
-            }
-        }
-
-        // 3. Try snake_case conversion for Ruby CamelCase constants
-        //    e.g., "OrderSearcher" -> "order_searcher", "ActiveModel::Validations" -> "active_model/validations"
-        if import_path.contains("::") {
-            // Scoped constant: split on ::, convert each segment, join with /
-            // e.g., ActiveModel::Validations -> active_model/validations
-            let snake_path: String = import_path
-                .split("::")
-                .map(camel_to_snake)
-                .collect::<Vec<_>>()
-                .join("/");
-            // Match on path segment boundaries (must be preceded by / or start of string)
-            let with_slash = format!("/{}", snake_path);
-            if let Some(matched) = self
-                .by_full_path
-                .keys()
-                .find(|k| k.starts_with(&snake_path) || k.contains(&with_slash))
-            {
-                return Some(matched.clone());
-            }
-            // Also try the last segment as a stem match
-            if let Some(last) = snake_path.rsplit('/').next() {
-                if let Some(matches) = self.by_stem.get(last) {
-                    for candidate in matches {
-                        if candidate.contains(&snake_path) {
-                            return Some(candidate.clone());
-                        }
-                    }
-                }
-            }
-        } else {
-            let snake = camel_to_snake(import_path);
-            if snake != import_path {
-                if let Some(matches) = self.by_stem.get(&snake) {
-                    if matches.len() == 1 {
-                        return Some(matches[0].clone());
-                    }
-                    if !matches.is_empty() {
-                        let mut sorted = matches.clone();
-                        sorted.sort_by_key(|s| s.len());
-                        return Some(sorted[0].clone());
-                    }
-                }
-            }
-        }
-
-        // 4. Try segment-based matching for module paths like "utils/helpers"
-        let segments: Vec<&str> = import_path.split('/').filter(|s| !s.is_empty()).collect();
-        if let Some(last_segment) = segments.last() {
-            if let Some(candidates) = self.by_stem.get(*last_segment) {
-                // Find candidates that match the full path pattern
-                for candidate in candidates {
-                    if candidate.contains(import_path) {
-                        return Some(candidate.clone());
-                    }
-                }
-                // Fall back to first match with the stem
-                if !candidates.is_empty() {
-                    return Some(candidates[0].clone());
-                }
-            }
-        }
-
-        None
-    }
-}
-
-/// Convert CamelCase to snake_case for Ruby constant-to-filename resolution.
-/// Handles consecutive uppercase (e.g., HTTPClient -> http_client).
-fn camel_to_snake(name: &str) -> String {
-    let mut result = String::with_capacity(name.len() + 4);
-    let chars: Vec<char> = name.chars().collect();
-    for (i, &c) in chars.iter().enumerate() {
-        if c.is_uppercase() {
-            if i > 0 {
-                let prev = chars[i - 1];
-                let next_is_lower = chars.get(i + 1).is_some_and(|n| n.is_lowercase());
-                // Insert underscore before: uppercase after lowercase, or
-                // start of new word in consecutive uppercase (e.g., the P in HTTPParser)
-                if prev.is_lowercase() || (prev.is_uppercase() && next_is_lower) {
-                    result.push('_');
-                }
-            }
-            for lc in c.to_lowercase() {
-                result.push(lc);
-            }
-        } else {
-            result.push(c);
-        }
-    }
-    result
-}
-
-/// Normalize a path by removing . and resolving ..
-fn normalize_path(path: &Path) -> String {
-    let mut components = Vec::new();
-    for component in path.components() {
-        match component {
-            std::path::Component::Normal(c) => {
-                components.push(c.to_string_lossy().to_string());
-            }
-            std::path::Component::ParentDir => {
-                components.pop();
-            }
-            std::path::Component::CurDir => {}
-            _ => {}
-        }
-    }
-    components.join("/")
 }
 
 impl Default for Config {
@@ -406,85 +110,45 @@ impl Analyzer {
     /// Uses ctx.read_file() to support both filesystem and git tree sources.
     pub fn analyze_files(&self, ctx: &AnalysisContext<'_>) -> Result<Analysis> {
         let files: Vec<_> = ctx.files.iter().collect();
+        let file_paths: Vec<std::path::PathBuf> = files.iter().map(|p| (*p).clone()).collect();
 
-        // Build file path index for O(1) lookups during import resolution
-        let file_index = FilePathIndex::new(
-            &files.iter().map(|p| (*p).clone()).collect::<Vec<_>>(),
-            ctx.root,
-        );
+        let file_imports: Vec<(String, Vec<String>)> = if self.config.resolve_imports {
+            // Shared with `smells` (same resolver AND same extraction step)
+            // so the two analyzers can never disagree on the edges they
+            // build for the same input (issue #479).
+            let file_index = ImportIndex::new(&file_paths, ctx.root);
+            extract_resolved_imports(&file_paths, ctx, &file_index, self.config.include_external)
+        } else {
+            // No CLI flag ever sets `resolve_imports = false`; kept for API
+            // completeness. Uses raw unresolved import specifiers as
+            // pseudo-targets instead of resolving them to files.
+            files
+                .par_iter()
+                .filter_map(|file| {
+                    let rel_path = file.strip_prefix(ctx.root).unwrap_or(file);
+                    let path_str = rel_path.to_string_lossy().to_string();
 
-        // Parallel parsing: extract imports from all files concurrently
-        let file_imports: Vec<(String, Vec<String>)> = files
-            .par_iter()
-            .filter_map(|file| {
-                let rel_path = file.strip_prefix(ctx.root).unwrap_or(file);
-                let path_str = rel_path.to_string_lossy().to_string();
+                    let content = ctx.read_file(file).ok()?;
+                    let lang = Language::detect(file)?;
 
-                // Read file via context (supports both filesystem and git tree)
-                let content = ctx.read_file(file).ok()?;
-                let lang = Language::detect(file)?;
+                    let parser = Parser::new();
+                    let result = parser.parse(&content, lang, file).ok()?;
+                    let imports: Vec<String> = extract_imports(&result)
+                        .into_iter()
+                        .filter(|imp| imp.kind == ImportKind::Use)
+                        .map(|imp| imp.path)
+                        .collect();
 
-                // Parse and extract imports using thread-local parser
-                let parser = Parser::new();
-                let result = parser.parse(&content, lang, file).ok()?;
-                let imports = extract_imports(&result);
+                    Some((path_str, imports))
+                })
+                .collect()
+        };
 
-                // Resolve imports using the pre-built index
-                let resolved: Vec<String> = if self.config.resolve_imports {
-                    imports
-                        .iter()
-                        .filter_map(|imp| {
-                            file_index.find_match(&imp.path, rel_path).or_else(|| {
-                                if self.config.include_external {
-                                    Some(imp.path.clone())
-                                } else {
-                                    None
-                                }
-                            })
-                        })
-                        .collect()
-                } else {
-                    imports.iter().map(|imp| imp.path.clone()).collect()
-                };
-
-                Some((path_str, resolved))
-            })
-            .collect();
-
-        // Build graph (sequential, but fast since parsing is done)
-        let mut graph: DiGraph<String, ()> = DiGraph::with_capacity(files.len(), files.len() * 4);
-        let mut node_indices: HashMap<String, NodeIndex> = HashMap::with_capacity(files.len());
-
-        // First pass: create all nodes
-        for (path_str, _) in &file_imports {
-            if !node_indices.contains_key(path_str) {
-                let idx = graph.add_node(path_str.clone());
-                node_indices.insert(path_str.clone(), idx);
-            }
-        }
-
-        // Second pass: create edges
-        for (from_path, imports) in &file_imports {
-            let from_idx = node_indices[from_path];
-
-            for import in imports {
-                // Add target node if not exists (external dependency)
-                let to_idx = if let Some(&idx) = node_indices.get(import) {
-                    idx
-                } else if self.config.include_external {
-                    let idx = graph.add_node(import.clone());
-                    node_indices.insert(import.clone(), idx);
-                    idx
-                } else {
-                    continue;
-                };
-
-                // Add edge (avoid self-loops)
-                if from_idx != to_idx && !graph.contains_edge(from_idx, to_idx) {
-                    graph.add_edge(from_idx, to_idx, ());
-                }
-            }
-        }
+        // Build graph applying the shared edge rules (no self-loops, no
+        // parallel edges for a repeated import) -- the same rules `smells`
+        // applies, via the same function.
+        let (graph, node_indices) =
+            build_dependency_graph(&file_imports, self.config.include_external);
 
         // Calculate metrics
         let pagerank = self.calculate_pagerank(&graph);
@@ -890,6 +554,217 @@ pub struct AnalysisSummary {
 mod tests {
     use super::*;
 
+    /// Write files (relative path -> content) into a fresh temp dir and build
+    /// the dependency graph over it from the filesystem.
+    fn analyze_fixture(files: &[(&str, &str)]) -> Analysis {
+        let temp_dir = tempfile::tempdir().unwrap();
+        for (rel_path, content) in files {
+            let full_path = temp_dir.path().join(rel_path);
+            std::fs::create_dir_all(full_path.parent().unwrap()).unwrap();
+            std::fs::write(full_path, content).unwrap();
+        }
+
+        let analyzer = Analyzer::new();
+        let mut analysis = analyzer.analyze_project(temp_dir.path()).unwrap();
+        analysis.summary.cycle_count = analysis.cycles.len();
+        analysis
+    }
+
+    #[test]
+    fn test_no_false_cycle_for_rust_sibling_modules_via_parent() {
+        // Bug 2: tdg and defect each import a sibling module (hotspot)
+        // through a grouped `use crate::analyzers::{hotspot};`. Neither tdg
+        // nor defect actually depend on each other, or on analyzers/mod.rs
+        // as anything but their container -- so no cycle should be reported.
+        let analysis = analyze_fixture(&[
+            ("src/lib.rs", "pub mod analyzers;\n"),
+            (
+                "src/analyzers/mod.rs",
+                "pub mod tdg;\npub mod defect;\npub mod hotspot;\n",
+            ),
+            (
+                "src/analyzers/tdg.rs",
+                "use crate::analyzers::{hotspot};\npub fn a() {}\n",
+            ),
+            (
+                "src/analyzers/defect.rs",
+                "use crate::analyzers::{hotspot};\npub fn b() {}\n",
+            ),
+            ("src/analyzers/hotspot.rs", "pub fn h() {}\n"),
+        ]);
+
+        assert_eq!(
+            analysis.summary.cycle_count, 0,
+            "no cycle should be reported for sibling modules through a parent, found: {:?}",
+            analysis.cycles
+        );
+    }
+
+    #[test]
+    fn test_real_rust_cycle_is_still_detected() {
+        // Do not over-correct: a genuine two-module cycle must still be caught.
+        let analysis = analyze_fixture(&[
+            ("src/lib.rs", "pub mod a;\npub mod b;\n"),
+            ("src/a.rs", "use crate::b;\npub fn f() { b::g(); }\n"),
+            ("src/b.rs", "use crate::a;\npub fn g() { a::f(); }\n"),
+        ]);
+
+        assert_eq!(
+            analysis.summary.cycle_count, 1,
+            "the real a.rs <-> b.rs cycle must still be reported, cycles: {:?}",
+            analysis.cycles
+        );
+    }
+
+    #[test]
+    fn test_real_rust_cycle_via_item_not_submodule_is_still_detected() {
+        // Regression: `use crate::a::{b};` where `b` is a function defined
+        // directly in a.rs (not a submodule file `a/b.rs`) must still
+        // resolve to a.rs. Over-correcting the grouped-import expansion so
+        // that per-leaf resolution gives up when `a/b.rs` doesn't exist
+        // silently drops the real a.rs <-> c.rs dependency and hides the
+        // cycle.
+        let analysis = analyze_fixture(&[
+            ("src/lib.rs", "pub mod a;\npub mod c;\n"),
+            ("src/a.rs", "use crate::c;\npub fn b() {}\n"),
+            ("src/c.rs", "use crate::a::{b};\n"),
+        ]);
+
+        assert_eq!(
+            analysis.summary.cycle_count, 1,
+            "the real a.rs <-> c.rs cycle must still be reported, cycles: {:?}",
+            analysis.cycles
+        );
+    }
+
+    #[test]
+    fn test_graph_and_smells_agree_on_edges_and_cycles() {
+        // graph and smells must build the SAME edge set -- not just the same
+        // cycle count -- for the same input, since they now share both the
+        // resolver and the extraction/edge-building step. Includes: a real
+        // cross-package cycle, a self-import (must not become a self-loop
+        // edge in either), and a barrel re-export (`export * from`, the
+        // issue #479 monorepo pattern).
+        use crate::analyzers::import_resolver::{build_dependency_graph, extract_resolved_imports};
+        use crate::analyzers::smells;
+        use crate::config::Config;
+        use crate::core::{AnalysisContext, FileSet};
+        use std::collections::HashSet;
+
+        let files: &[(&str, &str)] = &[
+            (
+                "packages/brain/src/types.ts",
+                "import type { M } from '../../mcp/src/types.js';\nexport type B = M;\n",
+            ),
+            ("packages/mcp/src/types.ts", "export type M = number;\n"),
+            ("a.ts", "import { b } from './b.js';\nexport const a = b;\n"),
+            ("b.ts", "import { a } from './a.js';\nexport const b = a;\n"),
+            (
+                "self.ts",
+                "import { helper } from './self.js';\nexport function helper() {}\n",
+            ),
+            ("pkg/index.ts", "export * from './widget';\n"),
+            ("pkg/widget.ts", "export const widget = 1;\n"),
+        ];
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        for (rel_path, content) in files {
+            let full_path = temp_dir.path().join(rel_path);
+            std::fs::create_dir_all(full_path.parent().unwrap()).unwrap();
+            std::fs::write(full_path, content).unwrap();
+        }
+
+        let graph_analysis = Analyzer::new().analyze_project(temp_dir.path()).unwrap();
+
+        let config = Config::default();
+        let file_set = FileSet::from_path(temp_dir.path(), &config).unwrap();
+        let ctx = AnalysisContext::new(&file_set, &config, Some(temp_dir.path()));
+        let smells_analysis = smells::Analyzer::new().analyze_repo(&ctx).unwrap();
+
+        // graph's public edge list, as a set: must have no self-loops and no
+        // duplicate (parallel) edges.
+        let graph_edges: HashSet<(String, String)> = graph_analysis
+            .edges
+            .iter()
+            .map(|e| (e.from.clone(), e.to.clone()))
+            .collect();
+        assert_eq!(
+            graph_edges.len(),
+            graph_analysis.edges.len(),
+            "graph's edge list must not contain duplicates"
+        );
+        assert!(
+            graph_edges.iter().all(|(from, to)| from != to),
+            "graph's edge list must not contain self-loops: {:?}",
+            graph_edges
+        );
+
+        // Independently rebuild the canonical edge set via the exact shared
+        // functions both analyzers call, and require graph's public edges
+        // to match it exactly.
+        let all_files: Vec<_> = file_set.iter().cloned().collect();
+        let file_index = ImportIndex::new(&all_files, temp_dir.path());
+        let file_imports = extract_resolved_imports(&all_files, &ctx, &file_index, false);
+        let (canonical_graph, canonical_indices) = build_dependency_graph(&file_imports, false);
+        let canonical_edges: HashSet<(String, String)> = canonical_graph
+            .edge_indices()
+            .map(|e| {
+                let (from, to) = canonical_graph.edge_endpoints(e).unwrap();
+                (canonical_graph[from].clone(), canonical_graph[to].clone())
+            })
+            .collect();
+        assert_eq!(
+            graph_edges, canonical_edges,
+            "graph's public edges must match the canonical shared-builder edge set"
+        );
+
+        // smells doesn't expose raw edges, but its per-file fan_in/fan_out
+        // are derived directly from its internal graph's degrees -- if that
+        // graph has the same edge set as the canonical one, these must
+        // match graph's public in_degree/out_degree for every file exactly.
+        let graph_degrees: HashMap<&str, (usize, usize)> = graph_analysis
+            .nodes
+            .iter()
+            .map(|n| (n.path.as_str(), (n.in_degree, n.out_degree)))
+            .collect();
+        for component in &smells_analysis.components {
+            let (expected_in, expected_out) = graph_degrees
+                .get(component.id.as_str())
+                .unwrap_or_else(|| panic!("graph has no node for {}", component.id));
+            assert_eq!(
+                (component.fan_in, component.fan_out),
+                (*expected_in, *expected_out),
+                "fan_in/fan_out for {} must match graph's in_degree/out_degree",
+                component.id
+            );
+        }
+        assert_eq!(smells_analysis.components.len(), graph_analysis.nodes.len());
+
+        // canonical builder must also agree with graph's degree sequence,
+        // and with cycle counts on both sides.
+        for (path, &idx) in &canonical_indices {
+            let in_deg = canonical_graph
+                .edges_directed(idx, Direction::Incoming)
+                .count();
+            let out_deg = canonical_graph
+                .edges_directed(idx, Direction::Outgoing)
+                .count();
+            let (expected_in, expected_out) = graph_degrees[path.as_str()];
+            assert_eq!((in_deg, out_deg), (expected_in, expected_out));
+        }
+
+        assert_eq!(
+            graph_analysis.cycles.len(),
+            smells_analysis.summary.cyclic_count,
+            "graph and smells must agree on cycle count: graph={:?} smells cyclic_count={}",
+            graph_analysis.cycles,
+            smells_analysis.summary.cyclic_count
+        );
+        // The known real cycle (a.ts <-> b.ts) is the only one either should
+        // find; the self-import and the barrel re-export must not add any.
+        assert_eq!(graph_analysis.cycles.len(), 1);
+    }
+
     #[test]
     fn test_analyzer_creation() {
         let analyzer = Analyzer::new();
@@ -1202,133 +1077,5 @@ mod tests {
         };
         assert_eq!(edge.from, "a.rs");
         assert_eq!(edge.to, "b.rs");
-    }
-
-    #[test]
-    fn test_camel_to_snake() {
-        assert_eq!(camel_to_snake("OrderSearcher"), "order_searcher");
-        assert_eq!(camel_to_snake("ApplicationRecord"), "application_record");
-        assert_eq!(camel_to_snake("HTTPClient"), "http_client");
-        assert_eq!(camel_to_snake("Foo"), "foo");
-        assert_eq!(camel_to_snake("FooBar"), "foo_bar");
-        assert_eq!(camel_to_snake("already_snake"), "already_snake");
-        assert_eq!(camel_to_snake("JSON"), "json");
-        assert_eq!(camel_to_snake("HTMLParser"), "html_parser");
-    }
-
-    #[test]
-    fn test_find_match_ruby_constant_to_snake_case() {
-        let root = Path::new("/project");
-        let files = vec![
-            std::path::PathBuf::from("/project/app/models/concerns/order_searcher.rb"),
-            std::path::PathBuf::from("/project/app/models/concerns/feature_gate.rb"),
-            std::path::PathBuf::from("/project/app/models/application_record.rb"),
-        ];
-        let index = FilePathIndex::new(&files, root);
-
-        // CamelCase constant should resolve to snake_case file
-        assert_eq!(
-            index.find_match("OrderSearcher", Path::new("app/models/order.rb")),
-            Some("app/models/concerns/order_searcher.rb".to_string())
-        );
-        assert_eq!(
-            index.find_match("FeatureGate", Path::new("app/models/order.rb")),
-            Some("app/models/concerns/feature_gate.rb".to_string())
-        );
-        assert_eq!(
-            index.find_match("ApplicationRecord", Path::new("app/models/order.rb")),
-            Some("app/models/application_record.rb".to_string())
-        );
-    }
-
-    #[test]
-    fn test_find_match_ruby_scoped_constant() {
-        let root = Path::new("/project");
-        let files = vec![
-            std::path::PathBuf::from("/project/app/models/concerns/active_model/validations.rb"),
-            std::path::PathBuf::from("/project/lib/active_record/base.rb"),
-        ];
-        let index = FilePathIndex::new(&files, root);
-
-        // Scoped constant ActiveModel::Validations -> active_model/validations
-        assert_eq!(
-            index.find_match("ActiveModel::Validations", Path::new("app/models/user.rb")),
-            Some("app/models/concerns/active_model/validations.rb".to_string())
-        );
-        assert_eq!(
-            index.find_match("ActiveRecord::Base", Path::new("app/models/user.rb")),
-            Some("lib/active_record/base.rb".to_string())
-        );
-    }
-
-    #[test]
-    fn test_find_match_scoped_constant_no_substring_collision() {
-        let root = Path::new("/project");
-        let files = vec![std::path::PathBuf::from(
-            "/project/packages/connect/app/controllers/connect/sign_up_controller.rb",
-        )];
-        let index = FilePathIndex::new(&files, root);
-
-        // T::Sig -> t/sig should NOT match connect/sign_up_controller.rb
-        // (substring "t/sig" appears in "connect/sign_up" but not on segment boundaries)
-        assert_eq!(
-            index.find_match("T::Sig", Path::new("app/models/user.rb")),
-            None
-        );
-    }
-
-    #[test]
-    fn test_find_match_rust_crate_import() {
-        let root = Path::new("/project");
-        let files = vec![
-            std::path::PathBuf::from("/project/src/config/mod.rs"),
-            std::path::PathBuf::from("/project/src/utils.rs"),
-            std::path::PathBuf::from("/project/src/analyzers/graph.rs"),
-        ];
-        let index = FilePathIndex::new(&files, root);
-
-        // crate::config::Config -> should match src/config/mod.rs
-        assert_eq!(
-            index.find_match("crate::config", Path::new("src/main.rs")),
-            Some("src/config/mod.rs".to_string())
-        );
-
-        // crate::utils -> should match src/utils.rs
-        assert_eq!(
-            index.find_match("crate::utils", Path::new("src/main.rs")),
-            Some("src/utils.rs".to_string())
-        );
-
-        // crate::analyzers::graph -> should match src/analyzers/graph.rs
-        assert_eq!(
-            index.find_match("crate::analyzers::graph", Path::new("src/main.rs")),
-            Some("src/analyzers/graph.rs".to_string())
-        );
-    }
-
-    #[test]
-    fn test_find_match_rust_mod_declaration() {
-        let root = Path::new("/project");
-        let files = vec![
-            std::path::PathBuf::from("/project/src/config.rs"),
-            std::path::PathBuf::from("/project/src/config/mod.rs"),
-            std::path::PathBuf::from("/project/src/utils.rs"),
-        ];
-        let index = FilePathIndex::new(&files, root);
-
-        // mod config -> should match src/config.rs or src/config/mod.rs
-        let result = index.find_match("config", Path::new("src/lib.rs"));
-        assert!(
-            result == Some("src/config.rs".to_string())
-                || result == Some("src/config/mod.rs".to_string()),
-            "Expected config.rs or config/mod.rs, got {:?}",
-            result
-        );
-
-        // mod utils -> should match src/utils.rs
-        assert_eq!(
-            index.find_match("utils", Path::new("src/lib.rs")),
-            Some("src/utils.rs".to_string())
-        );
     }
 }

--- a/src/analyzers/import_resolver.rs
+++ b/src/analyzers/import_resolver.rs
@@ -1,0 +1,784 @@
+//! Shared import-specifier resolver used by both `graph` and `smells`.
+//!
+//! Both analyzers build a dependency graph from the same parsed imports, and
+//! it is critical that they resolve specifiers to on-disk files identically -
+//! otherwise the two commands can disagree on edges and therefore on cycles
+//! for the same input (GitHub issue #479, where `smells` fabricated a
+//! self-cycle that `graph` correctly did not report). This module is the one
+//! resolver both call, so they can never diverge again.
+//!
+//! Relative specifiers (`./foo`, `../foo`) are resolved strictly against the
+//! importing file's directory: every candidate extension is tried, but if
+//! none of them exist on disk the specifier fails to resolve. It never falls
+//! back to matching some other file elsewhere in the repo that happens to
+//! share a file stem -- that fallback is what produced phantom cycles.
+//! Non-relative specifiers (Rust `crate::`/module paths, Ruby constants, Go
+//! import paths, ...) still use stem/segment heuristics, since they have no
+//! directory to resolve against.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use petgraph::graph::{DiGraph, NodeIndex};
+use rayon::prelude::*;
+
+use crate::core::{AnalysisContext, Language};
+use crate::parser::{extract_imports, ImportKind, Parser};
+
+/// Extensions tried, in priority order, once a relative specifier's own
+/// (possibly absent) extension has been stripped. Used for plain `.js`,
+/// `.jsx`, and extensionless specifiers.
+const JS_TS_SOURCE_EXTS: &[&str] = &[".ts", ".tsx", ".js", ".jsx", ".mts", ".cts"];
+
+/// An `.mjs` specifier is Node's explicit ESM marker, so its own `.mts`
+/// source (the TypeScript equivalent) is tried before the extensionless
+/// `.ts`/`.js` -- otherwise a directory with both `foo.ts` and `foo.mts`
+/// would resolve an `.mjs` import to the wrong module-system source.
+const MJS_SOURCE_EXTS: &[&str] = &[".mts", ".ts", ".tsx", ".js", ".jsx", ".cts"];
+
+/// Symmetric with `MJS_SOURCE_EXTS` for CommonJS.
+const CJS_SOURCE_EXTS: &[&str] = &[".cts", ".ts", ".tsx", ".js", ".jsx", ".mts"];
+
+/// Extensions for other supported languages, tried after JS/TS so that a
+/// relative import without a recognized JS/TS extension can still resolve.
+const OTHER_SOURCE_EXTS: &[&str] = &[
+    ".rs", ".go", ".py", ".java", ".rb", ".php", ".c", ".h", ".cpp", ".hpp", ".cs",
+];
+
+/// Pre-built index for O(1) file path lookups during import resolution.
+pub struct ImportIndex {
+    /// Full relative path -> relative path (identity mapping for exact matches).
+    by_full_path: HashMap<String, String>,
+    /// File stem (without extension) -> list of relative paths.
+    by_stem: HashMap<String, Vec<String>>,
+}
+
+impl ImportIndex {
+    pub fn new(files: &[std::path::PathBuf], root: &Path) -> Self {
+        let mut by_full_path = HashMap::with_capacity(files.len());
+        let mut by_stem: HashMap<String, Vec<String>> = HashMap::new();
+
+        for file in files {
+            let rel = file.strip_prefix(root).unwrap_or(file);
+            let rel_str = rel.to_string_lossy().to_string();
+
+            by_full_path.insert(rel_str.clone(), rel_str.clone());
+
+            if let Some(stem) = rel.file_stem() {
+                let stem_str = stem.to_string_lossy().to_string();
+                by_stem.entry(stem_str).or_default().push(rel_str.clone());
+            }
+        }
+
+        Self {
+            by_full_path,
+            by_stem,
+        }
+    }
+
+    /// Try to find a file matching the import path.
+    pub fn find_match(&self, import_path: &str, from_file: &Path) -> Option<String> {
+        // 0. Handle Rust crate-relative imports (crate::, super::, self::)
+        if import_path.starts_with("crate::")
+            || import_path.starts_with("super::")
+            || import_path.starts_with("self::")
+        {
+            if let Some(found) = self.find_rust_crate_relative(import_path, from_file) {
+                return Some(found);
+            }
+            // Fall through to other matching strategies below.
+        }
+
+        // 1. Relative imports (./foo, ../foo) resolve strictly against the
+        //    importing file's directory. No fallback to global stem matching:
+        //    a relative specifier names one specific file, and picking a
+        //    different same-named file elsewhere is exactly what produced
+        //    phantom cycles (issue #479).
+        if import_path.starts_with("./") || import_path.starts_with("../") {
+            let parent = from_file.parent()?;
+            let resolved = parent.join(import_path);
+            // `normalize_path` returns None if the specifier traverses
+            // above the analyzed root (more `..` than preceding path
+            // components) -- such a specifier points outside the repo and
+            // must not be clamped into some unrelated in-repo file.
+            let normalized = normalize_path(&resolved)?;
+            return self.resolve_relative(&normalized);
+        }
+
+        // 2. Try exact stem match
+        if let Some(matches) = self.by_stem.get(import_path) {
+            if let Some(found) = shortest(matches) {
+                return Some(found);
+            }
+        }
+
+        // 3. Try snake_case conversion for Ruby CamelCase constants
+        //    e.g., "OrderSearcher" -> "order_searcher", "ActiveModel::Validations" -> "active_model/validations"
+        if import_path.contains("::") {
+            // Scoped constant: split on ::, convert each segment, join with /
+            // e.g., ActiveModel::Validations -> active_model/validations
+            let snake_path: String = import_path
+                .split("::")
+                .map(camel_to_snake)
+                .collect::<Vec<_>>()
+                .join("/");
+            // Match on path segment boundaries (must be preceded by / or start of string).
+            // `HashMap::keys()` iteration order is randomized per-instance
+            // (a fresh random hasher seed each `HashMap::new()`), so two
+            // `ImportIndex`es built from identical files -- as `graph` and
+            // `smells` each build their own -- could pick different targets
+            // for the same specifier. Collect every match and pick the
+            // shortest (most specific), tie-broken lexicographically, so
+            // the result is stable regardless of hash iteration order.
+            let with_slash = format!("/{}", snake_path);
+            let mut candidates: Vec<&String> = self
+                .by_full_path
+                .keys()
+                .filter(|k| k.starts_with(&snake_path) || k.contains(&with_slash))
+                .collect();
+            candidates.sort_by(|a, b| a.len().cmp(&b.len()).then_with(|| a.cmp(b)));
+            if let Some(matched) = candidates.first() {
+                return Some((*matched).clone());
+            }
+            // Also try the last segment as a stem match
+            if let Some(last) = snake_path.rsplit('/').next() {
+                if let Some(matches) = self.by_stem.get(last) {
+                    for candidate in matches {
+                        if candidate.contains(&snake_path) {
+                            return Some(candidate.clone());
+                        }
+                    }
+                }
+            }
+        } else {
+            let snake = camel_to_snake(import_path);
+            if snake != import_path {
+                if let Some(matches) = self.by_stem.get(&snake) {
+                    if let Some(found) = shortest(matches) {
+                        return Some(found);
+                    }
+                }
+            }
+        }
+
+        // 4. Try segment-based matching for module paths like "utils/helpers"
+        let segments: Vec<&str> = import_path.split('/').filter(|s| !s.is_empty()).collect();
+        if let Some(last_segment) = segments.last() {
+            if let Some(candidates) = self.by_stem.get(*last_segment) {
+                // Find candidates that match the full path pattern
+                for candidate in candidates {
+                    if candidate.contains(import_path) {
+                        return Some(candidate.clone());
+                    }
+                }
+                // Fall back to first match with the stem
+                if !candidates.is_empty() {
+                    return Some(candidates[0].clone());
+                }
+            }
+        }
+
+        None
+    }
+
+    fn find_rust_crate_relative(&self, import_path: &str, from_file: &Path) -> Option<String> {
+        let stripped = import_path
+            .strip_prefix("crate::")
+            .or_else(|| import_path.strip_prefix("super::"))
+            .or_else(|| import_path.strip_prefix("self::"))
+            .unwrap_or(import_path);
+
+        // Take the module path part (strip trailing type names which are CamelCase)
+        // e.g., crate::config::Config -> config, crate::analyzers::graph -> analyzers/graph
+        let segments: Vec<&str> = stripped.split("::").collect();
+
+        // Find the last segment that looks like a module (lowercase/snake_case)
+        let module_segments: Vec<&str> = segments
+            .iter()
+            .take_while(|s| {
+                s.chars()
+                    .next()
+                    .map(|c| c.is_lowercase() || c == '_')
+                    .unwrap_or(false)
+            })
+            .copied()
+            .collect();
+
+        let module_path = if module_segments.is_empty() {
+            // All segments start with uppercase - use all as path
+            segments.join("/")
+        } else {
+            module_segments.join("/")
+        };
+
+        // Handle super:: relative to current file
+        if import_path.starts_with("super::") {
+            if let Some(parent) = from_file.parent().and_then(|p| p.parent()) {
+                let resolved = parent.join(&module_path);
+                if let Some(normalized) = normalize_path(&resolved) {
+                    for ext in &["", ".rs"] {
+                        let candidate = if ext.is_empty() {
+                            normalized.clone()
+                        } else {
+                            format!("{}{}", normalized, ext)
+                        };
+                        if self.by_full_path.contains_key(&candidate) {
+                            return Some(candidate);
+                        }
+                    }
+                    let mod_rs = format!("{}/mod.rs", normalized);
+                    if self.by_full_path.contains_key(&mod_rs) {
+                        return Some(mod_rs);
+                    }
+                }
+            }
+        }
+
+        // Try common Rust source roots with the module path, then
+        // progressively shorter prefixes of it (dropping trailing
+        // segments). `crate::a::b` may name a submodule file `a/b.rs`, or
+        // it may name an item (`fn`/`struct`/`const`) defined directly in
+        // `a.rs` -- syntactically indistinguishable from here. Falling back
+        // to the parent path when the full path doesn't match a file is
+        // what makes the latter resolve to `a.rs` instead of silently
+        // dropping the dependency (which hides real cycles).
+        let path_segments: Vec<&str> = module_path.split('/').filter(|s| !s.is_empty()).collect();
+        for take in (1..=path_segments.len()).rev() {
+            let candidate_path = path_segments[..take].join("/");
+            let source_roots = ["src", "lib", ""];
+            for root in &source_roots {
+                let base = if root.is_empty() {
+                    candidate_path.clone()
+                } else {
+                    format!("{}/{}", root, candidate_path)
+                };
+
+                // Try direct file match (e.g., src/config.rs)
+                let rs_path = format!("{}.rs", base);
+                if self.by_full_path.contains_key(&rs_path) {
+                    return Some(rs_path);
+                }
+
+                // Try mod.rs (e.g., src/config/mod.rs)
+                let mod_path = format!("{}/mod.rs", base);
+                if self.by_full_path.contains_key(&mod_path) {
+                    return Some(mod_path);
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Resolve a relative specifier (already joined onto the importer's
+    /// directory and normalized) against the file index. Tries the exact
+    /// path, then extension substitution (with JS/TS compiled-output
+    /// awareness), then `index.*` barrel files -- and nothing else.
+    fn resolve_relative(&self, normalized: &str) -> Option<String> {
+        if self.by_full_path.contains_key(normalized) {
+            return Some(normalized.to_string());
+        }
+
+        // Pick the source-extension priority list based on the specifier's
+        // own (stripped) extension, so an explicit `.mjs`/`.cjs` marker
+        // prefers its matching `.mts`/`.cts` module-system source over a
+        // plain `.ts` sibling.
+        let (stem, source_exts): (&str, &[&str]) = if let Some(s) = normalized.strip_suffix(".mjs")
+        {
+            (s, MJS_SOURCE_EXTS)
+        } else if let Some(s) = normalized.strip_suffix(".cjs") {
+            (s, CJS_SOURCE_EXTS)
+        } else if let Some(s) = normalized.strip_suffix(".js") {
+            (s, JS_TS_SOURCE_EXTS)
+        } else if let Some(s) = normalized.strip_suffix(".jsx") {
+            (s, JS_TS_SOURCE_EXTS)
+        } else {
+            (normalized, JS_TS_SOURCE_EXTS)
+        };
+
+        for ext in source_exts.iter().chain(OTHER_SOURCE_EXTS) {
+            let candidate = format!("{stem}{ext}");
+            if self.by_full_path.contains_key(&candidate) {
+                return Some(candidate);
+            }
+        }
+
+        for ext in source_exts.iter().chain(OTHER_SOURCE_EXTS) {
+            let candidate = format!("{stem}/index{ext}");
+            if self.by_full_path.contains_key(&candidate) {
+                return Some(candidate);
+            }
+        }
+
+        None
+    }
+}
+
+/// Prefer the shortest (most specific) path among stem matches.
+fn shortest(matches: &[String]) -> Option<String> {
+    matches.iter().min_by_key(|s| s.len()).cloned()
+}
+
+/// Convert CamelCase to snake_case for Ruby constant-to-filename resolution.
+/// Handles consecutive uppercase (e.g., HTTPClient -> http_client).
+pub fn camel_to_snake(name: &str) -> String {
+    let mut result = String::with_capacity(name.len() + 4);
+    let chars: Vec<char> = name.chars().collect();
+    for (i, &c) in chars.iter().enumerate() {
+        if c.is_uppercase() {
+            if i > 0 {
+                let prev = chars[i - 1];
+                let next_is_lower = chars.get(i + 1).is_some_and(|n| n.is_lowercase());
+                // Insert underscore before: uppercase after lowercase, or
+                // start of new word in consecutive uppercase (e.g., the P in HTTPParser)
+                if prev.is_lowercase() || (prev.is_uppercase() && next_is_lower) {
+                    result.push('_');
+                }
+            }
+            for lc in c.to_lowercase() {
+                result.push(lc);
+            }
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}
+
+/// Normalize a path by removing `.` and resolving `..`. Returns `None` if
+/// the path traverses above its own starting point (more `..` components
+/// than preceding path segments) -- such a specifier points outside the
+/// directory it was resolved against and must not be silently clamped into
+/// some unrelated in-repo file.
+pub fn normalize_path(path: &Path) -> Option<String> {
+    let mut components: Vec<String> = Vec::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::Normal(c) => {
+                components.push(c.to_string_lossy().to_string());
+            }
+            std::path::Component::ParentDir => {
+                components.pop()?;
+            }
+            std::path::Component::CurDir => {}
+            _ => {}
+        }
+    }
+    Some(components.join("/"))
+}
+
+/// Parse every file's imports (in parallel) and resolve each through the
+/// shared `ImportIndex`. Module containment declarations (Rust `mod foo;`)
+/// are not dependency edges, only real `use`/`import` statements are, so
+/// they are filtered out here. An import that fails to resolve produces no
+/// edge, unless `include_external` requests a node for it anyway.
+///
+/// Returns `(path, resolved_targets)` per file. This extraction step -- not
+/// just the resolver it calls -- is shared by `graph` and `smells`, so the
+/// two analyzers can never disagree on the edges they build for the same
+/// input (issue #479).
+pub fn extract_resolved_imports(
+    files: &[std::path::PathBuf],
+    ctx: &AnalysisContext<'_>,
+    file_index: &ImportIndex,
+    include_external: bool,
+) -> Vec<(String, Vec<String>)> {
+    files
+        .par_iter()
+        .filter_map(|file| {
+            let rel_path = file.strip_prefix(ctx.root).unwrap_or(file);
+            let path_str = rel_path.to_string_lossy().to_string();
+
+            let content = ctx.read_file(file).ok()?;
+            let lang = Language::detect(file)?;
+
+            let parser = Parser::new();
+            let result = parser.parse(&content, lang, file).ok()?;
+
+            let resolved: Vec<String> = extract_imports(&result)
+                .into_iter()
+                .filter(|imp| imp.kind == ImportKind::Use)
+                .filter_map(|imp| {
+                    file_index.find_match(&imp.path, rel_path).or_else(|| {
+                        if include_external {
+                            Some(imp.path.clone())
+                        } else {
+                            None
+                        }
+                    })
+                })
+                .collect();
+
+            Some((path_str, resolved))
+        })
+        .collect()
+}
+
+/// Build a dependency graph from resolved `(path, imports)` pairs, applying
+/// the shared edge rules: a file is never wired to itself (a self-import is
+/// not a real dependency cycle between two components) and a repeated
+/// import produces one edge, not a parallel edge. `include_external` gives
+/// unresolved import targets their own node instead of dropping them.
+///
+/// Sharing this step (not just the resolver) is what guarantees `graph` and
+/// `smells` build the identical edge set for the same input.
+pub fn build_dependency_graph(
+    file_imports: &[(String, Vec<String>)],
+    include_external: bool,
+) -> (DiGraph<String, ()>, HashMap<String, NodeIndex>) {
+    let mut graph: DiGraph<String, ()> =
+        DiGraph::with_capacity(file_imports.len(), file_imports.len() * 4);
+    let mut node_indices: HashMap<String, NodeIndex> = HashMap::with_capacity(file_imports.len());
+
+    for (path, _) in file_imports {
+        node_indices
+            .entry(path.clone())
+            .or_insert_with(|| graph.add_node(path.clone()));
+    }
+
+    for (from_path, imports) in file_imports {
+        let from_idx = node_indices[from_path];
+
+        for import in imports {
+            let to_idx = if let Some(&idx) = node_indices.get(import) {
+                idx
+            } else if include_external {
+                *node_indices
+                    .entry(import.clone())
+                    .or_insert_with(|| graph.add_node(import.clone()))
+            } else {
+                continue;
+            };
+
+            if from_idx != to_idx && !graph.contains_edge(from_idx, to_idx) {
+                graph.add_edge(from_idx, to_idx, ());
+            }
+        }
+    }
+
+    (graph, node_indices)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_camel_to_snake() {
+        assert_eq!(camel_to_snake("OrderSearcher"), "order_searcher");
+        assert_eq!(camel_to_snake("ApplicationRecord"), "application_record");
+        assert_eq!(camel_to_snake("HTTPClient"), "http_client");
+        assert_eq!(camel_to_snake("Foo"), "foo");
+        assert_eq!(camel_to_snake("FooBar"), "foo_bar");
+        assert_eq!(camel_to_snake("already_snake"), "already_snake");
+        assert_eq!(camel_to_snake("JSON"), "json");
+        assert_eq!(camel_to_snake("HTMLParser"), "html_parser");
+    }
+
+    #[test]
+    fn test_find_match_ruby_constant_to_snake_case() {
+        let root = Path::new("/project");
+        let files = vec![
+            std::path::PathBuf::from("/project/app/models/concerns/order_searcher.rb"),
+            std::path::PathBuf::from("/project/app/models/concerns/feature_gate.rb"),
+            std::path::PathBuf::from("/project/app/models/application_record.rb"),
+        ];
+        let index = ImportIndex::new(&files, root);
+
+        assert_eq!(
+            index.find_match("OrderSearcher", Path::new("app/models/order.rb")),
+            Some("app/models/concerns/order_searcher.rb".to_string())
+        );
+        assert_eq!(
+            index.find_match("FeatureGate", Path::new("app/models/order.rb")),
+            Some("app/models/concerns/feature_gate.rb".to_string())
+        );
+        assert_eq!(
+            index.find_match("ApplicationRecord", Path::new("app/models/order.rb")),
+            Some("app/models/application_record.rb".to_string())
+        );
+    }
+
+    #[test]
+    fn test_find_match_ruby_scoped_constant() {
+        let root = Path::new("/project");
+        let files = vec![
+            std::path::PathBuf::from("/project/app/models/concerns/active_model/validations.rb"),
+            std::path::PathBuf::from("/project/lib/active_record/base.rb"),
+        ];
+        let index = ImportIndex::new(&files, root);
+
+        assert_eq!(
+            index.find_match("ActiveModel::Validations", Path::new("app/models/user.rb")),
+            Some("app/models/concerns/active_model/validations.rb".to_string())
+        );
+        assert_eq!(
+            index.find_match("ActiveRecord::Base", Path::new("app/models/user.rb")),
+            Some("lib/active_record/base.rb".to_string())
+        );
+    }
+
+    #[test]
+    fn test_find_match_scoped_constant_no_substring_collision() {
+        let root = Path::new("/project");
+        let files = vec![std::path::PathBuf::from(
+            "/project/packages/connect/app/controllers/connect/sign_up_controller.rb",
+        )];
+        let index = ImportIndex::new(&files, root);
+
+        assert_eq!(
+            index.find_match("T::Sig", Path::new("app/models/user.rb")),
+            None
+        );
+    }
+
+    #[test]
+    fn test_find_match_rust_crate_import() {
+        let root = Path::new("/project");
+        let files = vec![
+            std::path::PathBuf::from("/project/src/config/mod.rs"),
+            std::path::PathBuf::from("/project/src/utils.rs"),
+            std::path::PathBuf::from("/project/src/analyzers/graph.rs"),
+        ];
+        let index = ImportIndex::new(&files, root);
+
+        assert_eq!(
+            index.find_match("crate::config", Path::new("src/main.rs")),
+            Some("src/config/mod.rs".to_string())
+        );
+        assert_eq!(
+            index.find_match("crate::utils", Path::new("src/main.rs")),
+            Some("src/utils.rs".to_string())
+        );
+        assert_eq!(
+            index.find_match("crate::analyzers::graph", Path::new("src/main.rs")),
+            Some("src/analyzers/graph.rs".to_string())
+        );
+    }
+
+    #[test]
+    fn test_find_match_rust_mod_declaration() {
+        let root = Path::new("/project");
+        let files = vec![
+            std::path::PathBuf::from("/project/src/config.rs"),
+            std::path::PathBuf::from("/project/src/config/mod.rs"),
+            std::path::PathBuf::from("/project/src/utils.rs"),
+        ];
+        let index = ImportIndex::new(&files, root);
+
+        let result = index.find_match("config", Path::new("src/lib.rs"));
+        assert!(
+            result == Some("src/config.rs".to_string())
+                || result == Some("src/config/mod.rs".to_string()),
+            "Expected config.rs or config/mod.rs, got {:?}",
+            result
+        );
+
+        assert_eq!(
+            index.find_match("utils", Path::new("src/lib.rs")),
+            Some("src/utils.rs".to_string())
+        );
+    }
+
+    #[test]
+    fn test_relative_esm_js_specifier_resolves_to_ts_source() {
+        // Issue #479 repro: an ESM `.js` specifier pointing at a `.ts` source
+        // file located via a relative path, not a global stem match.
+        let root = Path::new("/project");
+        let files = vec![
+            std::path::PathBuf::from("/project/packages/brain/src/types.ts"),
+            std::path::PathBuf::from("/project/packages/mcp/src/types.ts"),
+        ];
+        let index = ImportIndex::new(&files, root);
+
+        assert_eq!(
+            index.find_match(
+                "../../mcp/src/types.js",
+                Path::new("packages/brain/src/types.ts")
+            ),
+            Some("packages/mcp/src/types.ts".to_string())
+        );
+    }
+
+    #[test]
+    fn test_relative_import_never_falls_back_to_global_stem() {
+        // A relative specifier that does not actually resolve to any file on
+        // disk must fail, even though a same-named file exists elsewhere in
+        // the repo. Falling back to that other file is exactly the phantom
+        // self-cycle bug from issue #479.
+        let root = Path::new("/project");
+        let files = vec![
+            std::path::PathBuf::from("/project/a/types.ts"),
+            std::path::PathBuf::from("/project/b/types.ts"),
+        ];
+        let index = ImportIndex::new(&files, root);
+
+        assert_eq!(
+            index.find_match("./nonexistent.js", Path::new("a/types.ts")),
+            None
+        );
+    }
+
+    #[test]
+    fn test_relative_import_resolves_index_barrel() {
+        let root = Path::new("/project");
+        let files = vec![std::path::PathBuf::from("/project/src/utils/index.ts")];
+        let index = ImportIndex::new(&files, root);
+
+        assert_eq!(
+            index.find_match("./utils", Path::new("src/main.ts")),
+            Some("src/utils/index.ts".to_string())
+        );
+    }
+
+    #[test]
+    fn test_rust_crate_path_to_item_falls_back_to_parent_module_file() {
+        // `use crate::a::{b};` where `b` is a value/fn/type defined directly
+        // in a.rs (not a submodule) must still resolve to a.rs. Regression:
+        // resolving only the full `a/b` path and giving up when `b.rs`
+        // doesn't exist silently drops a real dependency edge, which hides
+        // real cycles (e.g. a.rs <-> c.rs).
+        let root = Path::new("/project");
+        let files = vec![
+            std::path::PathBuf::from("/project/src/a.rs"),
+            std::path::PathBuf::from("/project/src/c.rs"),
+        ];
+        let index = ImportIndex::new(&files, root);
+
+        assert_eq!(
+            index.find_match("crate::a::b", Path::new("src/c.rs")),
+            Some("src/a.rs".to_string())
+        );
+    }
+
+    #[test]
+    fn test_rust_crate_path_to_item_falls_back_through_multiple_levels() {
+        // crate::analyzers::graph::helper_fn -- "helper_fn" is an item in
+        // graph.rs, not a submodule of graph. Must fall back past both
+        // "analyzers/graph/helper_fn" and land on "analyzers/graph.rs".
+        let root = Path::new("/project");
+        let files = vec![
+            std::path::PathBuf::from("/project/src/analyzers/graph.rs"),
+            std::path::PathBuf::from("/project/src/analyzers/mod.rs"),
+        ];
+        let index = ImportIndex::new(&files, root);
+
+        assert_eq!(
+            index.find_match(
+                "crate::analyzers::graph::helper_fn",
+                Path::new("src/main.rs")
+            ),
+            Some("src/analyzers/graph.rs".to_string())
+        );
+    }
+
+    #[test]
+    fn test_scoped_constant_match_is_deterministic_across_instances() {
+        // The scoped-constant matcher (Ruby-style `Foo::Bar`) used to pick
+        // an arbitrary `HashMap::keys()` match via `.find()`, whose
+        // iteration order is randomized per-`HashMap` instance (a fresh
+        // random hasher seed per `HashMap::new()`) -- so two `ImportIndex`es
+        // built from identical files, as `graph` and `smells` each build
+        // their own, could pick different targets for the same specifier in
+        // the same run. Two same-length, same-prefix candidates make the
+        // old code's pick depend on hash iteration order; build many
+        // independent instances and require every one to agree.
+        let root = Path::new("/project");
+        let files = vec![
+            std::path::PathBuf::from("/project/reports/generator_aaa.rb"),
+            std::path::PathBuf::from("/project/reports/generator_bbb.rb"),
+        ];
+
+        let mut picks = std::collections::HashSet::new();
+        for _ in 0..50 {
+            let index = ImportIndex::new(&files, root);
+            let result = index.find_match("Reports::Generator", Path::new("app/user.rb"));
+            picks.insert(result);
+        }
+
+        assert_eq!(
+            picks.len(),
+            1,
+            "expected a single stable pick across instances, got {:?}",
+            picks
+        );
+        assert_eq!(
+            picks.into_iter().next().unwrap(),
+            Some("reports/generator_aaa.rb".to_string()),
+            "expected a deterministic (e.g. lexicographically first) pick"
+        );
+    }
+
+    #[test]
+    fn test_mjs_specifier_prefers_mts_over_ts() {
+        // main.mts importing `./foo.mjs` with both foo.ts and foo.mts
+        // present must resolve to the `.mts` sibling (the matching
+        // module-system source), not `.ts`.
+        let root = Path::new("/project");
+        let files = vec![
+            std::path::PathBuf::from("/project/src/foo.ts"),
+            std::path::PathBuf::from("/project/src/foo.mts"),
+        ];
+        let index = ImportIndex::new(&files, root);
+
+        assert_eq!(
+            index.find_match("./foo.mjs", Path::new("src/main.mts")),
+            Some("src/foo.mts".to_string())
+        );
+    }
+
+    #[test]
+    fn test_cjs_specifier_prefers_cts_over_ts() {
+        let root = Path::new("/project");
+        let files = vec![
+            std::path::PathBuf::from("/project/src/foo.ts"),
+            std::path::PathBuf::from("/project/src/foo.cts"),
+        ];
+        let index = ImportIndex::new(&files, root);
+
+        assert_eq!(
+            index.find_match("./foo.cjs", Path::new("src/main.cts")),
+            Some("src/foo.cts".to_string())
+        );
+    }
+
+    #[test]
+    fn test_relative_import_above_root_does_not_resolve() {
+        // `../../foo.js` from `src/main.ts` traverses above the analyzed
+        // root. It must not be silently clamped into a root-level file --
+        // that fabricates an edge to a file the specifier cannot actually
+        // reach.
+        let root = Path::new("/project");
+        let files = vec![std::path::PathBuf::from("/project/foo.ts")];
+        let index = ImportIndex::new(&files, root);
+
+        assert_eq!(
+            index.find_match("../../foo.js", Path::new("src/main.ts")),
+            None
+        );
+    }
+
+    #[test]
+    fn test_build_dependency_graph_rejects_self_loops_and_dedups() {
+        let file_imports = vec![
+            // a.ts "imports itself" and imports b.ts twice.
+            (
+                "a.ts".to_string(),
+                vec!["a.ts".to_string(), "b.ts".to_string(), "b.ts".to_string()],
+            ),
+            ("b.ts".to_string(), vec![]),
+        ];
+
+        let (graph, node_indices) = build_dependency_graph(&file_imports, false);
+
+        let a = node_indices["a.ts"];
+        let b = node_indices["b.ts"];
+        assert!(!graph.contains_edge(a, a), "self-loop must be rejected");
+        assert_eq!(
+            graph.edges_connecting(a, b).count(),
+            1,
+            "repeated import must produce exactly one edge, not a parallel edge"
+        );
+        assert_eq!(graph.edge_count(), 1);
+    }
+}

--- a/src/analyzers/import_resolver.rs
+++ b/src/analyzers/import_resolver.rs
@@ -211,9 +211,27 @@ impl ImportIndex {
             module_segments.join("/")
         };
 
-        // Handle super:: relative to current file
+        // Handle super:: relative to current file. `mod.rs`/`lib.rs`/
+        // `main.rs` stand in for their OWN directory (that directory IS the
+        // module they define), so `super::` -- the module's parent -- is one
+        // level further up than that. Every other file (e.g. `src/a/b.rs`,
+        // module `crate::a::b`) already lives in its own module's directory
+        // (`src/a/`), so `super::` is just one level up from the file, not
+        // two -- using two levels for a plain leaf module file resolves
+        // `super::x` against the wrong (grandparent) directory and drops or
+        // mis-resolves the edge.
         if import_path.starts_with("super::") {
-            if let Some(parent) = from_file.parent().and_then(|p| p.parent()) {
+            let is_directory_stand_in = from_file
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n == "mod.rs" || n == "lib.rs" || n == "main.rs");
+            let super_base = if is_directory_stand_in {
+                from_file.parent().and_then(|p| p.parent())
+            } else {
+                from_file.parent()
+            };
+
+            if let Some(parent) = super_base {
                 let resolved = parent.join(&module_path);
                 if let Some(normalized) = normalize_path(&resolved) {
                     for ext in &["", ".rs"] {
@@ -780,5 +798,63 @@ mod tests {
             "repeated import must produce exactly one edge, not a parallel edge"
         );
         assert_eq!(graph.edge_count(), 1);
+    }
+
+    #[test]
+    fn test_super_resolution_from_mod_rs_file() {
+        // `super::x` from `src/a/mod.rs` (module `crate::a`) means
+        // `crate::x` -- a's own directory `src/a` IS module a's directory,
+        // so its parent module's directory is one level further up, `src`.
+        let root = Path::new("/project");
+        let files = vec![
+            std::path::PathBuf::from("/project/src/a/mod.rs"),
+            std::path::PathBuf::from("/project/src/x.rs"),
+        ];
+        let index = ImportIndex::new(&files, root);
+
+        assert_eq!(
+            index.find_match("super::x", Path::new("src/a/mod.rs")),
+            Some("src/x.rs".to_string())
+        );
+    }
+
+    #[test]
+    fn test_super_resolution_from_nested_non_mod_rs_file() {
+        // `super::x` from `src/a/b.rs` (module `crate::a::b`) means
+        // `crate::a::x` -- a sibling of `b` within module `a`, which lives
+        // in a's directory `src/a/`. `b.rs` is a leaf file, not a directory
+        // stand-in like `mod.rs`, so its OWN directory (one level up from
+        // the file) is the `super::` base -- not two levels up.
+        let root = Path::new("/project");
+        let files = vec![
+            std::path::PathBuf::from("/project/src/a/b.rs"),
+            std::path::PathBuf::from("/project/src/a/x.rs"),
+        ];
+        let index = ImportIndex::new(&files, root);
+
+        assert_eq!(
+            index.find_match("super::x", Path::new("src/a/b.rs")),
+            Some("src/a/x.rs".to_string())
+        );
+    }
+
+    #[test]
+    fn test_super_resolution_from_lib_rs_and_main_rs() {
+        let root = Path::new("/project");
+        let files = vec![
+            std::path::PathBuf::from("/project/src/a/lib.rs"),
+            std::path::PathBuf::from("/project/src/a/main.rs"),
+            std::path::PathBuf::from("/project/src/x.rs"),
+        ];
+        let index = ImportIndex::new(&files, root);
+
+        assert_eq!(
+            index.find_match("super::x", Path::new("src/a/lib.rs")),
+            Some("src/x.rs".to_string())
+        );
+        assert_eq!(
+            index.find_match("super::x", Path::new("src/a/main.rs")),
+            Some("src/x.rs".to_string())
+        );
     }
 }

--- a/src/analyzers/mod.rs
+++ b/src/analyzers/mod.rs
@@ -11,6 +11,7 @@ pub mod flags;
 pub mod graph;
 pub mod hotspot;
 pub mod impact;
+pub mod import_resolver;
 #[cfg(feature = "mutation")]
 pub mod mutation;
 pub mod outline;

--- a/src/analyzers/smells.rs
+++ b/src/analyzers/smells.rs
@@ -18,13 +18,13 @@ use std::collections::HashMap;
 
 use chrono::Utc;
 use petgraph::algo::tarjan_scc;
-use petgraph::graph::{DiGraph, NodeIndex};
 use petgraph::Direction;
-use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::core::{AnalysisContext, Analyzer as AnalyzerTrait, Language, Result};
-use crate::parser::{extract_imports, Parser};
+use crate::analyzers::import_resolver::{
+    build_dependency_graph, extract_resolved_imports, ImportIndex,
+};
+use crate::core::{AnalysisContext, Analyzer as AnalyzerTrait, Result};
 
 /// Detection thresholds.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -105,97 +105,16 @@ impl Analyzer {
     pub fn analyze_repo(&self, ctx: &AnalysisContext<'_>) -> Result<Analysis> {
         // Phase 1: Get files from context (already filtered by language)
         let files: Vec<_> = ctx.files.iter().collect();
+        let file_paths: Vec<std::path::PathBuf> = files.iter().map(|p| (*p).clone()).collect();
 
-        // Phase 2: Parallel parsing - extract imports using content_source
-        let file_imports: Vec<(String, Vec<String>)> = files
-            .par_iter()
-            .filter_map(|path| {
-                let rel_path = path
-                    .strip_prefix(ctx.root)
-                    .unwrap_or(path)
-                    .to_string_lossy()
-                    .to_string();
-
-                // Read file via context (supports both filesystem and git tree)
-                let content = ctx.read_file(path).ok()?;
-                let lang = Language::detect(path)?;
-
-                // Parse with the content
-                let parser = Parser::new();
-                let parse_result = parser.parse(&content, lang, path).ok()?;
-                let imports = extract_imports(&parse_result);
-                let import_paths: Vec<String> = imports.into_iter().map(|imp| imp.path).collect();
-
-                Some((rel_path, import_paths))
-            })
-            .collect();
-
-        // Phase 3: Build graph and lookup index
-        let mut graph: DiGraph<String, ()> = DiGraph::new();
-        let mut node_indices: HashMap<String, NodeIndex> = HashMap::new();
-
-        // Build index for O(1) lookups: stem -> list of full paths
-        let mut by_stem: HashMap<String, Vec<String>> = HashMap::new();
-        let mut by_name: HashMap<String, Vec<String>> = HashMap::new();
-
-        // Create all nodes first
-        for (rel_path, _) in &file_imports {
-            if !node_indices.contains_key(rel_path) {
-                let idx = graph.add_node(rel_path.clone());
-                node_indices.insert(rel_path.clone(), idx);
-
-                // Index by file stem
-                if let Some(stem) = std::path::Path::new(rel_path).file_stem() {
-                    let stem_str = stem.to_string_lossy().to_string();
-                    by_stem.entry(stem_str).or_default().push(rel_path.clone());
-                }
-
-                // Index by file name
-                if let Some(name) = std::path::Path::new(rel_path).file_name() {
-                    let name_str = name.to_string_lossy().to_string();
-                    by_name.entry(name_str).or_default().push(rel_path.clone());
-                }
-            }
-        }
-
-        // Phase 4: Add edges based on imports using indexed lookups
-        for (from_file, imports) in &file_imports {
-            let from_idx = node_indices[from_file];
-
-            for import in imports {
-                // 1. Try exact path match
-                if let Some(&to_idx) = node_indices.get(import) {
-                    graph.add_edge(from_idx, to_idx, ());
-                    continue;
-                }
-
-                // 2. Try matching by import as stem or name (O(1) lookup)
-                let import_stem = std::path::Path::new(import)
-                    .file_stem()
-                    .map(|s| s.to_string_lossy().to_string())
-                    .unwrap_or_else(|| import.clone());
-
-                if let Some(matches) = by_stem.get(&import_stem) {
-                    if let Some(first_match) = matches.first() {
-                        if let Some(&to_idx) = node_indices.get(first_match) {
-                            graph.add_edge(from_idx, to_idx, ());
-                            continue;
-                        }
-                    }
-                }
-
-                // 3. Try matching by import containing a path segment
-                if let Some(last_segment) = import.split('/').next_back() {
-                    if let Some(matches) = by_stem.get(last_segment) {
-                        if let Some(first_match) = matches.first() {
-                            if let Some(&to_idx) = node_indices.get(first_match) {
-                                graph.add_edge(from_idx, to_idx, ());
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        // Build the shared import index, then extract+resolve every file's
+        // imports and build the graph through the same shared functions
+        // `graph` uses. Sharing this whole pipeline (not just the resolver)
+        // is what guarantees the two analyzers can never disagree on edges
+        // or cycles for the same input (issue #479).
+        let file_index = ImportIndex::new(&file_paths, ctx.root);
+        let file_imports = extract_resolved_imports(&file_paths, ctx, &file_index, false);
+        let (graph, node_indices) = build_dependency_graph(&file_imports, false);
 
         // Calculate component metrics
         let mut components: Vec<ComponentMetrics> = Vec::new();
@@ -320,36 +239,10 @@ impl Analyzer {
             };
 
             for import in imports {
-                // Find the target component using indexed lookups
-                // (mirrors the edge-building logic above)
-                let to_cm = if let Some(cm) = component_map.get(import) {
-                    *cm
-                } else {
-                    let import_stem = std::path::Path::new(import)
-                        .file_stem()
-                        .map(|s| s.to_string_lossy().to_string())
-                        .unwrap_or_else(|| import.clone());
-
-                    let found_key =
-                        by_stem
-                            .get(&import_stem)
-                            .and_then(|v| v.first())
-                            .or_else(|| {
-                                import
-                                    .split('/')
-                                    .next_back()
-                                    .and_then(|seg| by_stem.get(seg))
-                                    .and_then(|v| v.first())
-                            });
-
-                    if let Some(key) = found_key {
-                        match component_map.get(key) {
-                            Some(cm) => *cm,
-                            None => continue,
-                        }
-                    } else {
-                        continue;
-                    }
+                // Imports are already resolved to on-disk paths (Phase 2).
+                let to_cm = match component_map.get(import) {
+                    Some(cm) => *cm,
+                    None => continue,
                 };
 
                 let is_from_stable = from_cm.instability < self.config.thresholds.stable_threshold;
@@ -849,6 +742,156 @@ mod tests {
             }
         }
         assert!(found_cycle, "Multi-node cycle should be detected");
+    }
+
+    /// Write files (relative path -> content) into a fresh temp dir and run
+    /// the smells analyzer over it from the filesystem.
+    fn analyze_fixture(files: &[(&str, &str)]) -> Analysis {
+        use crate::config::Config;
+        use crate::core::{AnalysisContext, FileSet};
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        for (rel_path, content) in files {
+            let full_path = temp_dir.path().join(rel_path);
+            std::fs::create_dir_all(full_path.parent().unwrap()).unwrap();
+            std::fs::write(full_path, content).unwrap();
+        }
+
+        let config = Config::default();
+        let file_set = FileSet::from_path(temp_dir.path(), &config).unwrap();
+        let ctx = AnalysisContext::new(&file_set, &config, Some(temp_dir.path()));
+        Analyzer::new().analyze_repo(&ctx).unwrap()
+    }
+
+    #[test]
+    fn test_no_phantom_self_cycle_on_same_named_ts_files() {
+        // Issue #479: `packages/brain/src/types.ts` imports a DIFFERENT file
+        // (`packages/mcp/src/types.ts`) that happens to share the same file
+        // stem. The old global-stem `.first()` matching in smells.rs could
+        // fabricate a self-edge instead of resolving the relative ESM
+        // specifier to the actual file it points at.
+        let analysis = analyze_fixture(&[
+            (
+                "packages/brain/src/types.ts",
+                "import type { M } from '../../mcp/src/types.js';\nexport type B = M;\n",
+            ),
+            ("packages/mcp/src/types.ts", "export type M = number;\n"),
+        ]);
+
+        assert_eq!(
+            analysis.summary.cyclic_count,
+            0,
+            "no cyclic dependency should be reported, found: {:?}",
+            analysis
+                .smells
+                .iter()
+                .filter(|s| s.smell_type == SmellType::CyclicDependency)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_no_phantom_cycle_in_ts_monorepo_with_barrels() {
+        // A small TS "monorepo" with several `index.ts` barrels and `.js`
+        // ESM-style relative imports, but NO real import cycle. Global-stem
+        // matching can wire barrels to the wrong same-named file and
+        // fabricate cycles that do not exist in the real import graph.
+        let analysis = analyze_fixture(&[
+            ("pkg-a/src/index.ts", "export * from './widget.js';\n"),
+            ("pkg-a/src/widget.ts", "export const widget = 1;\n"),
+            (
+                "pkg-b/src/index.ts",
+                "import { widget } from '../../pkg-a/src/index.js';\nexport const used = widget;\n",
+            ),
+            ("pkg-c/src/index.ts", "export const c = 1;\n"),
+        ]);
+
+        assert_eq!(
+            analysis.summary.cyclic_count,
+            0,
+            "no cyclic dependency should be reported in an acyclic monorepo, found: {:?}",
+            analysis
+                .smells
+                .iter()
+                .filter(|s| s.smell_type == SmellType::CyclicDependency)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_real_ts_cycle_is_still_detected() {
+        // Do not over-correct: a genuine two-file cycle must still be caught.
+        let analysis = analyze_fixture(&[
+            ("a.ts", "import { b } from './b.js';\nexport const a = b;\n"),
+            ("b.ts", "import { a } from './a.js';\nexport const b = a;\n"),
+        ]);
+
+        assert_eq!(
+            analysis.summary.cyclic_count, 1,
+            "the real a.ts <-> b.ts cycle must still be reported"
+        );
+        let cyclic = analysis
+            .smells
+            .iter()
+            .find(|s| s.smell_type == SmellType::CyclicDependency)
+            .expect("expected a cyclic dependency smell");
+        assert_eq!(cyclic.metrics.cycle_length, Some(2));
+    }
+
+    #[test]
+    fn test_self_import_is_not_a_cyclic_smell() {
+        // A file importing itself (`import "./a.js"` inside a.ts) is not a
+        // real cyclic dependency between two components. `graph` has always
+        // rejected self-edges when building its graph; `smells` must apply
+        // the same rule so the two analyzers cannot disagree (issue #479).
+        let analysis = analyze_fixture(&[(
+            "a.ts",
+            "import { helper } from './a.js';\nexport function helper() {}\n",
+        )]);
+
+        assert_eq!(
+            analysis.summary.cyclic_count,
+            0,
+            "a file importing itself is not a cyclic-dependency smell, found: {:?}",
+            analysis
+                .smells
+                .iter()
+                .filter(|s| s.smell_type == SmellType::CyclicDependency)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_repeated_import_produces_single_edge_not_parallel_edges() {
+        // Importing the same target twice (e.g. two named imports resolving
+        // to the same file) must not inflate fan_in/fan_out with duplicate
+        // parallel edges -- `graph` already dedups, `smells` must match.
+        let analysis = analyze_fixture(&[
+            (
+                "a.ts",
+                "import { x } from './b.js';\nimport { y } from './b.js';\n",
+            ),
+            ("b.ts", "export const x = 1;\nexport const y = 2;\n"),
+        ]);
+
+        let a = analysis
+            .components
+            .iter()
+            .find(|c| c.id == "a.ts")
+            .expect("a.ts component");
+        let b = analysis
+            .components
+            .iter()
+            .find(|c| c.id == "b.ts")
+            .expect("b.ts component");
+        assert_eq!(
+            a.fan_out, 1,
+            "repeated import must not create a parallel edge"
+        );
+        assert_eq!(
+            b.fan_in, 1,
+            "repeated import must not create a parallel edge"
+        );
     }
 
     #[test]

--- a/src/analyzers/smells.rs
+++ b/src/analyzers/smells.rs
@@ -238,7 +238,15 @@ impl Analyzer {
                 None => continue,
             };
 
-            for import in imports {
+            // `build_dependency_graph` collapses a repeated import into a
+            // single edge; this loop must be driven off that same edge set,
+            // or importing the same target twice pushes two identical
+            // UnstableDependency smells for one real edge.
+            let mut unique_imports: Vec<&String> = imports.iter().collect();
+            unique_imports.sort();
+            unique_imports.dedup();
+
+            for import in unique_imports {
                 // Imports are already resolved to on-disk paths (Phase 2).
                 let to_cm = match component_map.get(import) {
                     Some(cm) => *cm,
@@ -891,6 +899,53 @@ mod tests {
         assert_eq!(
             b.fan_in, 1,
             "repeated import must not create a parallel edge"
+        );
+    }
+
+    #[test]
+    fn test_repeated_import_produces_single_unstable_dependency_smell() {
+        // The unstable-dependency smell loop iterated the raw (possibly
+        // duplicated) resolved-imports list instead of the deduped graph
+        // edges, so a file importing the same unstable target twice could
+        // push two identical `UnstableDependency` smells even though
+        // `build_dependency_graph` collapses them to a single edge.
+        let analysis = analyze_fixture(&[
+            // stable.ts: fan_in=4 (d1..d4), fan_out=1 (deduped edge to
+            // unstable.ts, despite two duplicate import statements) ->
+            // instability = 1/5 = 0.2 (stable).
+            (
+                "stable.ts",
+                "import { x } from './unstable.js';\nimport { y } from './unstable.js';\n",
+            ),
+            // unstable.ts: fan_in=1, fan_out=4 -> instability = 4/5 = 0.8
+            // (unstable). diff vs stable.ts = 0.6, over the 0.4 threshold.
+            (
+                "unstable.ts",
+                "import './u1.js';\nimport './u2.js';\nimport './u3.js';\nimport './u4.js';\nexport const x = 1;\nexport const y = 2;\n",
+            ),
+            ("u1.ts", "export const u1 = 1;\n"),
+            ("u2.ts", "export const u2 = 1;\n"),
+            ("u3.ts", "export const u3 = 1;\n"),
+            ("u4.ts", "export const u4 = 1;\n"),
+            ("d1.ts", "import './stable.js';\n"),
+            ("d2.ts", "import './stable.js';\n"),
+            ("d3.ts", "import './stable.js';\n"),
+            ("d4.ts", "import './stable.js';\n"),
+        ]);
+
+        let unstable_smells: Vec<_> = analysis
+            .smells
+            .iter()
+            .filter(|s| {
+                s.smell_type == SmellType::UnstableDependency
+                    && s.components == vec!["stable.ts".to_string(), "unstable.ts".to_string()]
+            })
+            .collect();
+        assert_eq!(
+            unstable_smells.len(),
+            1,
+            "a repeated import must produce a single UnstableDependency smell, found: {:?}",
+            unstable_smells
         );
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1267,8 +1267,17 @@ fn extract_rust_import(node: &tree_sitter::Node<'_>, source: &[u8]) -> Vec<Impor
                 }
                 return out;
             }
+            "use_wildcard" => {
+                // `use crate::foo::*;` -- the dependency is on the module
+                // `crate::foo`, not the literal `crate::foo::*` text (which
+                // breaks segment matching in the resolver).
+                let Some(path) = rust_use_wildcard_path(&child, source) else {
+                    return Vec::new();
+                };
+                return vec![ImportNode::new_use(path, line)];
+            }
             _ => {
-                // scoped_identifier, identifier, use_as_clause, use_wildcard
+                // scoped_identifier, identifier, use_as_clause
                 let Ok(text) = child.utf8_text(source) else {
                     return Vec::new();
                 };
@@ -1287,6 +1296,17 @@ fn extract_rust_import(node: &tree_sitter::Node<'_>, source: &[u8]) -> Vec<Impor
         }
     }
     Vec::new()
+}
+
+/// Extract the path a Rust `use_wildcard` node covers (the part before
+/// `::*`), e.g. `crate::foo::*` -> `crate::foo`, `bar::*` -> `bar`. The path
+/// is the wildcard node's one named child (an `identifier` or
+/// `scoped_identifier`); tree-sitter-rust exposes it positionally rather
+/// than through a named field.
+fn rust_use_wildcard_path(node: &tree_sitter::Node<'_>, source: &[u8]) -> Option<String> {
+    node.named_child(0)
+        .and_then(|p| p.utf8_text(source).ok())
+        .map(|s| s.to_string())
 }
 
 /// Recursively expand a Rust `use_list` (the `{a, b, c::{d}}` part of a
@@ -1315,9 +1335,15 @@ fn collect_rust_use_list(
             "self" if !base_path.is_empty() => {
                 out.push(ImportNode::new_use(base_path.to_string(), line));
             }
-            // `use foo::*` inside a group -- the dependency is on the module.
+            // `use foo::{bar::*}` -- the wildcard's own inner path (`bar`)
+            // must be joined onto the group's base path: the dependency is
+            // on `foo::bar`, not bare `foo`. A bare `use foo::{*}` (no inner
+            // path) falls back to the group's base path itself.
             "use_wildcard" if !base_path.is_empty() => {
-                out.push(ImportNode::new_use(base_path.to_string(), line));
+                let path = rust_use_wildcard_path(&item, source)
+                    .map(|inner| join(&inner))
+                    .unwrap_or_else(|| base_path.to_string());
+                out.push(ImportNode::new_use(path, line));
             }
             "scoped_use_list" => {
                 let sub_base = item
@@ -1833,6 +1859,40 @@ mod tests {
                 "crate::analyzers::defect::b",
             ]
         );
+    }
+
+    #[test]
+    fn test_extract_rust_top_level_wildcard_strips_star() {
+        // `use crate::foo::*;` at the top level (not inside a `{}` group)
+        // must resolve to the base module `crate::foo`, not the raw
+        // `crate::foo::*` text -- the trailing `::*` breaks segment matching
+        // in the resolver and silently drops the edge.
+        let parser = Parser::new();
+        let content = b"use crate::foo::*;\n\nfn main() {}";
+        let result = parser
+            .parse(content, Language::Rust, Path::new("main.rs"))
+            .unwrap();
+
+        let imports = extract_imports(&result);
+        assert_eq!(imports.len(), 1);
+        assert_eq!(imports[0].path, "crate::foo");
+        assert_eq!(imports[0].kind, ImportKind::Use);
+    }
+
+    #[test]
+    fn test_extract_rust_grouped_wildcard_keeps_inner_path() {
+        // `use foo::{bar::*}` -- the wildcard's own inner path (`bar`) must
+        // be joined onto the group's base path (`foo`), not dropped: the
+        // real dependency is on `foo::bar`, not bare `foo`.
+        let parser = Parser::new();
+        let content = b"use foo::{bar::*};\n\nfn main() {}";
+        let result = parser
+            .parse(content, Language::Rust, Path::new("main.rs"))
+            .unwrap();
+
+        let imports = extract_imports(&result);
+        assert_eq!(imports.len(), 1);
+        assert_eq!(imports[0].path, "foo::bar");
     }
 
     #[test]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -907,6 +907,15 @@ fn extract_cpp_field_name(
     }
 }
 
+/// Distinguishes a genuine dependency import from a module containment
+/// declaration (Rust `mod foo;`), which declares that `foo` is part of this
+/// module tree but is not itself a dependency edge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImportKind {
+    Use,
+    ModDeclaration,
+}
+
 /// An import statement.
 #[derive(Debug, Clone)]
 pub struct ImportNode {
@@ -916,6 +925,28 @@ pub struct ImportNode {
     pub line: u32,
     /// Imported names (if any).
     pub names: Vec<String>,
+    /// Whether this is a real dependency import or a containment declaration.
+    pub kind: ImportKind,
+}
+
+impl ImportNode {
+    fn new_use(path: String, line: u32) -> Self {
+        Self {
+            path,
+            line,
+            names: Vec::new(),
+            kind: ImportKind::Use,
+        }
+    }
+
+    fn new_mod_declaration(path: String, line: u32) -> Self {
+        Self {
+            path,
+            line,
+            names: Vec::new(),
+            kind: ImportKind::ModDeclaration,
+        }
+    }
 }
 
 /// Extract functions from a parse result.
@@ -972,9 +1003,7 @@ pub fn extract_imports(result: &ParseResult) -> Vec<ImportNode> {
                 }
             }
             Language::Rust if node.kind() == "use_declaration" => {
-                if let Some(import) = extract_rust_import(&node, source) {
-                    imports.push(import);
-                }
+                imports.extend(extract_rust_import(&node, source));
             }
             Language::Rust if node.kind() == "mod_item" => {
                 if let Some(import) = extract_rust_mod(&node, source) {
@@ -988,8 +1017,14 @@ pub fn extract_imports(result: &ParseResult) -> Vec<ImportNode> {
                     imports.push(import);
                 }
             }
+            // `export_statement` also covers `export * from '...'` and
+            // `export { x } from '...'` re-exports (barrel files) -- these
+            // are real dependency edges, not just `import_statement`.
+            // `extract_js_import` naturally filters out plain
+            // `export function foo() {}`/`export const x = 1`, which have
+            // no `source` field.
             Language::TypeScript | Language::JavaScript | Language::Tsx | Language::Jsx
-                if node.kind() == "import_statement" =>
+                if node.kind() == "import_statement" || node.kind() == "export_statement" =>
             {
                 if let Some(import) = extract_js_import(&node, source) {
                     imports.push(import);
@@ -1200,54 +1235,120 @@ fn extract_go_import(node: &tree_sitter::Node<'_>, source: &[u8]) -> Option<Impo
             .map(|s| s.trim_matches('"').to_string())
     })?;
 
-    Some(ImportNode {
+    Some(ImportNode::new_use(
         path,
-        line: node.start_position().row as u32 + 1,
-        names: Vec::new(),
-    })
+        node.start_position().row as u32 + 1,
+    ))
 }
 
-fn extract_rust_import(node: &tree_sitter::Node<'_>, source: &[u8]) -> Option<ImportNode> {
-    // use_declaration children: optional visibility_modifier, then the use argument
-    // The argument can be: scoped_identifier, use_as_clause, scoped_use_list, use_wildcard, identifier
+/// Extract one `ImportNode` per dependency named by a Rust `use` declaration.
+///
+/// A grouped import like `use crate::parent::{a, b};` names two distinct
+/// dependencies (`crate::parent::a` and `crate::parent::b`), not one
+/// dependency on `crate::parent` itself -- so each leaf of the group (including
+/// nested groups) is expanded into its own `ImportNode` joined onto the
+/// group's base path. Resolving grouped imports to the base path instead of
+/// their leaves is what caused false dependency cycles through parent modules
+/// (issue #479).
+fn extract_rust_import(node: &tree_sitter::Node<'_>, source: &[u8]) -> Vec<ImportNode> {
+    let line = node.start_position().row as u32 + 1;
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         match child.kind() {
             "use" | "visibility_modifier" | ";" => continue,
             "scoped_use_list" => {
-                // e.g., use std::collections::{HashMap, HashSet}
-                // Extract just the base path (the part before the {})
-                if let Some(path_node) = child.child_by_field_name("path") {
-                    let path = path_node.utf8_text(source).ok()?.to_string();
-                    return Some(ImportNode {
-                        path,
-                        line: node.start_position().row as u32 + 1,
-                        names: Vec::new(),
-                    });
+                let base = child
+                    .child_by_field_name("path")
+                    .and_then(|p| p.utf8_text(source).ok())
+                    .unwrap_or("");
+                let mut out = Vec::new();
+                if let Some(list) = child.child_by_field_name("list") {
+                    collect_rust_use_list(&list, base, source, line, &mut out);
                 }
+                return out;
             }
             _ => {
                 // scoped_identifier, identifier, use_as_clause, use_wildcard
-                let text = child.utf8_text(source).ok()?.to_string();
+                let Ok(text) = child.utf8_text(source) else {
+                    return Vec::new();
+                };
                 // For use_as_clause like "crate::foo as bar", take the path part
                 let path = if child.kind() == "use_as_clause" {
-                    if let Some(path_node) = child.child_by_field_name("path") {
-                        path_node.utf8_text(source).ok()?.to_string()
-                    } else {
-                        text
-                    }
+                    child
+                        .child_by_field_name("path")
+                        .and_then(|p| p.utf8_text(source).ok())
+                        .unwrap_or(text)
+                        .to_string()
                 } else {
-                    text
+                    text.to_string()
                 };
-                return Some(ImportNode {
-                    path,
-                    line: node.start_position().row as u32 + 1,
-                    names: Vec::new(),
-                });
+                return vec![ImportNode::new_use(path, line)];
             }
         }
     }
-    None
+    Vec::new()
+}
+
+/// Recursively expand a Rust `use_list` (the `{a, b, c::{d}}` part of a
+/// grouped import) into one leaf `ImportNode` per item, joined onto
+/// `base_path`.
+fn collect_rust_use_list(
+    list: &tree_sitter::Node<'_>,
+    base_path: &str,
+    source: &[u8],
+    line: u32,
+    out: &mut Vec<ImportNode>,
+) {
+    let join = |segment: &str| -> String {
+        if base_path.is_empty() {
+            segment.to_string()
+        } else {
+            format!("{base_path}::{segment}")
+        }
+    };
+
+    let mut cursor = list.walk();
+    for item in list.children(&mut cursor) {
+        match item.kind() {
+            "{" | "}" | "," => continue,
+            // `use foo::{self, bar}` -- `self` names the module itself.
+            "self" if !base_path.is_empty() => {
+                out.push(ImportNode::new_use(base_path.to_string(), line));
+            }
+            // `use foo::*` inside a group -- the dependency is on the module.
+            "use_wildcard" if !base_path.is_empty() => {
+                out.push(ImportNode::new_use(base_path.to_string(), line));
+            }
+            "scoped_use_list" => {
+                let sub_base = item
+                    .child_by_field_name("path")
+                    .and_then(|p| p.utf8_text(source).ok())
+                    .map(join)
+                    .unwrap_or_else(|| base_path.to_string());
+                if let Some(sub_list) = item.child_by_field_name("list") {
+                    collect_rust_use_list(&sub_list, &sub_base, source, line, out);
+                }
+            }
+            // Bare nested group with no path segment, e.g. use foo::{{a, b}}
+            "use_list" => {
+                collect_rust_use_list(&item, base_path, source, line, out);
+            }
+            "use_as_clause" => {
+                if let Some(path_text) = item
+                    .child_by_field_name("path")
+                    .and_then(|p| p.utf8_text(source).ok())
+                {
+                    out.push(ImportNode::new_use(join(path_text), line));
+                }
+            }
+            _ => {
+                // identifier / scoped_identifier leaf
+                if let Ok(text) = item.utf8_text(source) {
+                    out.push(ImportNode::new_use(join(text), line));
+                }
+            }
+        }
+    }
 }
 
 fn extract_rust_mod(node: &tree_sitter::Node<'_>, source: &[u8]) -> Option<ImportNode> {
@@ -1271,38 +1372,34 @@ fn extract_rust_mod(node: &tree_sitter::Node<'_>, source: &[u8]) -> Option<Impor
         return None;
     }
     let name = name?;
-    Some(ImportNode {
-        path: name,
-        line: node.start_position().row as u32 + 1,
-        names: Vec::new(),
-    })
+    Some(ImportNode::new_mod_declaration(
+        name,
+        node.start_position().row as u32 + 1,
+    ))
 }
 
 fn extract_python_import(node: &tree_sitter::Node<'_>, source: &[u8]) -> Option<ImportNode> {
     let path = node.utf8_text(source).ok()?.to_string();
-    Some(ImportNode {
+    Some(ImportNode::new_use(
         path,
-        line: node.start_position().row as u32 + 1,
-        names: Vec::new(),
-    })
+        node.start_position().row as u32 + 1,
+    ))
 }
 
 fn extract_js_import(node: &tree_sitter::Node<'_>, source: &[u8]) -> Option<ImportNode> {
     let path = find_child_by_field(node, "source", source)?;
-    Some(ImportNode {
-        path: path.trim_matches(|c| c == '"' || c == '\'').to_string(),
-        line: node.start_position().row as u32 + 1,
-        names: Vec::new(),
-    })
+    Some(ImportNode::new_use(
+        path.trim_matches(|c| c == '"' || c == '\'').to_string(),
+        node.start_position().row as u32 + 1,
+    ))
 }
 
 fn extract_java_import(node: &tree_sitter::Node<'_>, source: &[u8]) -> Option<ImportNode> {
     let path = node.utf8_text(source).ok()?.to_string();
-    Some(ImportNode {
+    Some(ImportNode::new_use(
         path,
-        line: node.start_position().row as u32 + 1,
-        names: Vec::new(),
-    })
+        node.start_position().row as u32 + 1,
+    ))
 }
 
 fn extract_ruby_import(node: &tree_sitter::Node<'_>, source: &[u8]) -> Option<ImportNode> {
@@ -1315,29 +1412,17 @@ fn extract_ruby_import(node: &tree_sitter::Node<'_>, source: &[u8]) -> Option<Im
         "require" | "require_relative" => {
             let string_node = find_node_child(&args, "string")?;
             let content = find_named_child(&string_node, "string_content", source)?;
-            Some(ImportNode {
-                path: content,
-                line,
-                names: Vec::new(),
-            })
+            Some(ImportNode::new_use(content, line))
         }
         "include" | "extend" | "prepend" => {
             let path = find_named_child(&args, "constant", source)
                 .or_else(|| find_named_child(&args, "scope_resolution", source))?;
-            Some(ImportNode {
-                path,
-                line,
-                names: Vec::new(),
-            })
+            Some(ImportNode::new_use(path, line))
         }
         "autoload" => {
             let string_node = find_node_child(&args, "string")?;
             let content = find_named_child(&string_node, "string_content", source)?;
-            Some(ImportNode {
-                path: content,
-                line,
-                names: Vec::new(),
-            })
+            Some(ImportNode::new_use(content, line))
         }
         _ => None,
     }
@@ -1347,11 +1432,10 @@ fn extract_ruby_superclass(node: &tree_sitter::Node<'_>, source: &[u8]) -> Optio
     let superclass = find_node_child(node, "superclass")?;
     let path = find_named_child(&superclass, "constant", source)
         .or_else(|| find_named_child(&superclass, "scope_resolution", source))?;
-    Some(ImportNode {
+    Some(ImportNode::new_use(
         path,
-        line: node.start_position().row as u32 + 1,
-        names: Vec::new(),
-    })
+        node.start_position().row as u32 + 1,
+    ))
 }
 
 /// Find byte ranges of Rust `#[cfg(test)]` modules using tree-sitter.
@@ -1711,6 +1795,11 @@ mod tests {
 
     #[test]
     fn test_extract_rust_use_group() {
+        // Regression for issue #479 / Bug 2: a grouped import names a distinct
+        // dependency per item. Collapsing to the shared base path (the old
+        // behavior) makes every item in the group resolve to the *parent*
+        // module instead of the item actually being used, which is what
+        // fabricated cycles through sibling modules.
         let parser = Parser::new();
         let content = b"use std::collections::{HashMap, HashSet};\n\nfn main() {}";
         let result = parser
@@ -1718,9 +1807,32 @@ mod tests {
             .unwrap();
 
         let imports = extract_imports(&result);
-        assert_eq!(imports.len(), 1);
-        // Group imports should extract the base path
-        assert_eq!(imports[0].path, "std::collections");
+        assert_eq!(imports.len(), 2);
+        assert_eq!(imports[0].path, "std::collections::HashMap");
+        assert_eq!(imports[1].path, "std::collections::HashSet");
+        assert!(imports.iter().all(|i| i.kind == ImportKind::Use));
+    }
+
+    #[test]
+    fn test_extract_rust_use_group_nested() {
+        // Nested groups, e.g. `use crate::analyzers::{tdg, defect::{a, b}};`
+        // must expand every leaf onto its full path, not just the outer base.
+        let parser = Parser::new();
+        let content = b"use crate::analyzers::{tdg, defect::{a, b}};\n\nfn main() {}";
+        let result = parser
+            .parse(content, Language::Rust, Path::new("main.rs"))
+            .unwrap();
+
+        let imports = extract_imports(&result);
+        let paths: Vec<&str> = imports.iter().map(|i| i.path.as_str()).collect();
+        assert_eq!(
+            paths,
+            vec![
+                "crate::analyzers::tdg",
+                "crate::analyzers::defect::a",
+                "crate::analyzers::defect::b",
+            ]
+        );
     }
 
     #[test]
@@ -1736,6 +1848,21 @@ mod tests {
         assert_eq!(imports[0].path, "config");
         assert_eq!(imports[1].path, "utils");
         assert_eq!(imports[2].path, "helpers");
+        // Mod declarations are containment, not a dependency edge.
+        assert!(imports.iter().all(|i| i.kind == ImportKind::ModDeclaration));
+    }
+
+    #[test]
+    fn test_extract_rust_use_declarations_are_kind_use() {
+        let parser = Parser::new();
+        let content = b"use crate::config::Config;\n\nfn main() {}";
+        let result = parser
+            .parse(content, Language::Rust, Path::new("main.rs"))
+            .unwrap();
+
+        let imports = extract_imports(&result);
+        assert_eq!(imports.len(), 1);
+        assert_eq!(imports[0].kind, ImportKind::Use);
     }
 
     #[test]
@@ -1760,6 +1887,23 @@ mod tests {
 
         let imports = extract_imports(&result);
         assert!(!imports.is_empty());
+    }
+
+    #[test]
+    fn test_extract_js_re_exports() {
+        // Barrel files re-export via `export * from` / `export {..} from`,
+        // which are real dependency edges (this is exactly the monorepo
+        // barrel pattern from issue #479) but were not previously extracted.
+        let parser = Parser::new();
+        let content = b"export * from './widget';\nexport { widget as w } from './widget';\nexport function local() {}\n";
+        let result = parser
+            .parse(content, Language::TypeScript, Path::new("index.ts"))
+            .unwrap();
+
+        let imports = extract_imports(&result);
+        let paths: Vec<&str> = imports.iter().map(|i| i.path.as_str()).collect();
+        assert_eq!(paths, vec!["./widget", "./widget"]);
+        assert!(imports.iter().all(|i| i.kind == ImportKind::Use));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes [#479](https://github.com/panbanda/omen/issues/479): `omen smells` reported phantom `CyclicDependency` findings (a length-1 self-cycle on a file with no self-import, and large false cycles) that `omen graph`'s own edge list contradicted.

**Root cause:** the smells analyzer built its dependency graph with global file-stem `.first()` matching. TypeScript ESM specifiers (`import { M } from '../../mcp/src/types.js'`) never exact-match the real `.ts` file, so every import fell back to picking an arbitrary same-stem file anywhere in the repo — frequently the importing file itself → phantom self-cycle. `graph` used a proper relative resolver, which is why the two disagreed.

**Fix (architectural — one shared graph pipeline):**
- Extract `extract_resolved_imports` + `build_dependency_graph` into a new `import_resolver.rs`, used by **both** `graph` and `smells`, so they produce identical edges (self-loops rejected, parallel edges deduped) and can never diverge again.
- Relative (`./`,`../`) specifiers resolve strictly against the importer's directory with real TS/ESM extension handling (`.js`→`.ts`/`.tsx`, `.mjs`→`.mts`, `.cjs`→`.cts`, `index.*` barrels, `export ... from` re-exports); no global-stem fallback; specifiers that escape above the analyzed root don't resolve.
- Rust: grouped `use crate::a::{b,c}` expands per-item and falls back to the parent module file when the item lives in `a.rs` (not a submodule); `mod X;` declarations no longer count as dependency edges.
- Deterministic non-relative candidate selection (sorted), removing HashMap-iteration nondeterminism.

## Impact (measured on omen itself)

| | before | after |
|---|---|---|
| `graph` cycle_count | 2 (both phantom) | 0 |
| `smells` cyclic findings | disagreed with graph | agrees with graph |
| coupling score | 49.9 | 71.1 |

Real TS (`a.ts ↔ b.ts`) and Rust (`a.rs ↔ c.rs` via item import) cycles are still detected.

## Quality

Two review cycles: the first cut fixed the phantom cycles but introduced a regression that *hid* real Rust cycles (grouped-item imports resolving to nothing) and left graph/smells still diverging on self-edges — both caught in review and fixed. Strict TDD (failing repro test first) across parser, resolver, graph, and smells. `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (2076 lib + 89 integration + property/doc) all pass. Verified no non-TS-language regression against `origin/main`.

Closes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved dependency and import analysis across Rust, JavaScript, TypeScript, and Ruby projects.
  - More accurately detects genuine circular dependencies while preventing false positives and duplicate relationships.
  - Improved support for grouped and nested Rust imports, Rust modules, TypeScript path aliases, index files, and JavaScript/TypeScript re-exports.
  - Dependency and code-smell results now use consistent import relationships for more reliable findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->