### PR TITLE
fix: anchor churn windows at the analyzed revision (#496)

### DIFF
--- a/omen.example.toml
+++ b/omen.example.toml
@@ -77,6 +77,15 @@ min_similarity = 0.9
 [hotspot]
 # Number of top hotspots to report
 top = 20
+# Days of history to measure churn over. The window ends at the analyzed
+# revision's own date, not at the current time, so an old checkout still
+# sees its own history.
+days = 90
+
+# Defect probability (PMAT)
+[defect]
+# Days of history to measure churn over, ending at the analyzed revision.
+churn_days = 30
 
 # Repository health score
 [score]

--- a/src/analyzers/defect.rs
+++ b/src/analyzers/defect.rs
@@ -60,6 +60,26 @@ impl Default for Weights {
     }
 }
 
+/// The precomputed inputs every file's score is derived from.
+struct ScoringInputs<'a> {
+    complexity_data: &'a HashMap<String, (u32, u32)>,
+    duplication_data: &'a HashMap<String, f32>,
+    coupling_data: &'a HashMap<String, (f32, f32)>,
+    git_metrics: &'a HashMap<PathBuf, (usize, usize)>,
+    /// Window width used to normalize churn into a per-30-day rate.
+    window_days: u32,
+}
+
+/// Git-derived inputs for one analysis run.
+struct GitMetrics {
+    /// file -> (commit count, distinct contributors)
+    per_file: HashMap<PathBuf, (usize, usize)>,
+    commits_matched: usize,
+    /// Days between the oldest and newest matched commit, which is the real
+    /// width of an all-history window.
+    observed_span_days: u32,
+}
+
 /// Configuration for defect analyzer.
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -111,7 +131,9 @@ impl Analyzer {
     /// subcommand, `omen all`, `report generate`, `score` -- uses the same
     /// window rather than the default.
     pub fn from_config(config: &crate::config::Config) -> Self {
-        Self::new().with_churn_days(config.defect.churn_days)
+        // A config or MCP caller can supply zero, which the CLI rejects; a
+        // window with no width would divide by zero.
+        Self::new().with_churn_days(config.defect.churn_days.max(1))
     }
 
     pub fn with_churn_days(mut self, days: u32) -> Self {
@@ -246,30 +268,45 @@ impl Analyzer {
         data
     }
 
+    /// The window width in days actually used, which for all-history is the
+    /// span the repository really covers rather than the sentinel.
+    ///
+    /// Without this, 20 commits spread over ten years would score the same as
+    /// 20 in a month.
+    fn effective_window_days(&self, observed_span_days: u32) -> u32 {
+        match self.config.churn_days {
+            u32::MAX => observed_span_days.max(1),
+            0 => 1,
+            days => days,
+        }
+    }
+
     /// Commits per 30 days, so a window other than the default 30 does not
     /// silently inflate or deflate the churn factor.
-    ///
-    /// All-history windows have no meaningful width, so their raw count is
-    /// used as-is rather than divided by a sentinel.
-    fn monthly_commit_rate(&self, commit_count: usize) -> f32 {
-        match self.config.churn_days {
-            0 | u32::MAX => commit_count as f32,
-            days => commit_count as f32 * 30.0 / days as f32,
-        }
+    fn monthly_commit_rate(&self, commit_count: usize, window_days: u32) -> f32 {
+        commit_count as f32 * 30.0 / window_days.max(1) as f32
     }
 
     /// Pre-compute git metrics (churn and ownership) for all files at once.
     /// Returns a map of file path -> (commit_count, contributor_count).
-    fn compute_git_metrics(
-        &self,
-        ctx: &AnalysisContext<'_>,
-    ) -> (HashMap<PathBuf, (usize, usize)>, usize) {
+    fn compute_git_metrics(&self, ctx: &AnalysisContext<'_>) -> Result<GitMetrics> {
         let mut result = HashMap::new();
-        let mut commits_matched = 0;
+        let mut observed_span_days = 0;
 
-        let since = format!("{} days", self.config.churn_days);
-        if let Ok(commits) = ctx.git_log_with_stats(Some(&since), None) {
+        let since = self.since();
+        // A git failure is a real failure. Swallowing it would put every file
+        // at churn 0 while the output still looked like a full prediction --
+        // the very shape of bug this analyzer was fixed for.
+        let commits_matched;
+        {
+            let commits = ctx.git_log_with_stats(Some(&since), None)?;
             commits_matched = commits.len();
+            if let (Some(newest), Some(oldest)) = (
+                commits.iter().map(|c| c.commit_time).max(),
+                commits.iter().map(|c| c.commit_time).min(),
+            ) {
+                observed_span_days = ((newest - oldest) / 86_400).max(0) as u32;
+            }
             // Build per-file metrics from the single git log call
             let mut file_commits: HashMap<PathBuf, usize> = HashMap::new();
             let mut file_contributors: HashMap<PathBuf, HashSet<String>> = HashMap::new();
@@ -291,7 +328,20 @@ impl Analyzer {
             }
         }
 
-        (result, commits_matched)
+        Ok(GitMetrics {
+            per_file: result,
+            commits_matched,
+            observed_span_days,
+        })
+    }
+
+    /// The churn window as a relative duration string. The git layer anchors
+    /// it at the analyzed revision's own date.
+    fn since(&self) -> String {
+        if self.config.churn_days == u32::MAX {
+            return "all".to_string();
+        }
+        format!("{} days", self.config.churn_days)
     }
 
     /// Get file metrics for defect prediction.
@@ -300,11 +350,16 @@ impl Analyzer {
         &self,
         root_path: &std::path::Path,
         file_path: &str,
-        complexity_data: &HashMap<String, (u32, u32)>,
-        duplication_data: &HashMap<String, f32>,
-        coupling_data: &HashMap<String, (f32, f32)>,
-        git_metrics: &HashMap<PathBuf, (usize, usize)>,
+        inputs: &ScoringInputs<'_>,
     ) -> FileMetrics {
+        let ScoringInputs {
+            complexity_data,
+            duplication_data,
+            coupling_data,
+            git_metrics,
+            window_days,
+        } = inputs;
+        let window_days = *window_days;
         let mut metrics = FileMetrics {
             file_path: file_path.to_string(),
             ..Default::default()
@@ -315,7 +370,8 @@ impl Analyzer {
         if let Some(&(commit_count, contributor_count)) = git_metrics.get(&file_pathbuf) {
             // Normalize churn as a monthly rate (~20 commits/month = high
             // churn), so the score means the same thing at any window width.
-            metrics.churn_score = (self.monthly_commit_rate(commit_count) / 20.0).min(1.0);
+            metrics.churn_score =
+                (self.monthly_commit_rate(commit_count, window_days) / 20.0).min(1.0);
             metrics.ownership_diffusion = contributor_count as f32;
         }
 
@@ -472,7 +528,9 @@ impl AnalyzerTrait for Analyzer {
         let coupling_data = self.compute_coupling_data(ctx);
 
         // Pre-compute git metrics once for all files (single git log call)
-        let (git_metrics, commits_matched) = self.compute_git_metrics(ctx);
+        let git = self.compute_git_metrics(ctx)?;
+        let window_days = self.effective_window_days(git.observed_span_days);
+        let git_metrics = git.per_file;
 
         // Pre-filter files
         let valid_files: Vec<_> = ctx
@@ -488,6 +546,14 @@ impl AnalyzerTrait for Analyzer {
             })
             .collect();
 
+        let scoring_inputs = ScoringInputs {
+            complexity_data: &complexity_data,
+            duplication_data: &duplication_data,
+            coupling_data: &coupling_data,
+            git_metrics: &git_metrics,
+            window_days,
+        };
+
         // Process files in parallel
         let weights = &self.config.weights;
         let file_scores: Vec<FileScore> = valid_files
@@ -496,14 +562,7 @@ impl AnalyzerTrait for Analyzer {
                 let file_path = path.strip_prefix(ctx.root).unwrap_or(path);
                 let file_str = file_path.to_string_lossy();
 
-                let metrics = self.get_file_metrics(
-                    ctx.root,
-                    &file_str,
-                    &complexity_data,
-                    &duplication_data,
-                    &coupling_data,
-                    &git_metrics,
-                );
+                let metrics = self.get_file_metrics(ctx.root, &file_str, &scoring_inputs);
                 let prob = self.calculate_probability(&metrics);
                 let confidence = self.calculate_confidence(&metrics);
                 let risk = RiskLevel::from_probability(prob);
@@ -580,7 +639,7 @@ impl AnalyzerTrait for Analyzer {
             files: file_scores,
             summary,
             weights: self.config.weights.clone(),
-            churn_window: ctx.churn_window(self.config.churn_days, commits_matched),
+            churn_window: ctx.churn_window(self.config.churn_days, git.commits_matched),
         })
     }
 }
@@ -1066,16 +1125,31 @@ mod tests {
     fn test_churn_is_normalized_as_a_monthly_rate() {
         // Widening the window must not inflate the churn factor: 10 commits
         // in 30 days and 10 in 60 days are different rates.
-        let narrow = Analyzer::new().with_churn_days(30);
-        let wide = Analyzer::new().with_churn_days(60);
-        assert_eq!(narrow.monthly_commit_rate(10), 10.0);
-        assert_eq!(wide.monthly_commit_rate(10), 5.0);
-        // All-history has no meaningful width, so the raw count is used.
+        let analyzer = Analyzer::new();
+        assert_eq!(analyzer.monthly_commit_rate(10, 30), 10.0);
+        assert_eq!(analyzer.monthly_commit_rate(10, 60), 5.0);
+    }
+
+    #[test]
+    fn test_all_history_window_uses_the_span_actually_covered() {
+        // Otherwise 20 commits over ten years would score like 20 in a month.
+        let all = Analyzer::new().with_churn_days(u32::MAX);
+        assert_eq!(all.effective_window_days(3650), 3650);
+        assert_eq!(all.monthly_commit_rate(20, 3650), 20.0 * 30.0 / 3650.0);
+
+        // A fixed window ignores the observed span.
         assert_eq!(
             Analyzer::new()
-                .with_churn_days(u32::MAX)
-                .monthly_commit_rate(10),
-            10.0
+                .with_churn_days(30)
+                .effective_window_days(3650),
+            30
+        );
+
+        // Degenerate widths never divide by zero.
+        assert_eq!(all.effective_window_days(0), 1);
+        assert_eq!(
+            Analyzer::new().with_churn_days(0).effective_window_days(0),
+            1
         );
     }
 }

--- a/src/analyzers/defect.rs
+++ b/src/analyzers/defect.rs
@@ -131,9 +131,7 @@ impl Analyzer {
     /// subcommand, `omen all`, `report generate`, `score` -- uses the same
     /// window rather than the default.
     pub fn from_config(config: &crate::config::Config) -> Self {
-        // A config or MCP caller can supply zero, which the CLI rejects; a
-        // window with no width would divide by zero.
-        Self::new().with_churn_days(config.defect.churn_days.max(1))
+        Self::new().with_churn_days(config.defect.churn_days)
     }
 
     pub fn with_churn_days(mut self, days: u32) -> Self {

--- a/src/analyzers/defect.rs
+++ b/src/analyzers/defect.rs
@@ -107,6 +107,13 @@ impl Analyzer {
         self
     }
 
+    /// Build from the loaded configuration, so every entry point -- the
+    /// subcommand, `omen all`, `report generate`, `score` -- uses the same
+    /// window rather than the default.
+    pub fn from_config(config: &crate::config::Config) -> Self {
+        Self::new().with_churn_days(config.defect.churn_days)
+    }
+
     pub fn with_churn_days(mut self, days: u32) -> Self {
         self.config.churn_days = days;
         self
@@ -239,13 +246,30 @@ impl Analyzer {
         data
     }
 
+    /// Commits per 30 days, so a window other than the default 30 does not
+    /// silently inflate or deflate the churn factor.
+    ///
+    /// All-history windows have no meaningful width, so their raw count is
+    /// used as-is rather than divided by a sentinel.
+    fn monthly_commit_rate(&self, commit_count: usize) -> f32 {
+        match self.config.churn_days {
+            0 | u32::MAX => commit_count as f32,
+            days => commit_count as f32 * 30.0 / days as f32,
+        }
+    }
+
     /// Pre-compute git metrics (churn and ownership) for all files at once.
     /// Returns a map of file path -> (commit_count, contributor_count).
-    fn compute_git_metrics(&self, ctx: &AnalysisContext<'_>) -> HashMap<PathBuf, (usize, usize)> {
+    fn compute_git_metrics(
+        &self,
+        ctx: &AnalysisContext<'_>,
+    ) -> (HashMap<PathBuf, (usize, usize)>, usize) {
         let mut result = HashMap::new();
+        let mut commits_matched = 0;
 
         let since = format!("{} days", self.config.churn_days);
         if let Ok(commits) = ctx.git_log_with_stats(Some(&since), None) {
+            commits_matched = commits.len();
             // Build per-file metrics from the single git log call
             let mut file_commits: HashMap<PathBuf, usize> = HashMap::new();
             let mut file_contributors: HashMap<PathBuf, HashSet<String>> = HashMap::new();
@@ -267,7 +291,7 @@ impl Analyzer {
             }
         }
 
-        result
+        (result, commits_matched)
     }
 
     /// Get file metrics for defect prediction.
@@ -289,8 +313,9 @@ impl Analyzer {
         // Get churn and ownership from pre-computed git metrics
         let file_pathbuf = PathBuf::from(file_path);
         if let Some(&(commit_count, contributor_count)) = git_metrics.get(&file_pathbuf) {
-            // Normalize churn score (max ~20 commits/month = high churn)
-            metrics.churn_score = (commit_count as f32 / 20.0).min(1.0);
+            // Normalize churn as a monthly rate (~20 commits/month = high
+            // churn), so the score means the same thing at any window width.
+            metrics.churn_score = (self.monthly_commit_rate(commit_count) / 20.0).min(1.0);
             metrics.ownership_diffusion = contributor_count as f32;
         }
 
@@ -447,7 +472,7 @@ impl AnalyzerTrait for Analyzer {
         let coupling_data = self.compute_coupling_data(ctx);
 
         // Pre-compute git metrics once for all files (single git log call)
-        let git_metrics = self.compute_git_metrics(ctx);
+        let (git_metrics, commits_matched) = self.compute_git_metrics(ctx);
 
         // Pre-filter files
         let valid_files: Vec<_> = ctx
@@ -555,6 +580,7 @@ impl AnalyzerTrait for Analyzer {
             files: file_scores,
             summary,
             weights: self.config.weights.clone(),
+            churn_window: ctx.churn_window(self.config.churn_days, commits_matched),
         })
     }
 }
@@ -588,6 +614,10 @@ pub struct Analysis {
     pub files: Vec<FileScore>,
     pub summary: Summary,
     pub weights: Weights,
+    /// The churn window these numbers came from. Defaulted so older
+    /// serialized results still deserialize.
+    #[serde(default)]
+    pub churn_window: Option<crate::git::ChurnWindow>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -956,6 +986,96 @@ mod tests {
             "Estimated metrics should have lower confidence: {} vs {}",
             conf_estimated,
             conf_real
+        );
+    }
+
+    // --- Issue #496: churn must not depend on the wall clock ---------------
+
+    /// A repo whose entire history predates any plausible wall clock, so a
+    /// window measured from "now" matches nothing.
+    fn init_old_repo(path: &std::path::Path) {
+        let run = |args: &[&str], date: Option<&str>| {
+            let mut cmd = std::process::Command::new("git");
+            cmd.args(args).current_dir(path);
+            if let Some(date) = date {
+                cmd.env("GIT_AUTHOR_DATE", date)
+                    .env("GIT_COMMITTER_DATE", date);
+            }
+            cmd.output().expect("git command failed");
+        };
+        run(&["init"], None);
+        run(&["config", "user.email", "test@example.com"], None);
+        run(&["config", "user.name", "Test Author"], None);
+
+        for i in 0..3 {
+            std::fs::write(
+                path.join("a.py"),
+                format!("def f(x):\n    if x:\n        return {i}\n    return 0\n"),
+            )
+            .unwrap();
+            run(&["add", "-A"], None);
+            run(
+                &["commit", "-m", &format!("commit {i}")],
+                Some("2020-06-01T00:00:00+0000"),
+            );
+        }
+    }
+
+    #[test]
+    fn test_churn_factor_is_non_zero_at_an_old_revision() {
+        // The regression the issue asks for: analyzing a commit older than
+        // the default window used to give every file a churn factor of zero,
+        // making 0.30 of the model's weight a constant while the output
+        // still looked like a full prediction.
+        let temp = tempfile::tempdir().unwrap();
+        init_old_repo(temp.path());
+
+        let config = crate::config::Config::default();
+        let files = crate::core::FileSet::from_path(temp.path(), &config).unwrap();
+        let ctx = crate::core::AnalysisContext::new(&files, &config, Some(temp.path()))
+            .with_git_path(temp.path());
+
+        let analysis = Analyzer::new().analyze(&ctx).expect("defect analysis");
+
+        let window = analysis
+            .churn_window
+            .as_ref()
+            .expect("the window used should be reported");
+        assert!(
+            window.commits_matched > 0,
+            "a 30-day window ending at the analyzed revision should match its \
+             own commits, got {window:?}"
+        );
+        assert_eq!(window.days, Some(30));
+        assert!(window.anchor_date.is_some());
+
+        let scored = analysis
+            .files
+            .iter()
+            .find(|f| f.file_path.ends_with("a.py"))
+            .expect("a.py should be scored");
+        let churn = scored
+            .contributing_factors
+            .get("churn")
+            .copied()
+            .unwrap_or(0.0);
+        assert!(churn > 0.0, "churn factor was {churn}, expected non-zero");
+    }
+
+    #[test]
+    fn test_churn_is_normalized_as_a_monthly_rate() {
+        // Widening the window must not inflate the churn factor: 10 commits
+        // in 30 days and 10 in 60 days are different rates.
+        let narrow = Analyzer::new().with_churn_days(30);
+        let wide = Analyzer::new().with_churn_days(60);
+        assert_eq!(narrow.monthly_commit_rate(10), 10.0);
+        assert_eq!(wide.monthly_commit_rate(10), 5.0);
+        // All-history has no meaningful width, so the raw count is used.
+        assert_eq!(
+            Analyzer::new()
+                .with_churn_days(u32::MAX)
+                .monthly_commit_rate(10),
+            10.0
         );
     }
 }

--- a/src/analyzers/hotspot.rs
+++ b/src/analyzers/hotspot.rs
@@ -90,6 +90,9 @@ impl Analyzer {
     /// The churn window as a relative duration string. The git layer anchors
     /// it at the analyzed revision's own date.
     fn since(&self) -> String {
+        if self.config.days == u32::MAX {
+            return "all".to_string();
+        }
         format!("{} days", self.config.days)
     }
 
@@ -97,7 +100,9 @@ impl Analyzer {
     /// subcommand, `omen all`, `report generate` -- uses the same window
     /// rather than the default.
     pub fn from_config(config: &crate::config::Config) -> Self {
-        Self::new().with_days(config.hotspot.days)
+        // A config or MCP caller can supply zero, which the CLI rejects; a
+        // zero-day window matches only commits sharing HEAD's exact second.
+        Self::new().with_days(config.hotspot.days.max(1))
     }
 
     pub fn with_days(mut self, days: u32) -> Self {

--- a/src/analyzers/hotspot.rs
+++ b/src/analyzers/hotspot.rs
@@ -19,7 +19,6 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use chrono::Utc;
 use ignore::WalkBuilder;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -88,6 +87,12 @@ impl Analyzer {
         }
     }
 
+    /// The churn window as a relative duration string. The git layer anchors
+    /// it at the analyzed revision's own date.
+    fn since(&self) -> String {
+        format!("{} days", self.config.days)
+    }
+
     pub fn with_days(mut self, days: u32) -> Self {
         self.config.days = days;
         self
@@ -126,12 +131,9 @@ impl Analyzer {
         files: &[std::path::PathBuf],
         root: &Path,
     ) -> Result<Vec<FileChurn>> {
-        // Get cutoff timestamp
-        let now = Utc::now();
-        let days_ago = now - chrono::Duration::days(self.config.days as i64);
-        let since = days_ago.format("%Y-%m-%d").to_string();
-
-        // Get all commits in the time range
+        // A relative window, not a date computed from the wall clock: the
+        // git layer anchors it at the analyzed revision.
+        let since = self.since();
         let commits = git_repo.log_with_stats(Some(&since), None)?;
 
         self.collect_churn_from_commits(&commits, files, root)
@@ -360,9 +362,7 @@ impl AnalyzerTrait for Analyzer {
         // Build absolute paths from the pre-filtered file set
         let files: Vec<std::path::PathBuf> = ctx.files.iter().map(|p| ctx.root.join(p)).collect();
 
-        let now = Utc::now();
-        let days_ago = now - chrono::Duration::days(self.config.days as i64);
-        let since = days_ago.format("%Y-%m-%d").to_string();
+        let since = self.since();
         let commits = ctx.git_log_with_stats(Some(&since), None)?;
         let churn_data = self.collect_churn_from_commits(&commits, &files, ctx.root)?;
         let complexity_data = self.collect_complexity_data(&files, ctx.root)?;

--- a/src/analyzers/hotspot.rs
+++ b/src/analyzers/hotspot.rs
@@ -93,6 +93,13 @@ impl Analyzer {
         format!("{} days", self.config.days)
     }
 
+    /// Build from the loaded configuration, so every entry point -- the
+    /// subcommand, `omen all`, `report generate` -- uses the same window
+    /// rather than the default.
+    pub fn from_config(config: &crate::config::Config) -> Self {
+        Self::new().with_days(config.hotspot.days)
+    }
+
     pub fn with_days(mut self, days: u32) -> Self {
         self.config.days = days;
         self
@@ -290,7 +297,11 @@ impl Analyzer {
                 .count(),
         };
 
-        Ok(Analysis { hotspots, summary })
+        Ok(Analysis {
+            hotspots,
+            summary,
+            churn_window: None,
+        })
     }
 
     fn classify_severity(&self, score: f64) -> Severity {
@@ -367,7 +378,9 @@ impl AnalyzerTrait for Analyzer {
         let churn_data = self.collect_churn_from_commits(&commits, &files, ctx.root)?;
         let complexity_data = self.collect_complexity_data(&files, ctx.root)?;
 
-        self.combine_analyses(&churn_data, &complexity_data)
+        let mut analysis = self.combine_analyses(&churn_data, &complexity_data)?;
+        analysis.churn_window = ctx.churn_window(self.config.days, commits.len());
+        Ok(analysis)
     }
 }
 
@@ -375,6 +388,10 @@ impl AnalyzerTrait for Analyzer {
 pub struct Analysis {
     pub hotspots: Vec<Hotspot>,
     pub summary: AnalysisSummary,
+    /// The churn window these numbers came from. Defaulted so older
+    /// serialized results still deserialize.
+    #[serde(default)]
+    pub churn_window: Option<crate::git::ChurnWindow>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -900,6 +917,67 @@ mod tests {
             total_commits > 0,
             "churn data should have commits > 0, got {}",
             total_commits
+        );
+    }
+
+    // --- Issue #496: an empty window must not read as "no hotspots" --------
+
+    fn init_old_repo(path: &std::path::Path) {
+        let run = |args: &[&str], date: Option<&str>| {
+            let mut cmd = std::process::Command::new("git");
+            cmd.args(args).current_dir(path);
+            if let Some(date) = date {
+                cmd.env("GIT_AUTHOR_DATE", date)
+                    .env("GIT_COMMITTER_DATE", date);
+            }
+            cmd.output().expect("git command failed");
+        };
+        run(&["init"], None);
+        run(&["config", "user.email", "test@example.com"], None);
+        run(&["config", "user.name", "Test Author"], None);
+
+        for i in 0..3 {
+            std::fs::write(
+                path.join("a.py"),
+                format!("def f(x):\n    if x:\n        return {i}\n    return 0\n"),
+            )
+            .unwrap();
+            run(&["add", "-A"], None);
+            run(
+                &["commit", "-m", &format!("commit {i}")],
+                Some("2020-06-01T00:00:00+0000"),
+            );
+        }
+    }
+
+    #[test]
+    fn test_hotspots_are_found_at_an_old_revision() {
+        // Before the fix a checkout older than the 90-day window produced an
+        // empty list, indistinguishable from a genuinely clean repository.
+        let temp = tempfile::tempdir().unwrap();
+        init_old_repo(temp.path());
+
+        let config = crate::config::Config::default();
+        let files = crate::core::FileSet::from_path(temp.path(), &config).unwrap();
+        let ctx = crate::core::AnalysisContext::new(&files, &config, Some(temp.path()))
+            .with_git_path(temp.path());
+
+        let analysis = Analyzer::new().analyze(&ctx).expect("hotspot analysis");
+
+        let window = analysis
+            .churn_window
+            .as_ref()
+            .expect("the window used should be reported");
+        assert!(
+            window.commits_matched > 0,
+            "a 90-day window ending at the analyzed revision should match its \
+             own commits, got {window:?}"
+        );
+        assert_eq!(window.days, Some(90));
+        assert!(window.history_complete);
+        assert!(
+            !analysis.hotspots.is_empty(),
+            "a churned, branching file should be a hotspot"
         );
     }
 }

--- a/src/analyzers/hotspot.rs
+++ b/src/analyzers/hotspot.rs
@@ -100,9 +100,7 @@ impl Analyzer {
     /// subcommand, `omen all`, `report generate` -- uses the same window
     /// rather than the default.
     pub fn from_config(config: &crate::config::Config) -> Self {
-        // A config or MCP caller can supply zero, which the CLI rejects; a
-        // zero-day window matches only commits sharing HEAD's exact second.
-        Self::new().with_days(config.hotspot.days.max(1))
+        Self::new().with_days(config.hotspot.days)
     }
 
     pub fn with_days(mut self, days: u32) -> Self {

--- a/src/analyzers/tdg.rs
+++ b/src/analyzers/tdg.rs
@@ -1450,6 +1450,7 @@ fn risky() {
                 critical_count: 0,
                 high_count: 1,
             },
+            churn_window: None,
         };
 
         let temporal_analysis = tp::Analysis {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -71,7 +71,7 @@ pub enum Command {
 
     /// Predict defect-prone files using PMAT
     #[command(visible_alias = "predict")]
-    Defect(AnalyzerArgs),
+    Defect(DefectArgs),
 
     /// Analyze recent changes (JIT risk)
     #[command(alias = "jit")]
@@ -95,7 +95,7 @@ pub enum Command {
     // plural `hotspots`. `hotspots` is accepted here as a visible alias so both
     // spellings work from the CLI without touching the JSON/report contract.
     #[command(alias = "hs", visible_alias = "hotspots")]
-    Hotspot(AnalyzerArgs),
+    Hotspot(HotspotArgs),
 
     /// Detect temporally coupled files
     #[command(alias = "tc", visible_alias = "temporal-coupling")]
@@ -274,6 +274,91 @@ pub enum GateSeverity {
     Low,
     Medium,
     High,
+}
+
+/// A churn time window: a relative duration, or all of history.
+///
+/// Unlike `churn`, these analyzers reject anything else rather than silently
+/// widening to all history -- `parse_since_to_days` returns `None` both for
+/// "all" and for garbage, so a permissive parse would make `--since
+/// 2024-01-01` mean "every commit ever".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChurnWindow {
+    Days(u32),
+    All,
+}
+
+impl ChurnWindow {
+    /// Resolve `--since` (canonical) over `--days` (alias) over the config.
+    pub fn resolve(
+        since: Option<&str>,
+        days: Option<u32>,
+        config_days: u32,
+    ) -> std::result::Result<Self, String> {
+        if let Some(since) = since {
+            return since.parse();
+        }
+        match days.unwrap_or(config_days) {
+            0 => Err("a window of 0 days contains no history".to_string()),
+            days => Ok(Self::Days(days)),
+        }
+    }
+
+    /// Days for analyzer builders; `u32::MAX` is the all-history sentinel.
+    pub fn as_days(self) -> u32 {
+        match self {
+            Self::Days(days) => days,
+            Self::All => u32::MAX,
+        }
+    }
+}
+
+impl std::str::FromStr for ChurnWindow {
+    type Err = String;
+
+    fn from_str(value: &str) -> std::result::Result<Self, Self::Err> {
+        if crate::git::is_since_all(value) {
+            return Ok(Self::All);
+        }
+        match crate::git::parse_since_to_days(value) {
+            Some(0) | None => Err(format!(
+                "invalid time window {value:?}: expected a duration such as 30d, 3m, 1y, or \"all\""
+            )),
+            Some(days) => Ok(Self::Days(days)),
+        }
+    }
+}
+
+/// The `--since`/`--days` pair shared by `defect` and `hotspot`.
+#[derive(Args)]
+pub struct ChurnWindowArgs {
+    /// Time period to measure churn over (e.g. 30d, 3m, 1y, all). The window
+    /// ends at the analyzed revision's own date, not at the current time.
+    /// Canonical flag; --days is an alias. If both are given, --since wins.
+    #[arg(long)]
+    pub since: Option<String>,
+
+    /// Days of history to measure churn over (alias for --since)
+    #[arg(long)]
+    pub days: Option<u32>,
+}
+
+#[derive(Args)]
+pub struct DefectArgs {
+    #[command(flatten)]
+    pub common: AnalyzerArgs,
+
+    #[command(flatten)]
+    pub window: ChurnWindowArgs,
+}
+
+#[derive(Args)]
+pub struct HotspotArgs {
+    #[command(flatten)]
+    pub common: AnalyzerArgs,
+
+    #[command(flatten)]
+    pub window: ChurnWindowArgs,
 }
 
 #[derive(Args)]
@@ -2374,5 +2459,62 @@ mod tests {
         assert!(hotspot
             .get_visible_aliases()
             .any(|alias| alias == "hotspots"));
+    }
+
+    // --- Issue #496: churn window flags -----------------------------------
+
+    #[test]
+    fn test_churn_window_parses_durations_and_all() {
+        use std::str::FromStr;
+        assert_eq!(ChurnWindow::from_str("30d"), Ok(ChurnWindow::Days(30)));
+        assert_eq!(ChurnWindow::from_str("3m"), Ok(ChurnWindow::Days(90)));
+        assert_eq!(ChurnWindow::from_str("1y"), Ok(ChurnWindow::Days(365)));
+        assert_eq!(ChurnWindow::from_str("all"), Ok(ChurnWindow::All));
+        assert_eq!(ChurnWindow::All.as_days(), u32::MAX);
+    }
+
+    #[test]
+    fn test_churn_window_rejects_input_it_cannot_measure() {
+        use std::str::FromStr;
+        // The trap this guards: `parse_since_to_days` returns None for "all"
+        // *and* for anything unparseable, so a permissive parse would make an
+        // absolute date silently mean "every commit ever".
+        for bad in ["2024-01-01", "yesterday", "", "0d"] {
+            assert!(
+                ChurnWindow::from_str(bad).is_err(),
+                "{bad:?} should be rejected, not widened to all history"
+            );
+        }
+    }
+
+    #[test]
+    fn test_churn_window_precedence() {
+        // --since wins over --days wins over config.
+        assert_eq!(
+            ChurnWindow::resolve(Some("1y"), Some(7), 30),
+            Ok(ChurnWindow::Days(365))
+        );
+        assert_eq!(
+            ChurnWindow::resolve(None, Some(7), 30),
+            Ok(ChurnWindow::Days(7))
+        );
+        assert_eq!(
+            ChurnWindow::resolve(None, None, 30),
+            Ok(ChurnWindow::Days(30))
+        );
+        // `--since all` must be a whole branch, not folded into --days.
+        assert_eq!(
+            ChurnWindow::resolve(Some("all"), Some(7), 30),
+            Ok(ChurnWindow::All)
+        );
+        assert!(ChurnWindow::resolve(None, Some(0), 30).is_err());
+    }
+
+    #[test]
+    fn test_defect_and_hotspot_accept_window_flags() {
+        assert_parses_to!(&["omen", "defect", "--since", "1y"], Command::Defect(_));
+        assert_parses_to!(&["omen", "defect", "--days", "90"], Command::Defect(_));
+        assert_parses_to!(&["omen", "hotspot", "--since", "all"], Command::Hotspot(_));
+        assert_parses_to!(&["omen", "hotspot", "--days", "180"], Command::Hotspot(_));
     }
 }

--- a/src/config/default_config.toml
+++ b/src/config/default_config.toml
@@ -32,6 +32,10 @@ min_similarity = 0.9
 
 [hotspot]
 top = 20
+days = 90
+
+[defect]
+churn_days = 30
 
 [score]
 # fail_under = 80

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -27,6 +27,8 @@ pub struct Config {
     pub duplicates: DuplicatesConfig,
     /// Hotspot configuration.
     pub hotspot: HotspotConfig,
+    /// Defect analyzer configuration.
+    pub defect: DefectConfig,
     /// Score thresholds.
     pub score: ScoreConfig,
     /// Feature flag configuration.
@@ -48,6 +50,7 @@ impl Default for Config {
             churn: ChurnConfig::default(),
             duplicates: DuplicatesConfig::default(),
             hotspot: HotspotConfig::default(),
+            defect: DefectConfig::default(),
             score: ScoreConfig::default(),
             feature_flags: FeatureFlagsConfig::default(),
             temporal: TemporalConfig::default(),
@@ -190,11 +193,29 @@ impl Default for DuplicatesConfig {
 pub struct HotspotConfig {
     /// Number of top hotspots to report.
     pub top: usize,
+    /// Days of history to measure churn over, ending at the analyzed
+    /// revision's own date.
+    pub days: u32,
 }
 
 impl Default for HotspotConfig {
     fn default() -> Self {
-        Self { top: 20 }
+        Self { top: 20, days: 90 }
+    }
+}
+
+/// Defect analyzer configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct DefectConfig {
+    /// Days of history to measure churn over, ending at the analyzed
+    /// revision's own date.
+    pub churn_days: u32,
+}
+
+impl Default for DefectConfig {
+    fn default() -> Self {
+        Self { churn_days: 30 }
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -84,6 +84,7 @@ impl Config {
             .merge(Env::prefixed("OMEN_").split("__"))
             .extract()
             .map_err(|e| crate::core::Error::Config(e.to_string()))?;
+        config.validate()?;
         Ok(config)
     }
 
@@ -104,12 +105,29 @@ impl Config {
             .merge(Env::prefixed("OMEN_").split("__"))
             .extract()
             .map_err(|e| crate::core::Error::Config(e.to_string()))?;
+        config.validate()?;
         Ok(config)
     }
 
     /// Alias for load_default.
     pub fn load_from_dir(dir: impl AsRef<Path>) -> Result<Self> {
         Self::load_default(dir)
+    }
+
+    /// Reject configuration that cannot mean anything, rather than silently
+    /// substituting a value the user did not ask for.
+    pub fn validate(&self) -> Result<()> {
+        for (key, days) in [
+            ("hotspot.days", self.hotspot.days),
+            ("defect.churn_days", self.defect.churn_days),
+        ] {
+            if days == 0 {
+                return Err(crate::core::Error::Config(format!(
+                    "{key} = 0: a window of 0 days contains no history"
+                )));
+            }
+        }
+        Ok(())
     }
 
     /// Create default config file content.
@@ -551,5 +569,28 @@ mod tests {
         assert_eq!(config.stale_days, 0);
         assert!(config.providers.is_empty());
         assert!(config.custom_providers.is_empty());
+    }
+
+    #[test]
+    fn test_zero_day_windows_are_rejected_at_load() {
+        // Otherwise an aggregate path would silently substitute a window the
+        // user never asked for.
+        let mut config = Config::default();
+        assert!(config.validate().is_ok());
+
+        config.hotspot.days = 0;
+        assert!(config.validate().is_err());
+
+        let mut config = Config::default();
+        config.defect.churn_days = 0;
+        let error = config.validate().unwrap_err().to_string();
+        assert!(error.contains("defect.churn_days"), "got {error}");
+    }
+
+    #[test]
+    fn test_churn_window_defaults() {
+        let config = Config::default();
+        assert_eq!(config.hotspot.days, 90);
+        assert_eq!(config.defect.churn_days, 30);
     }
 }

--- a/src/core/analyzer.rs
+++ b/src/core/analyzer.rs
@@ -101,6 +101,23 @@ impl<'a> AnalysisContext<'a> {
             .map_err(|error| super::Error::git(error.clone()))
     }
 
+    /// Describe the churn window an analyzer used, so an empty one is
+    /// visible in the output rather than silently indistinguishable from a
+    /// clean repository.
+    pub fn churn_window(
+        &self,
+        days: u32,
+        commits_matched: usize,
+    ) -> Option<crate::git::ChurnWindow> {
+        let data = self.git_log_data().ok()?;
+        Some(crate::git::ChurnWindow::new(
+            days,
+            data.anchor(),
+            commits_matched,
+            data.history_complete(),
+        ))
+    }
+
     /// Query the shared numstat history with the same window and limit as git log.
     pub fn git_log_with_stats(
         &self,

--- a/src/git/log.rs
+++ b/src/git/log.rs
@@ -84,10 +84,7 @@ pub fn get_log(
         .map_err(|e| Error::git(format!("Failed to get HEAD: {e}")))?;
 
     let cutoff_time = match since {
-        Some(since) => match anchored_cutoff(repo, since)? {
-            Cutoff::At(cutoff) => Some(cutoff),
-            Cutoff::All | Cutoff::Unresolved => None,
-        },
+        Some(since) => resolve_cutoff(repo, since)?,
         None => None,
     };
 
@@ -216,6 +213,45 @@ pub fn anchored_cutoff(repo: &Repository, since: &str) -> Result<Cutoff> {
         return Ok(Cutoff::All);
     };
     Ok(cutoff_from(anchor, duration))
+}
+
+/// Resolve any `since` string to a concrete cutoff, asking git to parse the
+/// absolute dates this module's own duration parser does not understand.
+///
+/// The gix walks need this: they have no git process to defer to, so without
+/// it an absolute date would silently mean "no lower bound".
+pub fn resolve_cutoff(repo: &Repository, since: &str) -> Result<Option<i64>> {
+    match anchored_cutoff(repo, since)? {
+        Cutoff::At(cutoff) => Ok(Some(cutoff)),
+        Cutoff::All => Ok(None),
+        Cutoff::Unresolved => {
+            let Some(workdir) = repo.workdir() else {
+                return Ok(None);
+            };
+            Ok(git_resolved_since(workdir, since).ok())
+        }
+    }
+}
+
+/// Ask `git rev-parse` to turn a date expression into a timestamp.
+pub fn git_resolved_since(repo_path: &std::path::Path, since: &str) -> Result<i64> {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", &format!("--since={since}")])
+        .current_dir(repo_path)
+        .output()
+        .map_err(|error| Error::git(format!("Failed to resolve git date: {error}")))?;
+    if !output.status.success() {
+        return Err(Error::git(format!(
+            "Failed to resolve git date: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+    let value = String::from_utf8_lossy(&output.stdout);
+    value
+        .trim()
+        .strip_prefix("--max-age=")
+        .and_then(|timestamp| timestamp.parse().ok())
+        .ok_or_else(|| Error::git(format!("Invalid git date result: {value}")))
 }
 
 /// Turn an anchor and a window width into a cutoff.
@@ -512,10 +548,7 @@ pub fn get_log_with_stats_gix(
         .map_err(|e| Error::git(format!("Failed to get HEAD: {e}")))?;
 
     let cutoff_time = match since {
-        Some(since) => match anchored_cutoff(repo, since)? {
-            Cutoff::At(cutoff) => Some(cutoff),
-            Cutoff::All | Cutoff::Unresolved => None,
-        },
+        Some(since) => resolve_cutoff(repo, since)?,
         None => None,
     };
 

--- a/src/git/log.rs
+++ b/src/git/log.rs
@@ -84,7 +84,10 @@ pub fn get_log(
         .map_err(|e| Error::git(format!("Failed to get HEAD: {e}")))?;
 
     let cutoff_time = match since {
-        Some(since) => anchored_cutoff(repo, since)?,
+        Some(since) => match anchored_cutoff(repo, since)? {
+            Cutoff::At(cutoff) => Some(cutoff),
+            Cutoff::All | Cutoff::Unresolved => None,
+        },
         None => None,
     };
 
@@ -164,41 +167,69 @@ pub fn get_log(
 
 /// The committer time of the repository's HEAD commit, or `None` when HEAD is
 /// unborn and there is therefore no history to window.
+///
+/// Only an unborn HEAD yields `None`. Every other failure propagates: a
+/// corrupt ref silently becoming "no history" is exactly the kind of quiet
+/// degradation this whole change is meant to remove.
 pub fn head_commit_time(repo: &Repository) -> Result<Option<i64>> {
-    let head = match repo.head_id() {
-        Ok(head) => head,
-        // An unborn HEAD means an empty repository, not a failure.
-        Err(_) => return Ok(None),
-    };
+    let mut head = repo
+        .head()
+        .map_err(|e| Error::git(format!("Failed to read HEAD: {e}")))?;
+    if head.is_unborn() {
+        return Ok(None);
+    }
     let commit = head
-        .object()
-        .map_err(|e| Error::git(format!("Failed to read HEAD commit: {e}")))?
-        .try_into_commit()
-        .map_err(|e| Error::git(format!("HEAD is not a commit: {e}")))?;
+        .peel_to_commit()
+        .map_err(|e| Error::git(format!("Failed to peel HEAD to a commit: {e}")))?;
     let committer = commit
         .committer()
         .map_err(|e| Error::git(format!("Failed to read HEAD committer: {e}")))?;
     Ok(Some(committer.seconds()))
 }
 
+/// How a `since` string resolved against the analyzed revision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Cutoff {
+    /// No lower bound: all of history.
+    All,
+    /// A relative window, anchored at the revision, ending at this timestamp.
+    At(i64),
+    /// Not a relative duration; git must resolve it (an absolute date).
+    Unresolved,
+}
+
 /// Resolve a relative `since` window against the analyzed revision's own date.
-///
-/// Returns `None` when `since` is not a relative duration -- an absolute date
-/// is already a fixed point and needs no anchor.
 ///
 /// Anchoring at HEAD rather than at the wall clock is what makes a window
 /// meaningful in a worktree, at a release tag, mid-bisect, or in a repository
 /// that simply has not been committed to lately. It also makes the result
 /// deterministic: the same revision analyzed on two different days scores the
 /// same.
-pub fn anchored_cutoff(repo: &Repository, since: &str) -> Result<Option<i64>> {
+pub fn anchored_cutoff(repo: &Repository, since: &str) -> Result<Cutoff> {
+    if is_since_all(since) {
+        return Ok(Cutoff::All);
+    }
     let Some(duration) = parse_since_duration(since) else {
-        return Ok(None);
+        return Ok(Cutoff::Unresolved);
     };
     let Some(anchor) = head_commit_time(repo)? else {
-        return Ok(None);
+        return Ok(Cutoff::All);
     };
-    Ok(Some(anchor.saturating_sub(duration.as_secs() as i64)))
+    Ok(cutoff_from(anchor, duration))
+}
+
+/// Turn an anchor and a window width into a cutoff.
+///
+/// A window wide enough to reach past the epoch is all of history. It must not
+/// become a negative timestamp: git's approxidate reads `--since=@-3710...`
+/// as roughly *now* and returns an empty log -- the exact silent-empty failure
+/// this change exists to fix. The all-history sentinel (`u32::MAX` days)
+/// always lands here.
+pub fn cutoff_from(anchor: i64, duration: std::time::Duration) -> Cutoff {
+    match anchor.checked_sub(duration.as_secs() as i64) {
+        Some(cutoff) if cutoff > 0 => Cutoff::At(cutoff),
+        _ => Cutoff::All,
+    }
 }
 
 /// Returns true if the since string means "all history" (no time limit).
@@ -268,9 +299,16 @@ pub fn get_log_with_stats(
         // A relative window is measured from the analyzed revision, not from
         // the wall clock, so an old checkout still sees its own history.
         match anchored_cutoff(repo, since_str)? {
-            Some(cutoff) => cmd.arg(format!("--since=@{cutoff}")),
-            None => cmd.arg(format!("--since={since_str}")),
-        };
+            Cutoff::At(cutoff) => {
+                cmd.arg(format!("--since=@{cutoff}"));
+            }
+            Cutoff::Unresolved => {
+                cmd.arg(format!("--since={since_str}"));
+            }
+            // No lower bound at all: asking git for one would only risk
+            // resolving it back to the present.
+            Cutoff::All => {}
+        }
     }
 
     if let Some(max) = limit {
@@ -474,7 +512,10 @@ pub fn get_log_with_stats_gix(
         .map_err(|e| Error::git(format!("Failed to get HEAD: {e}")))?;
 
     let cutoff_time = match since {
-        Some(since) => anchored_cutoff(repo, since)?,
+        Some(since) => match anchored_cutoff(repo, since)? {
+            Cutoff::At(cutoff) => Some(cutoff),
+            Cutoff::All | Cutoff::Unresolved => None,
+        },
         None => None,
     };
 
@@ -1082,6 +1123,30 @@ mod tests {
             !messages.iter().any(|m| m.contains("Add file2")),
             "Should NOT contain 'Add file2' commit, got: {:?}",
             messages
+        );
+    }
+
+    #[test]
+    fn test_wide_windows_become_all_history_not_a_negative_cutoff() {
+        use std::time::Duration;
+        let anchor = 1_700_000_000;
+
+        assert_eq!(
+            cutoff_from(anchor, Duration::from_secs(30 * 86_400)),
+            Cutoff::At(anchor - 30 * 86_400)
+        );
+
+        // The all-history sentinel: `u32::MAX days` reaches far past the
+        // epoch. It must not become `--since=@-371...`, which git's
+        // approxidate reads as roughly *now* and answers with an empty log --
+        // the silent-empty failure this change exists to remove.
+        let sentinel = parse_since_duration(&format!("{} days", u32::MAX)).unwrap();
+        assert_eq!(cutoff_from(anchor, sentinel), Cutoff::All);
+
+        // So does any window wider than the anchor itself.
+        assert_eq!(
+            cutoff_from(anchor, Duration::from_secs(anchor as u64 + 1)),
+            Cutoff::All
         );
     }
 

--- a/src/git/log.rs
+++ b/src/git/log.rs
@@ -17,8 +17,16 @@ pub struct Commit {
     pub author: String,
     /// Author email.
     pub email: String,
-    /// Commit timestamp.
+    /// Author timestamp, for attribution and display.
     pub timestamp: i64,
+    /// Committer timestamp.
+    ///
+    /// This is the clock `git log --since` filters on and gix's
+    /// `ByCommitTime` orders by, so every time window must use it. The author
+    /// date can be moved arbitrarily far out of topological order by a
+    /// rebase.
+    #[serde(default)]
+    pub commit_time: i64,
     /// Commit message (first line).
     pub message: String,
     /// Files changed in this commit.
@@ -75,14 +83,10 @@ pub fn get_log(
         .head_id()
         .map_err(|e| Error::git(format!("Failed to get HEAD: {e}")))?;
 
-    let cutoff_time = since.and_then(parse_since_duration).map(|duration| {
-        let now = std::time::SystemTime::now();
-        now.checked_sub(duration)
-            .unwrap_or(std::time::UNIX_EPOCH)
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs() as i64)
-            .unwrap_or(0)
-    });
+    let cutoff_time = match since {
+        Some(since) => anchored_cutoff(repo, since)?,
+        None => None,
+    };
 
     let walk = repo
         .rev_walk([head])
@@ -102,10 +106,15 @@ pub fn get_log(
 
         let author = commit.author().map_err(|e| Error::git(format!("{e}")))?;
         let timestamp = author.seconds();
+        let commit_time = commit
+            .committer()
+            .map(|committer| committer.seconds())
+            .unwrap_or(timestamp);
 
-        // Skip commits older than cutoff
+        // Skip commits older than the cutoff. The walk is ordered by
+        // committer time, so the filter must use the same clock.
         if let Some(cutoff) = cutoff_time {
-            if timestamp < cutoff {
+            if commit_time < cutoff {
                 break;
             }
         }
@@ -134,6 +143,7 @@ pub fn get_log(
             author: author.name.to_string(),
             email: author.email.to_string(),
             timestamp,
+            commit_time,
             message,
             files: Vec::new(), // File changes calculated separately if needed
         });
@@ -150,6 +160,45 @@ pub fn get_log(
     }
 
     Ok(commits)
+}
+
+/// The committer time of the repository's HEAD commit, or `None` when HEAD is
+/// unborn and there is therefore no history to window.
+pub fn head_commit_time(repo: &Repository) -> Result<Option<i64>> {
+    let head = match repo.head_id() {
+        Ok(head) => head,
+        // An unborn HEAD means an empty repository, not a failure.
+        Err(_) => return Ok(None),
+    };
+    let commit = head
+        .object()
+        .map_err(|e| Error::git(format!("Failed to read HEAD commit: {e}")))?
+        .try_into_commit()
+        .map_err(|e| Error::git(format!("HEAD is not a commit: {e}")))?;
+    let committer = commit
+        .committer()
+        .map_err(|e| Error::git(format!("Failed to read HEAD committer: {e}")))?;
+    Ok(Some(committer.seconds()))
+}
+
+/// Resolve a relative `since` window against the analyzed revision's own date.
+///
+/// Returns `None` when `since` is not a relative duration -- an absolute date
+/// is already a fixed point and needs no anchor.
+///
+/// Anchoring at HEAD rather than at the wall clock is what makes a window
+/// meaningful in a worktree, at a release tag, mid-bisect, or in a repository
+/// that simply has not been committed to lately. It also makes the result
+/// deterministic: the same revision analyzed on two different days scores the
+/// same.
+pub fn anchored_cutoff(repo: &Repository, since: &str) -> Result<Option<i64>> {
+    let Some(duration) = parse_since_duration(since) else {
+        return Ok(None);
+    };
+    let Some(anchor) = head_commit_time(repo)? else {
+        return Ok(None);
+    };
+    Ok(Some(anchor.saturating_sub(duration.as_secs() as i64)))
 }
 
 /// Returns true if the since string means "all history" (no time limit).
@@ -169,7 +218,7 @@ pub fn parse_since_to_days(since: &str) -> Option<u32> {
 }
 
 /// Parse "since" duration strings like "30 days ago", "1 week", "6m", "1y".
-fn parse_since_duration(since: &str) -> Option<std::time::Duration> {
+pub fn parse_since_duration(since: &str) -> Option<std::time::Duration> {
     let since = since.trim().to_lowercase();
 
     // Handle "X days ago" format
@@ -213,10 +262,15 @@ pub fn get_log_with_stats(
     // Build git log command with numstat
     let mut cmd = std::process::Command::new("git");
     cmd.current_dir(repo_path);
-    cmd.args(["log", "--format=%H|%an|%ae|%at|%s", "--numstat"]);
+    cmd.args(["log", "--format=%H|%an|%ae|%at|%ct|%s", "--numstat"]);
 
     if let Some(since_str) = since {
-        cmd.arg(format!("--since={}", since_str));
+        // A relative window is measured from the analyzed revision, not from
+        // the wall clock, so an old checkout still sees its own history.
+        match anchored_cutoff(repo, since_str)? {
+            Some(cutoff) => cmd.arg(format!("--since=@{cutoff}")),
+            None => cmd.arg(format!("--since={since_str}")),
+        };
     }
 
     if let Some(max) = limit {
@@ -340,8 +394,8 @@ fn parse_git_log_numstat(output: &[u8]) -> Result<Vec<Commit>> {
 
         // Check if this is a commit line (contains |)
         if line.contains('|') {
-            let parts: Vec<&str> = line.splitn(5, '|').collect();
-            if parts.len() == 5 {
+            let parts: Vec<&str> = line.splitn(6, '|').collect();
+            if parts.len() == 6 {
                 // Save previous commit
                 if let Some(commit) = current_commit.take() {
                     commits.push(commit);
@@ -352,13 +406,15 @@ fn parse_git_log_numstat(output: &[u8]) -> Result<Vec<Commit>> {
                 let author = parts[1].to_string();
                 let email = parts[2].to_string();
                 let timestamp: i64 = parts[3].parse().unwrap_or(0);
-                let message = parts[4].to_string();
+                let commit_time: i64 = parts[4].parse().unwrap_or(timestamp);
+                let message = parts[5].to_string();
 
                 current_commit = Some(Commit {
                     sha,
                     author,
                     email,
                     timestamp,
+                    commit_time,
                     message,
                     files: Vec::new(),
                 });
@@ -417,14 +473,10 @@ pub fn get_log_with_stats_gix(
         .head_id()
         .map_err(|e| Error::git(format!("Failed to get HEAD: {e}")))?;
 
-    let cutoff_time = since.and_then(parse_since_duration).map(|duration| {
-        let now = std::time::SystemTime::now();
-        now.checked_sub(duration)
-            .unwrap_or(std::time::UNIX_EPOCH)
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs() as i64)
-            .unwrap_or(0)
-    });
+    let cutoff_time = match since {
+        Some(since) => anchored_cutoff(repo, since)?,
+        None => None,
+    };
 
     let walk = repo
         .rev_walk([head])
@@ -444,10 +496,15 @@ pub fn get_log_with_stats_gix(
 
         let author = commit.author().map_err(|e| Error::git(format!("{e}")))?;
         let timestamp = author.seconds();
+        let commit_time = commit
+            .committer()
+            .map(|committer| committer.seconds())
+            .unwrap_or(timestamp);
 
-        // Skip commits older than cutoff
+        // Skip commits older than the cutoff. The walk is ordered by
+        // committer time, so the filter must use the same clock.
         if let Some(cutoff) = cutoff_time {
-            if timestamp < cutoff {
+            if commit_time < cutoff {
                 break;
             }
         }
@@ -466,6 +523,7 @@ pub fn get_log_with_stats_gix(
             author: author.name.to_string(),
             email: author.email.to_string(),
             timestamp,
+            commit_time,
             message,
             files,
         });
@@ -762,6 +820,7 @@ mod tests {
             author: "Test Author".to_string(),
             email: "test@example.com".to_string(),
             timestamp: 1704067200,
+            commit_time: 1704067200,
             message: "Initial commit".to_string(),
             files: vec![],
         };
@@ -816,6 +875,7 @@ mod tests {
             author: "Test Author".to_string(),
             email: "test@example.com".to_string(),
             timestamp: 1704067200,
+            commit_time: 1704067200,
             message: "Test commit".to_string(),
             files: vec![],
         };
@@ -859,6 +919,7 @@ mod tests {
             author: "Test Author".to_string(),
             email: "test@example.com".to_string(),
             timestamp: 1704067200,
+            commit_time: 1704067200,
             message: "Test commit".to_string(),
             files: vec![
                 FileChange {

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -94,23 +94,7 @@ impl GitLogData {
             }
         }
 
-        let output = std::process::Command::new("git")
-            .args(["rev-parse", &format!("--since={since}")])
-            .current_dir(&self.root)
-            .output()
-            .map_err(|error| Error::git(format!("Failed to resolve git date: {error}")))?;
-        if !output.status.success() {
-            return Err(Error::git(format!(
-                "Failed to resolve git date: {}",
-                String::from_utf8_lossy(&output.stderr)
-            )));
-        }
-        let value = String::from_utf8_lossy(&output.stdout);
-        value
-            .trim()
-            .strip_prefix("--max-age=")
-            .and_then(|timestamp| timestamp.parse().ok())
-            .ok_or_else(|| Error::git(format!("Invalid git date result: {value}")))
+        log::git_resolved_since(&self.root, since)
     }
 }
 
@@ -551,6 +535,26 @@ mod tests {
                 commit.commit_time
             );
         }
+    }
+
+    #[test]
+    fn test_gix_log_filters_on_absolute_dates_too() {
+        // `GitRepo::log` uses the gix walk, which has no git process to defer
+        // to -- so an absolute date must be resolved before filtering, not
+        // treated as "no lower bound".
+        let temp = tempfile::tempdir().unwrap();
+        init_old_repo(temp.path());
+        let repo = GitRepo::open(temp.path()).unwrap();
+
+        let all = repo.log(None, None, None).unwrap();
+        assert_eq!(all.len(), 2);
+
+        let since_mid = repo.log(Some("2020-03-01"), None, None).unwrap();
+        assert_eq!(
+            since_mid.len(),
+            1,
+            "an absolute date must filter the gix walk, not be ignored"
+        );
     }
 
     #[test]

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -32,13 +32,22 @@ impl GitLogData {
         Ok(Self { root, commits })
     }
 
+    /// The committer time of the newest commit reachable from HEAD, which is
+    /// the date of the revision being analyzed.
+    ///
+    /// `log_with_stats(None, None)` is reverse-chronological from HEAD, so
+    /// this is `commits[0]`.
+    pub fn anchor(&self) -> Option<i64> {
+        self.commits.first().map(|commit| commit.commit_time)
+    }
+
     /// Return the exact subset that `git log --since` would select.
     pub fn query(&self, since: Option<&str>, limit: Option<usize>) -> Result<Vec<Commit>> {
         let cutoff = since.map(|value| self.resolve_since(value)).transpose()?;
         let mut commits: Vec<Commit> = self
             .commits
             .iter()
-            .filter(|commit| cutoff.is_none_or(|timestamp| commit.timestamp >= timestamp))
+            .filter(|commit| cutoff.is_none_or(|timestamp| commit.commit_time >= timestamp))
             .cloned()
             .collect();
         if let Some(max) = limit {
@@ -47,7 +56,21 @@ impl GitLogData {
         Ok(commits)
     }
 
+    /// Resolve a `since` window to a cutoff timestamp.
+    ///
+    /// A relative duration is measured from the analyzed revision's own date
+    /// rather than from the wall clock: a worktree, a release tag, a bisect
+    /// step or a repository nobody has touched this quarter would otherwise
+    /// match no commits at all, and report that as "nothing to see" rather
+    /// than "no data". It also makes results deterministic. An absolute date
+    /// is already a fixed point, so it is handed to git as before.
     fn resolve_since(&self, since: &str) -> Result<i64> {
+        if let Some(duration) = log::parse_since_duration(since) {
+            if let Some(anchor) = self.anchor() {
+                return Ok(anchor.saturating_sub(duration.as_secs() as i64));
+            }
+        }
+
         let output = std::process::Command::new("git")
             .args(["rev-parse", &format!("--since={since}")])
             .current_dir(&self.root)
@@ -125,6 +148,13 @@ impl GitRepo {
             .head_id()
             .map_err(|e| Error::git(format!("Failed to get HEAD: {e}")))?;
         Ok(head.to_string())
+    }
+
+    /// Committer time of HEAD, or `None` when HEAD is unborn.
+    ///
+    /// This is the anchor every relative time window is measured from.
+    pub fn head_commit_time(&self) -> Result<Option<i64>> {
+        log::head_commit_time(&self.repo)
     }
 
     /// Get commit log with optional path filter.
@@ -385,5 +415,90 @@ mod tests {
         let result = repo.blame(&file_path);
         // blame might work or fail depending on gix implementation
         assert!(result.is_ok() || result.is_err());
+    }
+
+    // --- Issue #496: windows anchored at the analyzed revision -------------
+
+    /// Build a repo whose entire history predates any plausible wall clock,
+    /// so a window measured from "now" matches nothing.
+    fn init_old_repo(path: &std::path::Path) -> Vec<String> {
+        let run = |args: &[&str], date: Option<&str>| {
+            let mut cmd = std::process::Command::new("git");
+            cmd.args(args).current_dir(path);
+            if let Some(date) = date {
+                cmd.env("GIT_AUTHOR_DATE", date)
+                    .env("GIT_COMMITTER_DATE", date);
+            }
+            cmd.output().expect("git command failed");
+        };
+        run(&["init"], None);
+        run(&["config", "user.email", "test@example.com"], None);
+        run(&["config", "user.name", "Test Author"], None);
+
+        // Far enough apart that a 30-day window reaches only HEAD.
+        let dates = ["2020-01-01T00:00:00+0000", "2020-06-01T00:00:00+0000"];
+        for (i, date) in dates.iter().enumerate() {
+            std::fs::write(path.join("a.txt"), format!("line {i}\n")).unwrap();
+            run(&["add", "-A"], None);
+            run(&["commit", "-m", &format!("commit {i}")], Some(date));
+        }
+        dates.iter().map(|d| d.to_string()).collect()
+    }
+
+    #[test]
+    fn test_relative_window_is_anchored_at_head_not_the_wall_clock() {
+        // The bug: `--since=30 days` resolves against the current time, so a
+        // checkout older than the window matches nothing and the analyzers
+        // report "no data" as though it meant "nothing to report".
+        let temp = tempfile::tempdir().unwrap();
+        init_old_repo(temp.path());
+
+        let data = GitLogData::load(temp.path()).expect("history should load");
+        assert_eq!(data.commits.len(), 2, "fixture should have two commits");
+
+        let recent = data.query(Some("30 days"), None).expect("query");
+        assert_eq!(
+            recent.len(),
+            1,
+            "a 30-day window ending at HEAD (2020-06-01) should contain only \
+             the HEAD commit, not zero commits"
+        );
+
+        let wide = data.query(Some("1y"), None).expect("query");
+        assert_eq!(wide.len(), 2, "a one-year window should reach both commits");
+
+        let all = data.query(None, None).expect("query");
+        assert_eq!(all.len(), 2);
+    }
+
+    #[test]
+    fn test_window_is_measured_from_committer_time() {
+        // `git log --since` filters on committer date, and gix orders by it,
+        // so the window must use the same clock rather than the author date.
+        let temp = tempfile::tempdir().unwrap();
+        init_old_repo(temp.path());
+
+        let data = GitLogData::load(temp.path()).expect("history should load");
+        for commit in &data.commits {
+            assert!(
+                commit.commit_time > 0,
+                "committer time should be populated, got {}",
+                commit.commit_time
+            );
+        }
+    }
+
+    #[test]
+    fn test_absolute_since_dates_still_resolve() {
+        let temp = tempfile::tempdir().unwrap();
+        init_old_repo(temp.path());
+
+        let data = GitLogData::load(temp.path()).expect("history should load");
+        let since_mid = data.query(Some("2020-01-10"), None).expect("query");
+        assert_eq!(
+            since_mid.len(),
+            1,
+            "an absolute date is not relative to HEAD and must still work"
+        );
     }
 }

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -7,6 +7,7 @@ mod remote;
 use std::path::{Path, PathBuf};
 
 use gix::Repository;
+use serde::{Deserialize, Serialize};
 
 use crate::core::{Error, Result};
 
@@ -39,6 +40,11 @@ impl GitLogData {
     /// this is `commits[0]`.
     pub fn anchor(&self) -> Option<i64> {
         self.commits.first().map(|commit| commit.commit_time)
+    }
+
+    /// Whether the loaded history is complete, i.e. not a shallow clone.
+    pub fn history_complete(&self) -> bool {
+        !self.root.join(".git").join("shallow").exists()
     }
 
     /// Return the exact subset that `git log --since` would select.
@@ -88,6 +94,42 @@ impl GitLogData {
             .strip_prefix("--max-age=")
             .and_then(|timestamp| timestamp.parse().ok())
             .ok_or_else(|| Error::git(format!("Invalid git date result: {value}")))
+    }
+}
+
+/// The churn window an analyzer actually used.
+///
+/// Emitted so an empty window reads as "no data" rather than as "nothing to
+/// report", and so the numbers document the window that produced them.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ChurnWindow {
+    /// Window width in days. `None` means all of history.
+    pub days: Option<u32>,
+    /// Date of the revision the window ends at (RFC 3339), or `None` when the
+    /// repository has no commits.
+    pub anchor_date: Option<String>,
+    /// Commits the window actually matched.
+    pub commits_matched: usize,
+    /// False for a shallow clone, where a valid HEAD coexists with truncated
+    /// history, so a low match count proves nothing.
+    pub history_complete: bool,
+}
+
+impl ChurnWindow {
+    pub fn new(
+        days: u32,
+        anchor: Option<i64>,
+        commits_matched: usize,
+        history_complete: bool,
+    ) -> Self {
+        Self {
+            days: (days != u32::MAX).then_some(days),
+            anchor_date: anchor
+                .and_then(|seconds| chrono::DateTime::from_timestamp(seconds, 0))
+                .map(|date| date.to_rfc3339()),
+            commits_matched,
+            history_complete,
+        }
     }
 }
 

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -21,6 +21,7 @@ pub use remote::{clone_remote, is_remote_repo, CloneOptions};
 pub struct GitLogData {
     root: PathBuf,
     commits: Vec<Commit>,
+    history_complete: bool,
 }
 
 impl GitLogData {
@@ -29,8 +30,22 @@ impl GitLogData {
     pub fn load(path: &Path) -> Result<Self> {
         let repo = GitRepo::open(path)?;
         let root = repo.root().to_path_buf();
+        // Asked while the repository is open: in a worktree, a submodule or a
+        // separate git dir, `.git` is a file and the shallow marker lives in
+        // the resolved common directory, so looking for `root/.git/shallow`
+        // would call a shallow clone complete.
+        let history_complete = !repo.is_shallow();
         let commits = repo.log_with_stats(None, None)?;
-        Ok(Self { root, commits })
+        Ok(Self {
+            root,
+            commits,
+            history_complete,
+        })
+    }
+
+    /// Whether the loaded history is complete, i.e. not a shallow clone.
+    pub fn history_complete(&self) -> bool {
+        self.history_complete
     }
 
     /// The committer time of the newest commit reachable from HEAD, which is
@@ -40,11 +55,6 @@ impl GitLogData {
     /// this is `commits[0]`.
     pub fn anchor(&self) -> Option<i64> {
         self.commits.first().map(|commit| commit.commit_time)
-    }
-
-    /// Whether the loaded history is complete, i.e. not a shallow clone.
-    pub fn history_complete(&self) -> bool {
-        !self.root.join(".git").join("shallow").exists()
     }
 
     /// Return the exact subset that `git log --since` would select.
@@ -71,9 +81,16 @@ impl GitLogData {
     /// than "no data". It also makes results deterministic. An absolute date
     /// is already a fixed point, so it is handed to git as before.
     fn resolve_since(&self, since: &str) -> Result<i64> {
+        if is_since_all(since) {
+            return Ok(i64::MIN);
+        }
         if let Some(duration) = log::parse_since_duration(since) {
             if let Some(anchor) = self.anchor() {
-                return Ok(anchor.saturating_sub(duration.as_secs() as i64));
+                return Ok(match log::cutoff_from(anchor, duration) {
+                    log::Cutoff::At(cutoff) => cutoff,
+                    // A window reaching past the epoch is all of history.
+                    _ => i64::MIN,
+                });
             }
         }
 
@@ -163,6 +180,12 @@ impl GitRepo {
     /// Check if path is inside this repository.
     pub fn contains(&self, path: &Path) -> bool {
         path.starts_with(&self.root)
+    }
+
+    /// Whether this is a shallow clone, where a valid HEAD coexists with
+    /// truncated history.
+    pub fn is_shallow(&self) -> bool {
+        self.repo.is_shallow()
     }
 
     /// Get the current branch name.

--- a/src/main.rs
+++ b/src/main.rs
@@ -358,7 +358,13 @@ fn run_with_path(cli: &Cli, path: &PathBuf) -> omen::core::Result<()> {
                         }
                     }
                     None => {
-                        run_analyzer::<omen::score::Analyzer>(path, &config, format, None)?;
+                        run_analyzer_instance(
+                            path,
+                            &config,
+                            format,
+                            None,
+                            omen::score::Analyzer::from_config(&config),
+                        )?;
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,17 @@ fn main() -> ExitCode {
 
 /// Resolve the repository path, cloning if it's a remote reference.
 /// Returns (resolved_path, cleanup_path) where cleanup_path is Some if we cloned a temp repo.
+/// Resolve the churn window for `defect`/`hotspot`, erroring on input that is
+/// neither a duration nor "all" rather than silently widening to all history.
+fn resolve_churn_window(
+    args: &omen::cli::ChurnWindowArgs,
+    config_days: u32,
+) -> omen::core::Result<u32> {
+    omen::cli::ChurnWindow::resolve(args.since.as_deref(), args.days, config_days)
+        .map(|window| window.as_days())
+        .map_err(omen::core::Error::config)
+}
+
 fn resolve_repo_path(cli: &Cli) -> omen::core::Result<(PathBuf, Option<PathBuf>)> {
     let path_str = cli.path.to_string_lossy();
 
@@ -466,7 +477,7 @@ fn run_with_path(cli: &Cli, path: &PathBuf) -> omen::core::Result<()> {
 
             // Group C: analyzers that internally depend on both file and git data.
             // Run after groups A and B to benefit from warm OS page cache.
-            let mut hotspot_analyzer = omen::analyzers::hotspot::Analyzer::default();
+            let mut hotspot_analyzer = omen::analyzers::hotspot::Analyzer::from_config(&config);
             if let Some(complexity) = collected_result(&results, "complexity") {
                 hotspot_analyzer = hotspot_analyzer.with_precomputed_complexity(complexity);
             }
@@ -479,7 +490,7 @@ fn run_with_path(cli: &Cli, path: &PathBuf) -> omen::core::Result<()> {
                 tdg_analyzer = tdg_analyzer.with_precomputed_temporal(temporal);
             }
             results.push(run_instance_and_collect!(&ctx, tdg_analyzer, "tdg"));
-            let mut defect_analyzer = omen::analyzers::defect::Analyzer::default();
+            let mut defect_analyzer = omen::analyzers::defect::Analyzer::from_config(&config);
             if let Some(complexity) = collected_result(&results, "complexity") {
                 defect_analyzer = defect_analyzer.with_precomputed_complexity(complexity);
             }
@@ -615,7 +626,14 @@ fn dispatch_analyzer(
                 .with_exclude_tests(!args.include_tests && config.duplicates.exclude_tests),
         ),
         Command::Defect(args) => {
-            run_analyzer::<omen::analyzers::defect::Analyzer>(path, config, format, Some(args))
+            let window = resolve_churn_window(&args.window, config.defect.churn_days)?;
+            run_analyzer_instance(
+                path,
+                config,
+                format,
+                Some(&args.common),
+                omen::analyzers::defect::Analyzer::new().with_churn_days(window),
+            )
         }
         Command::Tdg(args) => {
             run_analyzer::<omen::analyzers::tdg::Analyzer>(path, config, format, Some(args))
@@ -623,13 +641,16 @@ fn dispatch_analyzer(
         Command::Graph(args) => {
             run_analyzer::<omen::analyzers::graph::Analyzer>(path, config, format, Some(args))
         }
-        Command::Hotspot(args) => run_analyzer_instance(
-            path,
-            config,
-            format,
-            Some(args),
-            omen::analyzers::hotspot::Analyzer::new(),
-        ),
+        Command::Hotspot(args) => {
+            let window = resolve_churn_window(&args.window, config.hotspot.days)?;
+            run_analyzer_instance(
+                path,
+                config,
+                format,
+                Some(&args.common),
+                omen::analyzers::hotspot::Analyzer::new().with_days(window),
+            )
+        }
         Command::Temporal(args) => {
             run_analyzer::<omen::analyzers::temporal::Analyzer>(path, config, format, Some(args))
         }
@@ -954,7 +975,8 @@ fn run_score_check(
     let file_set = FileSet::from_path(path, config)?;
     let ctx = build_context(path, &file_set, config);
 
-    let analyzer = omen::score::Analyzer::default();
+    let analyzer =
+        omen::score::Analyzer::default().with_defect_churn_days(config.defect.churn_days);
     let result = analyzer.analyze(&ctx)?;
 
     let min_score = args
@@ -1242,12 +1264,12 @@ fn run_report(
                         "flags"
                     );
                     run_analyzer!(
-                        omen::analyzers::defect::Analyzer::default(),
+                        omen::analyzers::defect::Analyzer::from_config(config),
                         "defect",
                         "defect"
                     );
                     run_analyzer!(
-                        omen::analyzers::hotspot::Analyzer::default(),
+                        omen::analyzers::hotspot::Analyzer::from_config(config),
                         "hotspots",
                         "hotspots"
                     );

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -914,7 +914,9 @@ impl McpServer {
                         .with_providers(providers),
                 )
             }
-            "score" => self.run_analyzer::<crate::score::Analyzer>(&ctx),
+            "score" => {
+                self.run_analyzer_instance(&ctx, crate::score::Analyzer::from_config(&self.config))
+            }
             "context" => {
                 return Ok(self
                     .handle_context(&path, &file_set, &arguments)

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -868,16 +868,22 @@ impl McpServer {
             ),
             "defect" => self.run_analyzer_instance(
                 &ctx,
-                crate::analyzers::defect::Analyzer::new()
-                    .with_churn_days(u32_arg(&arguments, "days", 30)),
+                crate::analyzers::defect::Analyzer::new().with_churn_days(u32_arg(
+                    &arguments,
+                    "days",
+                    self.config.defect.churn_days,
+                )),
             ),
             "changes" => self.run_analyzer::<crate::analyzers::changes::Analyzer>(&ctx),
             "tdg" => self.run_analyzer::<crate::analyzers::tdg::Analyzer>(&ctx),
             "graph" => self.run_analyzer::<crate::analyzers::graph::Analyzer>(&ctx),
             "hotspot" => self.run_analyzer_instance(
                 &ctx,
-                crate::analyzers::hotspot::Analyzer::new()
-                    .with_days(u32_arg(&arguments, "days", 90)),
+                crate::analyzers::hotspot::Analyzer::new().with_days(u32_arg(
+                    &arguments,
+                    "days",
+                    self.config.hotspot.days,
+                )),
             ),
             "temporal" => self.run_analyzer_instance(
                 &ctx,

--- a/src/score/mod.rs
+++ b/src/score/mod.rs
@@ -40,6 +40,13 @@ impl Analyzer {
         }
     }
 
+    /// Build from the loaded configuration, so scoring uses the configured
+    /// churn window wherever it runs -- the subcommand, the gate, MCP, and
+    /// each trend sample.
+    pub fn from_config(config: &crate::config::Config) -> Self {
+        Self::default().with_defect_churn_days(config.defect.churn_days)
+    }
+
     pub fn with_defect_churn_days(mut self, days: u32) -> Self {
         self.defect_churn_days = days;
         self

--- a/src/score/mod.rs
+++ b/src/score/mod.rs
@@ -1765,4 +1765,17 @@ mod tests {
         let score = calculate_defect_score(&result);
         assert!(score < 40.0);
     }
+
+    #[test]
+    fn test_score_forwards_the_configured_defect_window() {
+        // The window used to reach only the score gate; ordinary `omen
+        // score`, MCP and each trend sample built the analyzer with defaults.
+        let mut config = crate::config::Config::default();
+        config.defect.churn_days = 365;
+        assert_eq!(Analyzer::from_config(&config).defect_churn_days, 365);
+        assert_eq!(
+            Analyzer::default().defect_churn_days,
+            crate::config::DefectConfig::default().churn_days
+        );
+    }
 }

--- a/src/score/mod.rs
+++ b/src/score/mod.rs
@@ -12,9 +12,20 @@ use crate::core::{AnalysisContext, Analyzer as AnalyzerTrait, Result};
 pub use trend::{analyze_trend, default_sample_count};
 
 /// Score analyzer - calculates composite health score.
-#[derive(Default)]
 pub struct Analyzer {
     weights: ScoreWeights,
+    /// Churn window handed to the defect analyzer, so scoring honours the
+    /// configured window rather than always using the default.
+    defect_churn_days: u32,
+}
+
+impl Default for Analyzer {
+    fn default() -> Self {
+        Self {
+            weights: ScoreWeights::default(),
+            defect_churn_days: crate::config::DefectConfig::default().churn_days,
+        }
+    }
 }
 
 impl Analyzer {
@@ -23,7 +34,15 @@ impl Analyzer {
     }
 
     pub fn with_weights(weights: ScoreWeights) -> Self {
-        Self { weights }
+        Self {
+            weights,
+            ..Self::default()
+        }
+    }
+
+    pub fn with_defect_churn_days(mut self, days: u32) -> Self {
+        self.defect_churn_days = days;
+        self
     }
 }
 
@@ -167,7 +186,7 @@ impl AnalyzerTrait for Analyzer {
         run_analyzer!(
             "defect",
             self.weights.defect,
-            crate::analyzers::defect::Analyzer::new(),
+            crate::analyzers::defect::Analyzer::new().with_churn_days(self.defect_churn_days),
             calculate_defect_score,
             |r: &crate::analyzers::defect::Analysis| format!(
                 "{} high-risk files, avg probability: {:.1}%",
@@ -1496,6 +1515,7 @@ mod tests {
                 p95_probability: 0.15,
             },
             weights: crate::analyzers::defect::Weights::default(),
+            churn_window: None,
         };
         let score = calculate_defect_score(&result);
         assert_eq!(score, 100.0);
@@ -1733,6 +1753,7 @@ mod tests {
                 p95_probability: 0.95,
             },
             weights: crate::analyzers::defect::Weights::default(),
+            churn_window: None,
         };
         let score = calculate_defect_score(&result);
         assert!(score < 40.0);

--- a/src/score/trend.rs
+++ b/src/score/trend.rs
@@ -326,11 +326,12 @@ fn find_commit_at_time(
 ) -> Option<&crate::git::Commit> {
     let target_ts = target.timestamp();
 
-    // Find the commit with timestamp closest to but not after target
+    // Committer time, matching the window bounds: a rebase can move an author
+    // date far out of order and select the wrong tree.
     commits
         .iter()
-        .filter(|c| c.timestamp <= target_ts)
-        .min_by_key(|c| (target_ts - c.timestamp).abs())
+        .filter(|c| c.commit_time <= target_ts)
+        .min_by_key(|c| (target_ts - c.commit_time).abs())
 }
 
 /// Analyze code at a specific git tree (commit) without filesystem checkout.
@@ -341,7 +342,7 @@ pub fn analyze_at_tree(tree_source: &TreeSource, config: &Config) -> Result<supe
     let root = Path::new(".");
     let ctx =
         AnalysisContext::new(&file_set, config, Some(root)).with_content_source(content_source);
-    let analyzer = ScoreAnalyzer::new();
+    let analyzer = ScoreAnalyzer::from_config(config);
     analyzer.analyze(&ctx)
 }
 
@@ -350,10 +351,10 @@ pub fn analyze_at_tree(tree_source: &TreeSource, config: &Config) -> Result<supe
 fn collect_commits_in_range(commits: &[Commit], after_ts: i64, up_to_ts: i64) -> Vec<String> {
     let mut messages: Vec<&Commit> = commits
         .iter()
-        .filter(|c| c.timestamp > after_ts && c.timestamp <= up_to_ts)
+        .filter(|c| c.commit_time > after_ts && c.commit_time <= up_to_ts)
         .collect();
     // Most recent first
-    messages.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    messages.sort_by(|a, b| b.commit_time.cmp(&a.commit_time));
     messages
         .into_iter()
         .take(5)

--- a/src/score/trend.rs
+++ b/src/score/trend.rs
@@ -28,10 +28,19 @@ pub fn analyze_trend(
     samples: Option<usize>,
 ) -> Result<TrendData> {
     let repo = GitRepo::open(path)?;
-    let now = Utc::now();
+
+    // Measure the window from the analyzed revision, not the wall clock, so
+    // an old checkout still produces a trend instead of an empty one. An
+    // unborn HEAD has no history to plot.
+    let Some(anchor) = repo.head_commit_time()? else {
+        return Ok(TrendData::default());
+    };
+    let Some(anchor) = DateTime::from_timestamp(anchor, 0) else {
+        return Ok(TrendData::default());
+    };
 
     // Parse the "since" parameter to determine how far back to go
-    let start_time = parse_since_to_datetime(since, now)?;
+    let start_time = parse_since_to_datetime(since, anchor)?;
 
     // Get commits in the time range
     let since_arg = if crate::git::is_since_all(since) {
@@ -45,7 +54,7 @@ pub fn analyze_trend(
     // window end would stretch the grid over commit-less time (for `--since all`
     // that means back to the epoch), leaving only a handful of sample points
     // landing on real commits.
-    let Some((window_start, window_end)) = trend_window(&commits, start_time, now) else {
+    let Some((window_start, window_end)) = trend_window(&commits, start_time, anchor) else {
         return Ok(TrendData::default());
     };
 
@@ -219,13 +228,13 @@ pub fn default_sample_count(days: f64) -> usize {
 fn trend_window(
     commits: &[Commit],
     since: DateTime<Utc>,
-    now: DateTime<Utc>,
+    anchor: DateTime<Utc>,
 ) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
-    let first = commits.iter().map(|c| c.timestamp).min()?;
-    let last = commits.iter().map(|c| c.timestamp).max()?;
+    let first = commits.iter().map(|c| c.commit_time).min()?;
+    let last = commits.iter().map(|c| c.commit_time).max()?;
 
     let start = DateTime::from_timestamp(first, 0)?.max(since);
-    let end = DateTime::from_timestamp(last, 0)?.min(now);
+    let end = DateTime::from_timestamp(last, 0)?.min(anchor);
 
     if end < start {
         return None;
@@ -770,6 +779,7 @@ fn complex(x: i32) -> i32 {
             author: "A".to_string(),
             email: "a@test.com".to_string(),
             timestamp,
+            commit_time: timestamp,
             message: format!("{sha} message"),
             files: vec![],
         }
@@ -885,6 +895,7 @@ fn complex(x: i32) -> i32 {
                 author: "A".to_string(),
                 email: "a@test.com".to_string(),
                 timestamp: 100,
+                commit_time: 100,
                 message: "first commit".to_string(),
                 files: vec![],
             },
@@ -893,6 +904,7 @@ fn complex(x: i32) -> i32 {
                 author: "B".to_string(),
                 email: "b@test.com".to_string(),
                 timestamp: 200,
+                commit_time: 200,
                 message: "second commit".to_string(),
                 files: vec![],
             },
@@ -901,6 +913,7 @@ fn complex(x: i32) -> i32 {
                 author: "C".to_string(),
                 email: "c@test.com".to_string(),
                 timestamp: 300,
+                commit_time: 300,
                 message: "third commit".to_string(),
                 files: vec![],
             },
@@ -909,6 +922,7 @@ fn complex(x: i32) -> i32 {
                 author: "D".to_string(),
                 email: "d@test.com".to_string(),
                 timestamp: 400,
+                commit_time: 400,
                 message: "fourth commit".to_string(),
                 files: vec![],
             },
@@ -939,6 +953,7 @@ fn complex(x: i32) -> i32 {
                 author: "A".to_string(),
                 email: "a@test.com".to_string(),
                 timestamp: (i + 1) * 100,
+                commit_time: (i + 1) * 100,
                 message: format!("commit {}", i),
                 files: vec![],
             })


### PR DESCRIPTION
Fixes #496.

## The bug

`git log --since="30 days"` resolves against the current time, never against the revision being analyzed. In a worktree, at a release tag, mid-bisect, at a pinned submodule — or simply in a repository nobody has committed to this quarter — the window is empty, and nothing says so:

- `hotspot` returns an empty list, which reads as "no hotspots" rather than "no data".
- `defect` returns a probability for every file with the churn factor at zero, so 0.30 of the model's weight plus the ownership share are constants while the output still looks like a full prediction.

Reproduced on a repo whose newest commit is dated 2024-02-01:

| | before | after |
|---|---|---|
| `hotspot` | `total_hotspots: 0` | `total_hotspots: 1` |
| `defect` churn factor | *absent* | `0.0075` |

There is a second reason to fix it: wall-clock anchoring makes output non-deterministic. The same commit analyzed on two different days scored differently, which the repo's own accuracy rules forbid.

## The fix

Measure relative windows from HEAD's own date. On a current checkout this behaves exactly as before; on an old one it starts being correct instead of empty.

`GitLogData::resolve_since` is the chokepoint every analyzer reaches through `AnalysisContext::git_log_with_stats`, so churn, temporal, changes, defect and hotspot all move together. The gix walks and the `git log` CLI path are anchored too. Absolute dates are already fixed points and still go to git unchanged.

Two prerequisites fell out:

- **`Commit` gains `commit_time`.** `git log --since` filters on the committer date and gix's `ByCommitTime` orders by it, but only the author date was recorded — so the walk sorted by one clock and stopped on another, unsound as soon as a rebase moves an author date out of topological order. Windows use the committer date; the author date stays for attribution and display.
- **`score trend` derived its bounds from `Utc::now()`** and discarded windows where `end < start`. Left alone it would have loaded HEAD-relative commits and thrown them all away.

## Exposing the window

`defect` and `hotspot` now take `--since`/`--days` and read `[defect] churn_days` / `[hotspot] days`, which `churn` and `changes` already had.

Unlike `churn`, they reject input they cannot measure. `parse_since_to_days` returns `None` both for `"all"` and for anything unparseable, and the churn arm turns `None` into `u32::MAX` — so a copied implementation would make `--since 2024-01-01` silently mean *every commit ever*:

```
$ omen hotspot --since 2024-01-01
Error: Configuration error: invalid time window "2024-01-01": expected a duration such as 30d, 3m, 1y, or "all"
$ omen defect --days 0
Error: Configuration error: a window of 0 days contains no history
```

The window is wired through every construction path, not just the subcommand — `omen all`, `report generate`, `score` and MCP all built these analyzers with defaults and would have ignored the config.

Output now carries the window it used, so an empty one is visible:

```json
"churn_window": {
  "days": 90,
  "anchor_date": "2024-02-01T07:00:00+00:00",
  "commits_matched": 2,
  "history_complete": true
}
```

`history_complete` is false for a shallow clone, where a valid HEAD coexists with truncated history and a low match count proves nothing. The field is `#[serde(default)]` so existing serialized results still deserialize.

Defect's churn normalizer divided by a hardcoded 20, calibrated for a 30-day window; it is a per-30-day rate now, so widening the window no longer inflates the factor. Identical at the default.

## Review

Codex (gpt-5.6-sol, high) reviewed the plan before I wrote it and the diff before merging. Both passes caught real problems.

On the plan: the anchor had to use **committer** time, not the author date I had specified; and `--since 2024-01-01` would have silently meant all history.

On the diff, the most serious finding was mine: an all-history window produced a *pre-epoch cutoff*. `u32::MAX` days is an anchor minus ~3.7e14 seconds, handed to git as `--since=@-371...` — and approxidate reads that as roughly *now*, returning an empty log. `--since all` returned nothing through the CLI path. Confirmed directly:

```
$ git log --format=%H --since=@-371000000000 | wc -l
0
$ git log --format=%H | wc -l
2
```

Cutoff resolution is an explicit `All | At(t) | Unresolved` now. Also fixed from that pass: `history_complete` looked for `root/.git/shallow`, which does not exist when `.git` is a file (worktrees, submodules, separate git dirs), so shallow clones reported complete history; `head_commit_time` turned every `head_id` error into "no history", hiding corrupt refs; defect swallowed git failures with `if let Ok(commits)`, recreating the very "churn = 0" behaviour this issue is about; all-history churn was not normalized at all, so 20 commits over ten years scored like 20 in a month; trend's sample selection still used author time while its bounds had moved to committer time; and `[defect] churn_days` reached only the score gate, not ordinary `omen score`, MCP, or trend samples.

## Tests

The regression the issue asks for, at three levels: `GitLogData::resolve_since` against a repo whose HEAD is years old, and `defect`/`hotspot` analyses of a backdated fixture asserting a non-zero churn factor and a non-empty hotspot list. I verified all three genuinely fail without the anchoring by removing it and re-running:

```
test git::tests::test_relative_window_is_anchored_at_head_not_the_wall_clock ... FAILED
test analyzers::defect::tests::test_churn_factor_is_non_zero_at_an_old_revision ... FAILED
test analyzers::hotspot::tests::test_hotspots_are_found_at_an_old_revision ... FAILED
```

Plus: committer-time population; absolute dates still resolving; the pre-epoch cutoff collapsing to all-history; `ChurnWindow` parsing, rejection and `--since` > `--days` > config precedence; and the churn rate normalizing across window widths including all-history.

`cargo test` is green (2151 lib + 112 integration). `cargo clippy` reports 26 findings both with and without this branch — all pre-existing, from a newer local clippy than CI pins; this branch adds none.

## Left for follow-ups

- `report generate --days` does not flow into defect, hotspot, or trend, so one invocation can mix windows. Resolving a single canonical window for the whole report is a design change beyond this issue.
- Trend samples build their context rooted at `"."` with no `git_path`, so each historical sample takes git metrics from current HEAD rather than from the sampled commit. Pre-existing, and orthogonal to the anchor.
- The gix log paths ignore absolute `since` dates (they only ever understood durations), while the CLI and cached paths hand them to git. Pre-existing divergence.
- `git log` records are `|`-delimited, so a `|` in an author name or email shifts the timestamp fields. `-z` framing would fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011AM4uztuA35XSLxrcTBEad

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable churn windows for hotspot and defect analysis, with defaults of 90 and 30 days.
  * Added `--days` and `--since` options, supporting durations such as `30d`, `3m`, `1y`, or all history.
  * Analysis results now report the churn window, matching commits, and history completeness.

* **Bug Fixes**
  * Relative analysis windows now anchor to the analyzed revision instead of the current date.
  * Invalid windows and git log failures now produce clear errors rather than misleading results.
  * Scoring and trend analysis now honor configured churn periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->