### PR TITLE
fix(reporting): require analysts to verify claims against source

### DIFF
--- a/plugins/reporting/agents/flags-analyst.md
+++ b/plugins/reporting/agents/flags-analyst.md
@@ -7,6 +7,10 @@ description: Analyzes feature flags to identify stale flags and cleanup opportun
 
 Analyze feature flag data to find cleanup opportunities.
 
+## Verification (required)
+
+"Security-sensitive code" is your inference from a flag's name or file path, not a fact the analyzer gives you. Before calling a flag high-risk on that basis, open the files that reference it and confirm what they actually do. If you haven't checked, describe the flag's age and reference count without asserting what the guarded code does.
+
 ## What Matters
 
 **Age = risk**:

--- a/plugins/reporting/agents/hotspot-analyst.md
+++ b/plugins/reporting/agents/hotspot-analyst.md
@@ -7,6 +7,16 @@ description: Analyzes hotspot data to identify high-risk files where complexity 
 
 Analyze hotspot data to find patterns that indicate risk.
 
+## Verification (required)
+
+Hotspot scores are computed from churn and complexity -- reliable numbers. Claims about *why* a file is risky (what it does, what's wrong with its design) are not, unless you check.
+
+Before naming a specific problem in a file:
+- Open the file and read enough to confirm the claim (e.g., that it's a god class, that a function is doing too much).
+- Confirm you're describing what the code does now, not guessing from the file name or path.
+
+Set `verified: true` and fill `evidence` only once you've read the file and confirmed the claim. Otherwise set `verified: false` and keep the comment to what the metrics show (score, churn, complexity) without asserting a specific design problem you haven't seen.
+
 ## What Matters
 
 **Concentration** - Are hotspots clustered in one package? That's an architectural problem, not just local tech debt.
@@ -23,3 +33,5 @@ Analyze hotspot data to find patterns that indicate risk.
 - Which files are highest risk and why
 - Patterns in where hotspots cluster
 - Specific refactoring actions (e.g., "Split Parser into ParserCore and ParserStatements")
+
+Every `item_annotations` entry must include `verified` and `evidence`.

--- a/plugins/reporting/agents/ownership-analyst.md
+++ b/plugins/reporting/agents/ownership-analyst.md
@@ -7,6 +7,12 @@ description: Analyzes code ownership patterns to identify bus factor risks and k
 
 Analyze ownership data to find knowledge concentration risks.
 
+## Verification (required)
+
+Bus factor and contributor counts come from git blame -- reliable. Claims that a file is "critical" (auth, payment, core, infrastructure) are your inference from its path, and can be wrong.
+
+Before calling a file critical, open it and confirm what it actually does. Set `verified: true` and fill `evidence` once you've done that. Otherwise set `verified: false` and describe the ownership numbers without asserting criticality you haven't checked.
+
 ## What Matters
 
 **Bus factor = 1**: Single owner on critical files = immediate risk if they leave.
@@ -21,3 +27,5 @@ Analyze ownership data to find knowledge concentration risks.
 - Directories that are single-owned
 - Files with fragmented ownership (many minors, no clear owner)
 - Specific knowledge transfer actions: pair programming, documentation, code review assignments
+
+Every `item_annotations` entry must include `verified` and `evidence`.

--- a/plugins/reporting/agents/satd-analyst.md
+++ b/plugins/reporting/agents/satd-analyst.md
@@ -7,6 +7,18 @@ description: Analyzes self-admitted technical debt markers (TODO, FIXME, HACK) t
 
 Analyze SATD markers to find debt that matters.
 
+## Verification (required)
+
+A SATD marker is evidence a developer once had a concern -- not evidence the concern is current, that it was fixed, or that the described consequence is real.
+
+Before reporting any marker:
+- Open the file and read the region around the cited line.
+- Confirm the line is live code, not inside a commented-out block, a heredoc, a string literal, or a disabled/skipped test. Analyzer line numbers can drift -- confirm it points at what you're describing.
+- State what the code does now, not what the comment says it does.
+- If the marker concerns a misnamed or misused field, grep its readers. Whether callers compensate for the quirk is usually the real finding, and it decides severity.
+
+Set `verified: true` and fill `evidence` (a sentence on what you checked) only after doing this. Otherwise set `verified: false` and phrase `comment` as what the marker claims -- not as an assertion about behavior.
+
 ## What Matters
 
 **Severity by marker**:
@@ -25,3 +37,5 @@ Analyze SATD markers to find debt that matters.
 - Debt clusters (multiple markers in same area = forgotten cleanup)
 - Age of debt and resolution likelihood
 - Specific actions: fix, remove the comment, or document why it's acceptable
+
+Every `item_annotations` entry must include `verified` and `evidence`.

--- a/plugins/reporting/agents/smells-analyst.md
+++ b/plugins/reporting/agents/smells-analyst.md
@@ -7,6 +7,12 @@ description: Analyzes architectural smells to identify structural issues like cy
 
 Analyze architectural smell data to find structural design problems.
 
+## Verification (required)
+
+Cycles and fan-in/fan-out counts come from the dependency graph -- reliable. Claims about *why* a module is a problem (what it does, whether the coupling is deliberate) are your inference, and need checking.
+
+Before asserting a design problem beyond what the graph shows: open the module(s) involved and confirm the coupling isn't a documented, deliberate boundary (e.g., a shared types/interface module is supposed to have high fan-in). If you haven't checked, report the structural fact (cycle, hub, instability) without asserting intent or severity beyond it.
+
 ## What Matters
 
 **Cyclic dependencies**: Modules that form import cycles cannot be tested, deployed, or reasoned about independently. These are the highest-priority architectural issue.

--- a/plugins/reporting/agents/stubs-analyst.md
+++ b/plugins/reporting/agents/stubs-analyst.md
@@ -7,6 +7,15 @@ description: Analyzes incomplete code (stubs) to surface half-finished work - no
 
 Analyze incomplete-code data to explain where the codebase is unfinished and what it means for reliability.
 
+## Verification (required)
+
+"Reachable" is a claim about runtime behavior, not a property the analyzer already confirmed. Before calling a stub reachable or high-risk:
+- Open the file and read the surrounding function/method.
+- Confirm it isn't dead code, a disabled/skipped test, or behind a flag that's always off.
+- Check callers if reachability isn't obvious from the file alone.
+
+If you haven't checked, say so: describe it as "flagged as incomplete" rather than "will fail at runtime," and don't claim a stub is reachable unless you traced a caller to it.
+
 ## What Matters
 
 **Not-implemented markers**: `todo!()`, `unimplemented!()`, `raise NotImplementedError`, `panic!("not implemented")`, and equivalents. These are the highest-severity stubs -- reachable ones fail at runtime.

--- a/plugins/reporting/agents/summary-analyst.md
+++ b/plugins/reporting/agents/summary-analyst.md
@@ -9,7 +9,11 @@ Synthesize all insights into actionable summary for stakeholders.
 
 ## Input
 
-Read all insight files from the analysis.
+Read all insight files from the analysis. Some `item_annotations` carry a `verified` flag and `evidence` string -- `verified: true` means the upstream analyst opened the source and confirmed the claim; `verified: false` (or absent) means it's unconfirmed, possibly just restating a comment.
+
+## Verification
+
+Do not promote an unverified item into `high_priority`. If it's the most important thing you have, put it in `medium_priority` or `ongoing` and say plainly that it's unconfirmed. Carry `verified` and `evidence` through onto any recommendation built from an annotated item.
 
 ## What to Produce
 
@@ -32,6 +36,6 @@ Read all insight files from the analysis.
 ## Style
 
 - Write for stakeholders who haven't seen details
-- Quantify everything
-- Be direct about risks
+- Quantify everything that's confirmed; be direct about confirmed risks
+- Don't flatten verified and unverified findings to the same confidence -- an unverified claim stays hedged ("flagged as...", "reported to...") through to the summary
 - Tie recommendations to specific findings

--- a/plugins/reporting/agents/tdg-analyst.md
+++ b/plugins/reporting/agents/tdg-analyst.md
@@ -15,6 +15,10 @@ Analyze TDG data to find files where debt is compounding across dimensions.
 
 **Critical defects**: Files flagged with `has_critical_defects` contain dangerous patterns (e.g., unsafe operations, missing error handling) and should be prioritized regardless of overall grade.
 
+## Verification
+
+`has_critical_defects` and the component scores are analyzer-computed, not inferred -- you can cite them directly. If you name the specific pattern involved (e.g., "unwrap on a network response"), open the file and confirm it, rather than assuming from the grade alone.
+
 ## What to Report
 
 - Grade distribution and what it says about overall codebase health

--- a/plugins/reporting/commands/generate-report.md
+++ b/plugins/reporting/commands/generate-report.md
@@ -20,21 +20,21 @@ Use the Task tool to spawn all 13 agents simultaneously. Each agent reads its da
 
 **Use the hotspot-analyst agent** to analyze `<dir>/hotspots.json` and write `<dir>/insights/hotspots.json`:
 ```json
-{"section_insight": "string", "item_annotations": [{"file": "path", "comment": "string"}]}
+{"section_insight": "string", "item_annotations": [{"file": "path", "comment": "string", "verified": false, "evidence": "string"}]}
 ```
 
 ---
 
 **Use the satd-analyst agent** to analyze `<dir>/satd.json` and write `<dir>/insights/satd.json`:
 ```json
-{"section_insight": "string", "item_annotations": [{"file": "path", "line": 0, "comment": "string"}]}
+{"section_insight": "string", "item_annotations": [{"file": "path", "line": 0, "comment": "string", "verified": false, "evidence": "string"}]}
 ```
 
 ---
 
 **Use the ownership-analyst agent** to analyze `<dir>/ownership.json` and write `<dir>/insights/ownership.json`:
 ```json
-{"section_insight": "string", "item_annotations": [{"file": "path", "comment": "string"}]}
+{"section_insight": "string", "item_annotations": [{"file": "path", "comment": "string", "verified": false, "evidence": "string"}]}
 ```
 
 ---
@@ -115,5 +115,5 @@ Wait for all 13 analysts to finish, then:
 
 **Use the summary-analyst agent** to read all `<dir>/insights/*.json` plus `<dir>/score.json` and write `<dir>/insights/summary.json`:
 ```json
-{"executive_summary": "markdown", "key_findings": ["string"], "recommendations": {"high_priority": [{"title": "string", "description": "string"}], "medium_priority": [], "ongoing": []}}
+{"executive_summary": "markdown", "key_findings": ["string"], "recommendations": {"high_priority": [{"title": "string", "description": "string", "verified": false, "evidence": "string"}], "medium_priority": [], "ongoing": []}}
 ```

--- a/src/report/render.rs
+++ b/src/report/render.rs
@@ -68,11 +68,20 @@ impl Renderer {
         let data = self.load_data(data_dir)?;
         let roots = &data.metadata.paths;
 
-        let hotspots_json = data
-            .hotspots
-            .as_ref()
-            .map(|h| build_hotspots_json(&h.files, roots));
-        let satd_json = data.satd.as_ref().map(|s| build_satd_json(&s.items, roots));
+        let hotspots_json = data.hotspots.as_ref().map(|h| {
+            let annotations = data
+                .hotspots_insight
+                .as_ref()
+                .map(|i| i.item_annotations.as_slice());
+            build_hotspots_json(&h.files, roots, annotations)
+        });
+        let satd_json = data.satd.as_ref().map(|s| {
+            let annotations = data
+                .satd_insight
+                .as_ref()
+                .map(|i| i.item_annotations.as_slice());
+            build_satd_json(&s.items, roots, annotations)
+        });
         let churn_json = data.churn.as_ref().map(|c| build_churn_json(&c.files));
         let cohesion_json = data
             .cohesion
@@ -770,7 +779,31 @@ fn rows_to_json(rows: &[Vec<String>]) -> Value {
     Value::from_serialize(rows)
 }
 
-fn build_hotspots_json(files: &[HotspotItem], roots: &[String]) -> Value {
+/// Renders an analyst annotation as a verified/unverified badge followed by its
+/// comment, so a reader can tell a confirmed defect from an unchecked comment
+/// marker. `evidence`, when present, is surfaced as a title tooltip.
+fn annotation_cell(comment: &str, verified: bool, evidence: &str) -> String {
+    let (badge_class, status) = if verified {
+        ("badge-success", "Verified")
+    } else {
+        ("badge-warning", "Unverified")
+    };
+    let title = if evidence.is_empty() {
+        String::new()
+    } else {
+        format!(" title=\"{}\"", html_escape(evidence))
+    };
+    format!(
+        "<span class=\"badge {badge_class}\"{title}>{status}</span> {}",
+        html_escape(comment)
+    )
+}
+
+fn build_hotspots_json(
+    files: &[HotspotItem],
+    roots: &[String],
+    annotations: Option<&[FileAnnotation]>,
+) -> Value {
     let rows: Vec<Vec<String>> = files
         .iter()
         .map(|item| {
@@ -778,26 +811,39 @@ fn build_hotspots_json(files: &[HotspotItem], roots: &[String]) -> Value {
             let lang = lang_from_path(&item.path);
             let score = item.hotspot_score;
             let badge = hotspot_badge(score);
-            vec![
+            let mut row = vec![
                 format!("<code>{}</code>", html_escape(&truncate_path(&path, 60))),
                 lang,
                 format!("<span class=\"badge {badge}\">{:.3}</span>", score),
                 item.commits.to_string(),
                 format!("{:.1}", item.avg_cognitive),
-            ]
+            ];
+            if let Some(annotations) = annotations {
+                let note = annotations
+                    .iter()
+                    .find(|a| rel_path_ref(&a.file, roots) == path)
+                    .map(|a| annotation_cell(&a.comment, a.verified, &a.evidence))
+                    .unwrap_or_default();
+                row.push(note);
+            }
+            row
         })
         .collect();
     rows_to_json(&rows)
 }
 
-fn build_satd_json(items: &[SATDItem], roots: &[String]) -> Value {
+fn build_satd_json(
+    items: &[SATDItem],
+    roots: &[String],
+    annotations: Option<&[SATDAnnotation]>,
+) -> Value {
     let rows: Vec<Vec<String>> = items
         .iter()
         .map(|item| {
             let sev_lower = item.severity.to_lowercase();
             let path = rel_path_ref(&item.file, roots);
             let lang = lang_from_path(&item.file);
-            vec![
+            let mut row = vec![
                 format!(
                     "<span class=\"badge {sev_lower}\">{}</span>",
                     html_escape(&item.severity)
@@ -807,7 +853,16 @@ fn build_satd_json(items: &[SATDItem], roots: &[String]) -> Value {
                 lang,
                 item.line.to_string(),
                 html_escape(&item.content),
-            ]
+            ];
+            if let Some(annotations) = annotations {
+                let note = annotations
+                    .iter()
+                    .find(|a| rel_path_ref(&a.file, roots) == path && a.line == item.line)
+                    .map(|a| annotation_cell(&a.comment, a.verified, &a.evidence))
+                    .unwrap_or_default();
+                row.push(note);
+            }
+            row
         })
         .collect();
     rows_to_json(&rows)
@@ -1323,7 +1378,7 @@ mod tests {
             },
         ];
         let roots = vec!["/root".to_string()];
-        let json = tojson_filter(build_hotspots_json(&files, &roots));
+        let json = tojson_filter(build_hotspots_json(&files, &roots, None));
         let parsed: Vec<Vec<String>> = serde_json::from_str(json.as_str().unwrap()).unwrap();
         assert_eq!(parsed.len(), 2);
         assert_eq!(parsed[0].len(), 5);
@@ -1332,6 +1387,115 @@ mod tests {
         assert!(parsed[0][2].contains("critical"));
         assert!(parsed[1][2].contains("low"));
         assert_eq!(parsed[0][3], "42");
+    }
+
+    #[test]
+    fn test_build_hotspots_json_with_unverified_annotation() {
+        let files = vec![HotspotItem {
+            path: "/root/src/main.rs".to_string(),
+            hotspot_score: 0.85,
+            commits: 42,
+            avg_cognitive: 12.3,
+        }];
+        let roots = vec!["/root".to_string()];
+        let annotations = vec![FileAnnotation {
+            file: "/root/src/main.rs".to_string(),
+            comment: "TODO says this leaks memory".to_string(),
+            verified: false,
+            evidence: String::new(),
+        }];
+        let json = tojson_filter(build_hotspots_json(&files, &roots, Some(&annotations)));
+        let parsed: Vec<Vec<String>> = serde_json::from_str(json.as_str().unwrap()).unwrap();
+        assert_eq!(parsed[0].len(), 6);
+        assert!(parsed[0][5].contains("badge-warning"));
+        assert!(parsed[0][5].contains("Unverified"));
+        assert!(parsed[0][5].contains("TODO says this leaks memory"));
+    }
+
+    #[test]
+    fn test_build_hotspots_json_with_verified_annotation() {
+        let files = vec![HotspotItem {
+            path: "/root/src/main.rs".to_string(),
+            hotspot_score: 0.85,
+            commits: 42,
+            avg_cognitive: 12.3,
+        }];
+        let roots = vec!["/root".to_string()];
+        let annotations = vec![FileAnnotation {
+            file: "/root/src/main.rs".to_string(),
+            comment: "confirmed unbounded recursion".to_string(),
+            verified: true,
+            evidence: "read main.rs:10-40, recursion has no base case".to_string(),
+        }];
+        let json = tojson_filter(build_hotspots_json(&files, &roots, Some(&annotations)));
+        let parsed: Vec<Vec<String>> = serde_json::from_str(json.as_str().unwrap()).unwrap();
+        assert_eq!(parsed[0].len(), 6);
+        assert!(parsed[0][5].contains("badge-success"));
+        assert!(parsed[0][5].contains("Verified"));
+        assert!(parsed[0][5].contains("read main.rs:10-40, recursion has no base case"));
+    }
+
+    #[test]
+    fn test_build_satd_json_without_annotations() {
+        let items = vec![SATDItem {
+            file: "/root/src/main.rs".to_string(),
+            line: 10,
+            severity: "high".to_string(),
+            category: "defect".to_string(),
+            content: "TODO: fix this".to_string(),
+        }];
+        let roots = vec!["/root".to_string()];
+        let json = tojson_filter(build_satd_json(&items, &roots, None));
+        let parsed: Vec<Vec<String>> = serde_json::from_str(json.as_str().unwrap()).unwrap();
+        assert_eq!(parsed[0].len(), 6);
+    }
+
+    #[test]
+    fn test_build_satd_json_with_unverified_annotation() {
+        let items = vec![SATDItem {
+            file: "/root/src/main.rs".to_string(),
+            line: 10,
+            severity: "high".to_string(),
+            category: "defect".to_string(),
+            content: "TODO: fix this".to_string(),
+        }];
+        let roots = vec!["/root".to_string()];
+        let annotations = vec![SATDAnnotation {
+            file: "/root/src/main.rs".to_string(),
+            line: 10,
+            comment: "restates the TODO".to_string(),
+            verified: false,
+            evidence: String::new(),
+        }];
+        let json = tojson_filter(build_satd_json(&items, &roots, Some(&annotations)));
+        let parsed: Vec<Vec<String>> = serde_json::from_str(json.as_str().unwrap()).unwrap();
+        assert_eq!(parsed[0].len(), 7);
+        assert!(parsed[0][6].contains("badge-warning"));
+        assert!(parsed[0][6].contains("Unverified"));
+        assert!(parsed[0][6].contains("restates the TODO"));
+    }
+
+    #[test]
+    fn test_build_satd_json_annotation_line_mismatch_not_applied() {
+        let items = vec![SATDItem {
+            file: "/root/src/main.rs".to_string(),
+            line: 10,
+            severity: "high".to_string(),
+            category: "defect".to_string(),
+            content: "TODO: fix this".to_string(),
+        }];
+        let roots = vec!["/root".to_string()];
+        let annotations = vec![SATDAnnotation {
+            file: "/root/src/main.rs".to_string(),
+            line: 99,
+            comment: "unrelated".to_string(),
+            verified: true,
+            evidence: String::new(),
+        }];
+        let json = tojson_filter(build_satd_json(&items, &roots, Some(&annotations)));
+        let parsed: Vec<Vec<String>> = serde_json::from_str(json.as_str().unwrap()).unwrap();
+        assert_eq!(parsed[0].len(), 7);
+        assert_eq!(parsed[0][6], "");
     }
 
     #[test]

--- a/src/report/template.html
+++ b/src/report/template.html
@@ -355,7 +355,7 @@
                     </div>
                     {% for item in Summary.recommendations.high_priority %}
                     <div class="recommendation-item">
-                        <strong>{{ item.title }}</strong>
+                        <strong>{{ item.title }}</strong>{% if not item.verified %} <span class="badge badge-warning tooltip" data-tooltip="{% if item.evidence %}{{ item.evidence }}{% else %}Derived from a comment or heuristic; not confirmed by reading the code.{% endif %}">Unverified</span>{% endif %}
                         <div>{{ item.description | markdown }}</div>
                     </div>
                     {% endfor %}
@@ -370,7 +370,7 @@
                     </div>
                     {% for item in Summary.recommendations.medium_priority %}
                     <div class="recommendation-item">
-                        <strong>{{ item.title }}</strong>
+                        <strong>{{ item.title }}</strong>{% if not item.verified %} <span class="badge badge-warning tooltip" data-tooltip="{% if item.evidence %}{{ item.evidence }}{% else %}Derived from a comment or heuristic; not confirmed by reading the code.{% endif %}">Unverified</span>{% endif %}
                         <div>{{ item.description | markdown }}</div>
                     </div>
                     {% endfor %}
@@ -385,7 +385,7 @@
                     </div>
                     {% for item in Summary.recommendations.ongoing %}
                     <div class="recommendation-item">
-                        <strong>{{ item.title }}</strong>
+                        <strong>{{ item.title }}</strong>{% if not item.verified %} <span class="badge badge-warning tooltip" data-tooltip="{% if item.evidence %}{{ item.evidence }}{% else %}Derived from a comment or heuristic; not confirmed by reading the code.{% endif %}">Unverified</span>{% endif %}
                         <div>{{ item.description | markdown }}</div>
                     </div>
                     {% endfor %}
@@ -458,6 +458,9 @@
                             <th class="num"><span class="tooltip" data-tooltip="Combined score of churn frequency and code complexity. Higher risk = more likely to have bugs.">Risk</span></th>
                             <th class="num"><span class="tooltip" data-tooltip="Number of times this file was modified in the analysis period.">Changes</span></th>
                             <th class="num"><span class="tooltip" data-tooltip="Cyclomatic complexity - number of independent paths through the code.">Complexity</span></th>
+                            {% if HotspotsInsight and HotspotsInsight.item_annotations %}
+                            <th><span class="tooltip" data-tooltip="Analyst note on this file. Verified means the analyst opened the source and confirmed the claim; unverified means it is derived from a comment or heuristic and has not been checked.">Analyst Note</span></th>
+                            {% endif %}
                         </tr>
                     </thead>
                 </table>
@@ -732,6 +735,9 @@
                             <th>Lang</th>
                             <th class="num">Line</th>
                             <th>Comment</th>
+                            {% if SATDInsight and SATDInsight.item_annotations %}
+                            <th><span class="tooltip" data-tooltip="Analyst note on this item. Verified means the analyst opened the source and confirmed the claim; unverified means it is derived from the comment text and has not been checked.">Analyst Note</span></th>
+                            {% endif %}
                         </tr>
                     </thead>
                 </table>

--- a/src/report/types.rs
+++ b/src/report/types.rs
@@ -670,6 +670,13 @@ pub struct TdgFile {
 pub struct Recommendation {
     pub title: String,
     pub description: String,
+    /// Whether the analyst opened the cited source and confirmed the claim
+    /// describes current behavior, rather than restating a comment.
+    #[serde(default)]
+    pub verified: bool,
+    /// What the analyst checked to reach the verified conclusion.
+    #[serde(default)]
+    pub evidence: String,
 }
 
 /// Recommendations groups recommendations by priority.
@@ -760,6 +767,13 @@ pub struct ComponentsInsight {
 pub struct FileAnnotation {
     pub file: String,
     pub comment: String,
+    /// Whether the analyst opened the cited source and confirmed the claim
+    /// describes current behavior, rather than restating a comment.
+    #[serde(default)]
+    pub verified: bool,
+    /// What the analyst checked to reach the verified conclusion.
+    #[serde(default)]
+    pub evidence: String,
 }
 
 /// HotspotsInsight contains hotspot analysis.
@@ -787,6 +801,13 @@ pub struct SATDAnnotation {
     #[serde(default)]
     pub line: i32,
     pub comment: String,
+    /// Whether the analyst opened the cited source and confirmed the claim
+    /// describes current behavior, rather than restating a comment.
+    #[serde(default)]
+    pub verified: bool,
+    /// What the analyst checked to reach the verified conclusion.
+    #[serde(default)]
+    pub evidence: String,
 }
 
 /// SATDInsight contains SATD analysis.
@@ -1286,5 +1307,85 @@ mod tests {
         let flags: FlagsData = serde_json::from_str(json).unwrap();
         assert_eq!(flags.flags[0].priority.level, "");
         assert_eq!(flags.flags[0].priority.score, 0.0);
+    }
+
+    #[test]
+    fn test_satd_annotation_deserialize_verified_defaults_when_missing() {
+        let json = r#"{
+            "file": "src/foo.rs",
+            "line": 12,
+            "comment": "TODO: fix this"
+        }"#;
+        let annotation: SATDAnnotation = serde_json::from_str(json).unwrap();
+        assert!(!annotation.verified);
+        assert_eq!(annotation.evidence, "");
+    }
+
+    #[test]
+    fn test_satd_annotation_deserialize_verified_present() {
+        let json = r#"{
+            "file": "src/foo.rs",
+            "line": 12,
+            "comment": "TODO: fix this",
+            "verified": true,
+            "evidence": "opened src/foo.rs:12 and confirmed the branch is unreachable"
+        }"#;
+        let annotation: SATDAnnotation = serde_json::from_str(json).unwrap();
+        assert!(annotation.verified);
+        assert_eq!(
+            annotation.evidence,
+            "opened src/foo.rs:12 and confirmed the branch is unreachable"
+        );
+    }
+
+    #[test]
+    fn test_file_annotation_deserialize_verified_defaults_when_missing() {
+        let json = r#"{
+            "file": "src/bar.rs",
+            "comment": "high churn"
+        }"#;
+        let annotation: FileAnnotation = serde_json::from_str(json).unwrap();
+        assert!(!annotation.verified);
+        assert_eq!(annotation.evidence, "");
+    }
+
+    #[test]
+    fn test_file_annotation_deserialize_verified_present() {
+        let json = r#"{
+            "file": "src/bar.rs",
+            "comment": "high churn",
+            "verified": true,
+            "evidence": "reviewed git log for src/bar.rs"
+        }"#;
+        let annotation: FileAnnotation = serde_json::from_str(json).unwrap();
+        assert!(annotation.verified);
+        assert_eq!(annotation.evidence, "reviewed git log for src/bar.rs");
+    }
+
+    #[test]
+    fn test_recommendation_deserialize_verified_defaults_when_missing() {
+        let json = r#"{
+            "title": "Fix null check",
+            "description": "Add a null check before dereferencing"
+        }"#;
+        let recommendation: Recommendation = serde_json::from_str(json).unwrap();
+        assert!(!recommendation.verified);
+        assert_eq!(recommendation.evidence, "");
+    }
+
+    #[test]
+    fn test_recommendation_deserialize_verified_present() {
+        let json = r#"{
+            "title": "Fix null check",
+            "description": "Add a null check before dereferencing",
+            "verified": true,
+            "evidence": "confirmed missing null check at src/baz.rs:42"
+        }"#;
+        let recommendation: Recommendation = serde_json::from_str(json).unwrap();
+        assert!(recommendation.verified);
+        assert_eq!(
+            recommendation.evidence,
+            "confirmed missing null check at src/baz.rs:42"
+        );
     }
 }


### PR DESCRIPTION
Fixes #490

## Problem

The `omen-reporting` analyst agents build insights from the analyzer JSON alone. No prompt instructs them to open the referenced source file and confirm a finding before asserting it. Comment-derived findings — SATD especially — reach the executive summary as confident, actionable claims without anyone checking whether the code does what the comment implies, or whether the cited line is even live.

The reported spot-check found 1 of 3 claims in a single "high priority" recommendation correct, in the section of the report most likely to be turned directly into tickets.

The three failure modes from the issue:

1. A marker inside a large commented-out block reported as an active defect — nothing at the cited line executes.
2. A deliberate, documented tradeoff (`rescue KnownScenarioError` that reports to `ErrorTracking` with an explanatory comment) reported as "silently swallows errors" — the opposite of what it does. The cited line was also off by eight.
3. A real finding mischaracterized so severity was overstated, while the finding that actually mattered — two API versions rendering the same field differently — was one `grep` away and missed entirely.

This is a prompt problem, not a model problem: the agents have full tool access and could verify. They are simply never asked to.

## Changes

### Verification protocol in the analyst prompts

Prompts now require, before reporting any file:line claim: read the cited region; confirm the line is live code rather than a comment block, heredoc, string literal, or skipped test; confirm the line number points at the thing being described, since analyzer line numbers drift; and state what the code does **now**, not what the comment says. For findings about a misnamed or misused field, grep its readers — whether callers compensate for the quirk is usually the real finding and is where severity is determined.

The protocol is **inlined per agent rather than kept in a shared file**. Each analyst is spawned via the Task tool with its own markdown as the entire system prompt, and nothing would load a second file into that context; a shared file would only work if every Task prompt were also told to go read it. Wording is tailored per agent rather than copy-pasted, because the risk profile differs — `tdg-analyst`'s `has_critical_defects` is tree-sitter ground truth and citable directly, while a SATD marker is just a comment.

Updated: `satd`, `stubs`, `hotspot`, `smells`, `ownership`, `flags`, `tdg`. Deliberately **not** updated: `churn`, `temporal`, `graph`, `duplicates`, `components`, `trends` — their claims are grounded in git log or graph algorithms, not comment interpretation or path inference.

### `verified` / `evidence` in the schema

`FileAnnotation`, `SATDAnnotation`, and `Recommendation` gain `verified: bool` and `evidence: String`. Both use `#[serde(default)]`, so insight files written before this change still deserialize — covered by tests.

The renderer distinguishes confirmed defects from unchecked markers with a Verified/Unverified badge, surfacing `evidence` as a tooltip.

### Summary analyst preserves uncertainty

It consumes per-analyst insights rather than source, so it previously had no way to know what was checked. It now reads the `verified` flag, **may not promote an unverified item into `high_priority`**, carries `verified`/`evidence` onto emitted recommendations, and keeps unverified claims hedged all the way through instead of flattening everything to the same confidence.

## Incidental finding

Wiring the badges through surfaced that hotspot and SATD `item_annotations` were parsed into `RenderData` and then never used — the analyst notes were being generated and silently discarded. They now render as an Analyst Note column, matched to rows by file (hotspots) or file+line (SATD).

## Behavior note

Because `verified` defaults to `false`, recommendations from insight JSON generated before this change will render as "Unverified" until regenerated with the updated prompts. That is the intended conservative default.

## Verification

`cargo test` (2106 lib + 89 integration + 11 property + 3 doc), `cargo fmt --check`, and `cargo clippy --all-targets --all-features -- -D warnings` all pass.

New tests cover backward-compatible deserialization (field absent → `verified: false`, `evidence: ""`) and present-field round-trips for all three types, plus annotation rendering including the case where a SATD annotation's line does not match the row and must not be applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)